### PR TITLE
Fix CHANGES_REQUESTED reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix handling of `CHANGE_REQUESTED` reviews. We weren't nullifying `CHANGE_REQUESTED` reviews after the user placed another review.
+
 ## 0.2.1 - 2019-05-23
 
 ### Fixed

--- a/kodiak/conftest.py
+++ b/kodiak/conftest.py
@@ -1,4 +1,5 @@
 import typing
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -81,12 +82,22 @@ def branch_protection() -> queries.BranchProtectionRule:
 
 @pytest.fixture
 def review() -> queries.PRReview:
-    return queries.PRReview(id="abc", state=queries.PRReviewState.APPROVED)
+    return queries.PRReview(
+        state=queries.PRReviewState.APPROVED,
+        createdAt=datetime(2015, 5, 25),
+        author=queries.PRReviewAuthor(login="ghost"),
+        authorAssociation=queries.CommentAuthorAssociation.CONTRIBUTOR,
+    )
 
 
 @pytest.fixture
 def status_context() -> queries.StatusContext:
-    return queries.StatusContext(context="123", state=queries.StatusState.SUCCESS)
+    return queries.StatusContext(context="ci/api", state=queries.StatusState.SUCCESS)
+
+
+@pytest.fixture
+def context(status_context: queries.StatusContext) -> queries.StatusContext:
+    return status_context
 
 
 @pytest.fixture

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -164,7 +164,7 @@ def mergable(
                     if review.state in (
                         PRReviewState.CHANGES_REQUESTED,
                         PRReviewState.APPROVED,
-                        PRReviewState.DISMISSED
+                        PRReviewState.DISMISSED,
                     ):
                         status = review.state
                 return status

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -10,6 +10,7 @@ from kodiak.queries import (
     BranchProtectionRule,
     CheckConclusionState,
     CheckRun,
+    CommentAuthorAssociation,
     MergableState,
     MergeStateStatus,
     PRReview,
@@ -155,6 +156,9 @@ def mergable(
                 str, typing.List[PRReview]
             ] = defaultdict(list)
             for review in sorted(reviews, key=lambda x: x.createdAt):
+                # only reviews by members with write access count towards mergeability
+                if review.authorAssociation == CommentAuthorAssociation.NONE:
+                    continue
                 reviews_by_author[review.author.login].append(review)
 
             def review_status(reviews: typing.List[PRReview]) -> PRReviewState:

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -164,6 +164,7 @@ def mergable(
                     if review.state in (
                         PRReviewState.CHANGES_REQUESTED,
                         PRReviewState.APPROVED,
+                        PRReviewState.DISMISSED
                     ):
                         status = review.state
                 return status

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -68,6 +68,22 @@ class NotQueueable(BaseException):
     pass
 
 
+def review_status(reviews: typing.List[PRReview]) -> PRReviewState:
+    """
+    Find the most recent actionable review state for a user
+    """
+    status = PRReviewState.COMMENTED
+    for review in reviews:
+        # only these events are meaningful to us
+        if review.state in (
+            PRReviewState.CHANGES_REQUESTED,
+            PRReviewState.APPROVED,
+            PRReviewState.DISMISSED,
+        ):
+            status = review.state
+    return status
+
+
 def mergable(
     config: config.V1,
     pull_request: PullRequest,
@@ -160,18 +176,6 @@ def mergable(
                 if review.authorAssociation == CommentAuthorAssociation.NONE:
                     continue
                 reviews_by_author[review.author.login].append(review)
-
-            def review_status(reviews: typing.List[PRReview]) -> PRReviewState:
-                status = PRReviewState.COMMENTED
-                for review in reviews:
-                    # only these events are meaningful to us
-                    if review.state in (
-                        PRReviewState.CHANGES_REQUESTED,
-                        PRReviewState.APPROVED,
-                        PRReviewState.DISMISSED,
-                    ):
-                        status = review.state
-                return status
 
             successful_reviews = 0
             for review_list in reviews_by_author.values():

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -150,8 +150,11 @@ def mergable(
             branch_protection.requiresApprovingReviews
             and branch_protection.requiredApprovingReviewCount
         ):
+            reviews_by_author: typing.MutableMapping[str, PRReview] = {}
+            for review in sorted(reviews, key=lambda x: x.createdAt):
+                reviews_by_author[review.author.login] = review
             successful_reviews = 0
-            for review in reviews:
+            for review in reviews_by_author.values():
                 # blocking review
                 if review.state == PRReviewState.CHANGES_REQUESTED:
                     raise NotQueueable("blocking review")

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -84,11 +84,14 @@ query GetEventInfo($owner: String!, $repo: String!, $configFileExpression: Strin
       reviewRequests(first: 100) {
         totalCount
       }
-      reviews(first: 100, states: [APPROVED, CHANGES_REQUESTED]) {
+      reviews(first: 100) {
         nodes {
-          id
-          databaseId
+          createdAt
           state
+          author {
+            login
+          }
+          authorAssociation
         }
         totalCount
       }
@@ -244,9 +247,25 @@ class PRReviewState(Enum):
     PENDING = "PENDING"
 
 
+class CommentAuthorAssociation(Enum):
+    COLLABORATOR = "COLLABORATOR"
+    CONTRIBUTOR = "CONTRIBUTOR"
+    FIRST_TIMER = "FIRST_TIMER"
+    FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"
+    MEMBER = "MEMBER"
+    NONE = "NONE"
+    OWNER = "OWNER"
+
+
+class PRReviewAuthor(BaseModel):
+    login: str
+
+
 class PRReview(BaseModel):
-    id: str
     state: PRReviewState
+    createdAt: datetime
+    author: PRReviewAuthor
+    authorAssociation: CommentAuthorAssociation
 
 
 class StatusState(Enum):

--- a/kodiak/test/fixtures/api/get_event/behind.json
+++ b/kodiak/test/fixtures/api/get_event/behind.json
@@ -40,14 +40,44 @@
         "reviews": {
           "nodes": [
             {
-              "id": "32f57f6aaf91489cb6ce76af62f7c7e2f3b15956",
-              "databaseId": 319685856,
-              "state": "APPROVED"
+              "createdAt": "2019-05-22T15:29:34Z",
+              "state": "COMMENTED",
+              "author": {
+                "login": "ghost"
+              },
+              "authorAssociation": "CONTRIBUTOR"
             },
             {
-              "id": "1ff69d4ad5d345a5ab2a0882d799f6066d89f675",
-              "databaseId": 921139199,
-              "state": "APPROVED"
+              "createdAt": "2019-05-22T15:29:52Z",
+              "state": "CHANGES_REQUESTED",
+              "author": {
+                "login": "ghost"
+              },
+              "authorAssociation": "CONTRIBUTOR"
+            },
+            {
+              "createdAt": "2019-05-22T15:30:52Z",
+              "state": "COMMENTED",
+              "author": {
+                "login": "kodiak"
+              },
+              "authorAssociation": "CONTRIBUTOR"
+            },
+            {
+              "createdAt": "2019-05-22T15:43:17Z",
+              "state": "APPROVED",
+              "author": {
+                "login": "ghost"
+              },
+              "authorAssociation": "CONTRIBUTOR"
+            },
+            {
+              "createdAt": "2019-05-23T15:13:29Z",
+              "state": "APPROVED",
+              "author": {
+                "login": "walrus"
+              },
+              "authorAssociation": "CONTRIBUTOR"
             }
           ],
           "totalCount": 2

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -672,6 +672,7 @@ def test_regression_mishandling_multiple_reviews_okay_reviews(
             valid_merge_methods=[MergeMethod.squash],
         )
 
+
 def test_regression_mishandling_multiple_reviews_okay_dismissed_reviews(
     pull_request: PullRequest,
     config: V1,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -672,6 +672,51 @@ def test_regression_mishandling_multiple_reviews_okay_reviews(
             valid_merge_methods=[MergeMethod.squash],
         )
 
+def test_regression_mishandling_multiple_reviews_okay_dismissed_reviews(
+    pull_request: PullRequest,
+    config: V1,
+    branch_protection: BranchProtectionRule,
+    check_run: CheckRun,
+    context: StatusContext,
+) -> None:
+    pull_request.mergeStateStatus = MergeStateStatus.BEHIND
+    branch_protection.requiresApprovingReviews = True
+    branch_protection.requiredApprovingReviewCount = 1
+    first_review_date = datetime(2010, 5, 15)
+    latest_review_date = first_review_date + timedelta(minutes=20)
+    reviews = [
+        PRReview(
+            state=PRReviewState.CHANGES_REQUESTED,
+            createdAt=first_review_date,
+            author=PRReviewAuthor(login="chdsbd"),
+            authorAssociation=CommentAuthorAssociation.CONTRIBUTOR,
+        ),
+        PRReview(
+            state=PRReviewState.DISMISSED,
+            createdAt=latest_review_date,
+            author=PRReviewAuthor(login="chdsbd"),
+            authorAssociation=CommentAuthorAssociation.CONTRIBUTOR,
+        ),
+        PRReview(
+            state=PRReviewState.APPROVED,
+            createdAt=latest_review_date,
+            author=PRReviewAuthor(login="ghost"),
+            authorAssociation=CommentAuthorAssociation.CONTRIBUTOR,
+        ),
+    ]
+    with pytest.raises(NeedsBranchUpdate):
+        mergable(
+            config=config,
+            pull_request=pull_request,
+            branch_protection=branch_protection,
+            review_requests_count=1,
+            reviews=reviews,
+            check_runs=[check_run],
+            contexts=[context],
+            valid_signature=False,
+            valid_merge_methods=[MergeMethod.squash],
+        )
+
 
 def test_passing(
     pull_request: PullRequest,

--- a/kodiak/test_queries.py
+++ b/kodiak/test_queries.py
@@ -2,6 +2,7 @@ import json
 import typing
 from pathlib import Path
 
+import arrow
 import pytest
 
 from kodiak.config import V1, Merge, MergeMethod
@@ -10,11 +11,13 @@ from kodiak.queries import (
     CheckConclusionState,
     CheckRun,
     Client,
+    CommentAuthorAssociation,
     EventInfoResponse,
     GraphQLResponse,
     MergableState,
     MergeStateStatus,
     PRReview,
+    PRReviewAuthor,
     PRReviewState,
     PullRequest,
     PullRequestState,
@@ -110,12 +113,34 @@ def block_event() -> EventInfoResponse:
         review_requests_count=0,
         reviews=[
             PRReview(
-                id="32f57f6aaf91489cb6ce76af62f7c7e2f3b15956",
-                state=PRReviewState.APPROVED,
+                createdAt=arrow.get("2019-05-22T15:29:34Z").datetime,
+                state=PRReviewState.COMMENTED,
+                author=PRReviewAuthor(login="ghost"),
+                authorAssociation=CommentAuthorAssociation.CONTRIBUTOR,
             ),
             PRReview(
-                id="1ff69d4ad5d345a5ab2a0882d799f6066d89f675",
+                createdAt=arrow.get("2019-05-22T15:29:52Z").datetime,
+                state=PRReviewState.CHANGES_REQUESTED,
+                author=PRReviewAuthor(login="ghost"),
+                authorAssociation=CommentAuthorAssociation.CONTRIBUTOR,
+            ),
+            PRReview(
+                createdAt=arrow.get("2019-05-22T15:30:52Z").datetime,
+                state=PRReviewState.COMMENTED,
+                author=PRReviewAuthor(login="kodiak"),
+                authorAssociation=CommentAuthorAssociation.CONTRIBUTOR,
+            ),
+            PRReview(
+                createdAt=arrow.get("2019-05-22T15:43:17Z").datetime,
                 state=PRReviewState.APPROVED,
+                author=PRReviewAuthor(login="ghost"),
+                authorAssociation=CommentAuthorAssociation.CONTRIBUTOR,
+            ),
+            PRReview(
+                createdAt=arrow.get("2019-05-23T15:13:29Z").datetime,
+                state=PRReviewState.APPROVED,
+                author=PRReviewAuthor(login="walrus"),
+                authorAssociation=CommentAuthorAssociation.CONTRIBUTOR,
             ),
         ],
         status_contexts=[

--- a/poetry.lock
+++ b/poetry.lock
@@ -17,6 +17,17 @@ version = "0.1.0"
 
 [[package]]
 category = "main"
+description = "Better dates and times for Python"
+name = "arrow"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.13.2"
+
+[package.dependencies]
+python-dateutil = "*"
+
+[[package]]
+category = "main"
 description = "Fast ASN.1 parser and serializer with definitions for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP"
 name = "asn1crypto"
 optional = false
@@ -531,6 +542,17 @@ pytest = ">=2.7"
 
 [[package]]
 category = "main"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.8.0"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
@@ -719,12 +741,13 @@ python-versions = "*"
 version = "1.11.1"
 
 [metadata]
-content-hash = "52a1eb930601e9ea33b049ae1c961124eb02af8c3762f0396632c764030fa266"
+content-hash = "8fcce7837e85251241b77dd357115b1fb29985c5cffc3c8f3ca6a6a1e4dc664d"
 python-versions = "^3.7"
 
 [metadata.hashes]
 appdirs = ["9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92", "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"]
 appnope = ["5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0", "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"]
+arrow = ["002f2315cf4c8404de737c42860441732d339bbc57fee584e2027520e055ecc1", "82dd5e13b733787d4eb0fef42d1ee1a99136dc1d65178f70373b3678b3181bfc"]
 asn1crypto = ["2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87", "9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"]
 astroid = ["6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4", "b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"]
 atomicwrites = ["03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4", "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"]
@@ -775,6 +798,7 @@ pylint = ["5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09", "7
 pytest = ["1a8aa4fa958f8f451ac5441f3ac130d9fc86ea38780dd2715e6d5c5882700b24", "b8bf138592384bd4e87338cb0f256bf5f615398a649d4bd83915f0e4047a5ca6"]
 pytest-asyncio = ["9fac5100fd716cbecf6ef89233e8590a4ad61d729d1732e0a96b84182df1daaf", "d734718e25cfc32d2bf78d346e99d33724deeba774cc4afdf491530c6184b63b"]
 pytest-mock = ["43ce4e9dd5074993e7c021bb1c22cbb5363e612a2b5a76bc6d956775b10758b7", "5bf5771b1db93beac965a7347dc81c675ec4090cb841e49d9d34637a25c30568"]
+python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
 requests-async = ["484221fb41ccc47b475cdc2634b37884ca78ca291160664e9b8b8c5e53fdd4af"]
 sentry-asgi = ["c72d45e980f3e499f06a02498d3ad91f3599f11bbe2fa45e53b0a47e2a50459a"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ sentry-sdk = "^0.8.0"
 sentry-asgi = "^0.1.5"
 fastapi = "^0.17.0"
 ujson = "^1.35"
+arrow = "^0.13.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.4"


### PR DESCRIPTION
We want to ignore old `CHANGES_REQUESTED` reviews that are superseded by `APPROVED` reviews.

CHANGES
- add arrow to make dealing with datetimes easier
- fix bug in handling of reviews