### PR TITLE
Add support for include_pr_number configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for `include_pr_number` configuration. Enabling `include_pr_number` with a non-default merge message option will append the pr number to the commit message, like the Github UI.
 
 ## 0.3.0 - 2019-05-24
 

--- a/kodiak/conftest.py
+++ b/kodiak/conftest.py
@@ -50,7 +50,8 @@ def config(config_file: str) -> V1:
 @pytest.fixture
 def pull_request() -> queries.PullRequest:
     return queries.PullRequest(
-        id="123",
+        id="MDExOlB1bGxSZXF1ZXN0MjgxODQ0Nzg2",
+        number=235,
         mergeStateStatus=queries.MergeStateStatus.BEHIND,
         state=queries.PullRequestState.OPEN,
         mergeable=queries.MergableState.MERGEABLE,

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -293,6 +293,8 @@ class PR:
             merge_body.update(dict(commit_message=pull_request.bodyText))
         if config.merge.message.title == MergeTitleStyle.pull_request_title:
             merge_body.update(dict(commit_title=pull_request.title))
+        if config.merge.message.include_pr_number and merge_body.get("commit_title"):
+            merge_body["commit_title"] += f" ({pull_request.number})"
         return merge_body
 
     async def merge(self) -> MergeResults:

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -183,6 +183,7 @@ class PullRequestState(Enum):
 
 class PullRequest(BaseModel):
     id: str
+    number: int
     title: str
     bodyText: str
     mergeStateStatus: MergeStateStatus
@@ -513,6 +514,7 @@ class Client:
         )
 
         pull_request["latest_sha"] = sha
+        pull_request["number"] = pr_number
         try:
             pr = PullRequest.parse_obj(pull_request)
         except ValueError:

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -30,7 +30,8 @@ from kodiak.queries import (
 @pytest.fixture
 def pull_request() -> PullRequest:
     return PullRequest(
-        id="254",
+        id="FDExOlB1bGxSZXX1ZXN0MjgxODQ0Nzg7",
+        number=142,
         mergeStateStatus=MergeStateStatus.CLEAN,
         state=PullRequestState.OPEN,
         mergeable=MergableState.MERGEABLE,

--- a/kodiak/test_main.py
+++ b/kodiak/test_main.py
@@ -211,6 +211,7 @@ def test_pr_get_merge_body_full(pull_request: queries.PullRequest) -> None:
                 message=MergeMessage(
                     title=MergeTitleStyle.pull_request_title,
                     body=MergeBodyStyle.pull_request_body,
+                    include_pr_number=True,
                 ),
             ),
         ),
@@ -218,7 +219,7 @@ def test_pr_get_merge_body_full(pull_request: queries.PullRequest) -> None:
     )
     expected = dict(
         merge_method="squash",
-        commit_title=pull_request.title,
+        commit_title=pull_request.title + f" ({pull_request.number})",
         commit_message=pull_request.bodyText,
     )
     assert actual == expected

--- a/kodiak/test_queries.py
+++ b/kodiak/test_queries.py
@@ -77,6 +77,7 @@ def block_event() -> EventInfoResponse:
     )
     pr = PullRequest(
         id="e14ff7599399478fb9dbc2dacb87da72",
+        number=100,
         mergeStateStatus=MergeStateStatus.BEHIND,
         state=PullRequestState.OPEN,
         mergeable=MergableState.MERGEABLE,


### PR DESCRIPTION
Enabling `include_pr_number` with a non-default merge message option
will append the pr number to the commit message, like the Github UI.