### PR TITLE
Simplify whitelist and blacklist checks

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -84,18 +84,17 @@ def mergable(
         valid_signature=valid_signature,
         valid_merge_methods=valid_merge_methods,
     )
-    if config.merge.whitelist:
-        if set(pull_request.labels).isdisjoint(set(config.merge.whitelist)):
-            log.info(
-                "missing required whitelist labels",
-                has=pull_request.labels,
-                requires=config.merge.whitelist,
-            )
-            raise NotQueueable("missing whitelist")
-    if config.merge.blacklist:
-        if not set(pull_request.labels).isdisjoint(config.merge.blacklist):
-            log.info("missing required blacklist labels")
-            raise NotQueueable("has blacklist labels")
+
+    if set(pull_request.labels).isdisjoint(set(config.merge.whitelist)):
+        log.info(
+            "missing required whitelist labels",
+            has=pull_request.labels,
+            requires=config.merge.whitelist,
+        )
+        raise NotQueueable("missing whitelist")
+    if not set(pull_request.labels).isdisjoint(config.merge.blacklist):
+        log.info("missing required blacklist labels")
+        raise NotQueueable("has blacklist labels")
 
     if config.merge.method not in valid_merge_methods:
         # TODO: This is a fatal configuration error. We should provide some notification of this issue

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -89,6 +89,28 @@ def test_failing_whitelist(
         )
 
 
+def test_empty_whitelist(
+    pull_request: PullRequest,
+    config: V1,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+) -> None:
+    pull_request.labels = ["bug"]
+    config.merge.whitelist = []
+    with pytest.raises(NotQueueable, match="missing whitelist"):
+        mergable(
+            config=config,
+            pull_request=pull_request,
+            branch_protection=branch_protection,
+            review_requests_count=0,
+            reviews=[review],
+            contexts=[context],
+            valid_signature=False,
+            valid_merge_methods=[MergeMethod.merge, MergeMethod.squash],
+        )
+
+
 def test_blacklisted(
     pull_request: PullRequest,
     config: V1,


### PR DESCRIPTION
- add test to ensure that merging is disabled when whitelist is empty