### PR TITLE
Add blacklist_title_regex. Rename blacklist to blacklist_labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ updated when their targets were updated.
 
 4. Pull request mergeability is evaluated using PR data
 
-   - configuration automerge_label and blacklist are checked
+   - configuration automerge_label, blacklist_title_regex, and blacklist_labels are checked
    - configuration merge method is checked against enabled repo merge methods
    - pull request merge states are evaluated
    - the branch is updated if necessary and this process restarts
@@ -64,7 +64,8 @@ Kodiak won't merge PRs if branch protection is disabled.
 
    [merge]
    automerge_label = "automerge" # default: "automerge"
-   blacklist = [] # default: []
+   blacklist_title_regex = "WIP.*" # default: unset
+   blacklist_labels = [] # default: []
    method = "squash" # default: "merge", options: "merge", "squash", "rebase"
    delete_branch_on_merge = true # default: false
    block_on_reviews_requested = false # default: false

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Kodiak won't merge PRs if branch protection is disabled.
 
    [merge]
    automerge_label = "automerge" # default: "automerge"
-   blacklist_title_regex = "WIP.*" # default: unset
+   blacklist_title_regex = "^WIP.*" # default: "^WIP.*"
    blacklist_labels = [] # default: []
    method = "squash" # default: "merge", options: "merge", "squash", "rebase"
    delete_branch_on_merge = true # default: false

--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -43,8 +43,9 @@ class MergeMessage(BaseModel):
 class Merge(BaseModel):
     # label to enable merging of pull request.
     automerge_label: str = "automerge"
-    # regex to match against title and block merging
-    blacklist_title_regex: typing.Optional[str] = None
+    # regex to match against title and block merging. Set to empty string to
+    # disable check.
+    blacklist_title_regex: str = "^WIP:.*"
     # labels to block merging of pull request
     blacklist_labels: typing.List[str] = []
     # action to take when attempting to merge PR. An error will occur if method

--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -43,8 +43,10 @@ class MergeMessage(BaseModel):
 class Merge(BaseModel):
     # label to enable merging of pull request.
     automerge_label: str = "automerge"
+    # regex to match against title and block merging
+    blacklist_title_regex: typing.Optional[str] = None
     # labels to block merging of pull request
-    blacklist: typing.List[str] = []
+    blacklist_labels: typing.List[str] = []
     # action to take when attempting to merge PR. An error will occur if method
     # is disabled for repository
     method: MergeMethod = MergeMethod.merge

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -1,3 +1,4 @@
+import re
 import typing
 from collections import defaultdict
 
