### PR TITLE
fix: correct bad type for configuration of app_id

### DIFF
--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -68,7 +68,7 @@ class V1(BaseModel):
     # kodiak, but also run the development version on a specific repo. By
     # setting _app_id to the development github app ID, we can prevent the
     # production kodiak instance from interfering.
-    app_id: typing.Optional[int]
+    app_id: typing.Optional[str]
     merge: Merge = Merge()
 
     @validator("version", pre=True, always=True)

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -39,7 +39,7 @@ def test_config_parsing_opposite() -> None:
 
     expected = V1(
         version=1,
-        app_id=12345,
+        app_id="12345",
         merge=Merge(
             whitelist=["mergeit!"],
             blacklist=["wip", "block-merge"],

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -788,7 +788,7 @@ def test_passing(
 def test_app_id(
     pull_request: PullRequest, config: V1, branch_protection: BranchProtectionRule
 ) -> None:
-    config.app_id = 123
+    config.app_id = "123"
     with pytest.raises(NotQueueable, match="app_id"):
         mergable(
             app_id="1234",


### PR DESCRIPTION
app_id is configured as a string, so the configuration should be a
string as well.