@@ -106,9 +107,16 @@ def mergeable(
         raise NotQueueable(
             f"missing automerge_label: {repr(config.merge.automerge_label)}"
         )
-    if not set(pull_request.labels).isdisjoint(config.merge.blacklist):
+    if not set(pull_request.labels).isdisjoint(config.merge.blacklist_labels):
         log.info("missing required blacklist labels")
         raise NotQueueable("has blacklist labels")
+
+    if (
+        config.merge.blacklist_title_regex
+        and re.search(config.merge.blacklist_title_regex, pull_request.title)
+        is not None
+    ):
+        raise NotQueueable("title matches blacklist_title_regex")
 
     if config.merge.method not in valid_merge_methods:
         # TODO: This is a fatal configuration error. We should provide some notification of this issue

--- a/kodiak/test/fixtures/config/v1-default.toml
+++ b/kodiak/test/fixtures/config/v1-default.toml
@@ -3,7 +3,7 @@ version = 1 # required
 
 [merge]
 automerge_label = "automerge"
-blacklist = []
+blacklist_labels = []
 method = "merge"
 delete_branch_on_merge = false
 block_on_reviews_requested = false

--- a/kodiak/test/fixtures/config/v1-default.toml
+++ b/kodiak/test/fixtures/config/v1-default.toml
@@ -3,6 +3,7 @@ version = 1 # required
 
 [merge]
 automerge_label = "automerge"
+blacklist_title_regex = "^WIP:.*"
 blacklist_labels = []
 method = "merge"
 delete_branch_on_merge = false

--- a/kodiak/test/fixtures/config/v1-opposite.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.toml
@@ -4,7 +4,8 @@ app_id = 12345 # default: None
 
 [merge]
 automerge_label = "mergeit!" # default: "automerge"
-blacklist = ["wip", "block-merge"] # default: []
+blacklist_title_regex = "WIP:.*" # default: unset
+blacklist_labels = ["wip", "block-merge"] # default: []
 method = "squash" # default: "merge"
 delete_branch_on_merge = true # default: False
 block_on_reviews_requested = true # default: false

--- a/kodiak/test/fixtures/config/v1-opposite.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.toml
@@ -4,7 +4,7 @@ app_id = 12345 # default: None
 
 [merge]
 automerge_label = "mergeit!" # default: "automerge"
-blacklist_title_regex = "WIP:.*" # default: unset
+blacklist_title_regex = "" # default: "^WIP:.*"
 blacklist_labels = ["wip", "block-merge"] # default: []
 method = "squash" # default: "merge"
 delete_branch_on_merge = true # default: False

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -42,7 +42,7 @@ def test_config_parsing_opposite() -> None:
         app_id="12345",
         merge=Merge(
             automerge_label="mergeit!",
-            blacklist_title_regex="WIP:.*",
+            blacklist_title_regex="",
             blacklist_labels=["wip", "block-merge"],
             method=MergeMethod.squash,
             delete_branch_on_merge=True,

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -42,7 +42,8 @@ def test_config_parsing_opposite() -> None:
         app_id="12345",
         merge=Merge(
             automerge_label="mergeit!",
-            blacklist=["wip", "block-merge"],
+            blacklist_title_regex="WIP:.*",
+            blacklist_labels=["wip", "block-merge"],
             method=MergeMethod.squash,
             delete_branch_on_merge=True,
             block_on_reviews_requested=True,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -120,6 +120,29 @@ def test_blacklisted(
             valid_merge_methods=[MergeMethod.merge, MergeMethod.squash],
         )
 
+def test_blacklist_title_match(
+    pull_request: PullRequest,
+    config: V1,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+) -> None:
+    # a PR with a blacklisted label should not be mergeable
+    with pytest.raises(NotQueueable, match="blacklist_title"):
+        config.merge.blacklist_title_regex = "^WIP:.*"
+        pull_request.title = "WIP: add fleeb to plumbus"
+        mergeable(
+            config=config,
+            pull_request=pull_request,
+            branch_protection=branch_protection,
+            review_requests_count=0,
+            reviews=[review],
+            contexts=[context],
+            check_runs=[],
+            valid_signature=False,
+            valid_merge_methods=[MergeMethod.merge, MergeMethod.squash],
+        )
+
 
 def test_bad_merge_method_config(
     pull_request: PullRequest,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -120,6 +120,7 @@ def test_blacklisted(
             valid_merge_methods=[MergeMethod.merge, MergeMethod.squash],
         )
 
+
 def test_blacklist_title_match(
     pull_request: PullRequest,
     config: V1,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -51,7 +51,7 @@ def pull_request() -> PullRequest:
 def config() -> V1:
     cfg = V1(version=1)
     cfg.merge.automerge_label = "automerge"
-    cfg.merge.blacklist = []
+    cfg.merge.blacklist_labels = []
     cfg.merge.method = MergeMethod.squash
     return cfg
 
@@ -107,7 +107,7 @@ def test_blacklisted(
     with pytest.raises(NotQueueable, match="blacklist"):
         pull_request.labels = ["automerge", "dont-merge"]
         config.merge.automerge_label = "automerge"
-        config.merge.blacklist = ["dont-merge"]
+        config.merge.blacklist_labels = ["dont-merge"]
         mergeable(
             config=config,
             pull_request=pull_request,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -128,7 +128,7 @@ def test_blacklist_title_match(
     review: PRReview,
     context: StatusContext,
 ) -> None:
-    # a PR with a blacklisted label should not be mergeable
+    # a PR with a blacklisted title should not be mergeable
     with pytest.raises(NotQueueable, match="blacklist_title"):
         config.merge.blacklist_title_regex = "^WIP:.*"
         pull_request.title = "WIP: add fleeb to plumbus"


### PR DESCRIPTION
This will help fix the infinite loop that occurs from the WIP app. Since
that app sets the check-run to "in-progress" instead of "failed", kodiak
will wait forever for the check to finish if the PR is up for merging.

With blacklist_title_regex, we can simply set it to match the behavior
of the WIP app and mark the PR as not mergeable early on.