### PR TITLE
Show kodiak state information in Github CheckRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Kodiak won't merge PRs if branch protection is disabled.
    | name                       | level       | reason                          |
    | -------------------------- | ----------- | ------------------------------- |
    | repository administration  | read-only   | branch protection info          |
-   | checks                     | read-only   | PR mergeability                 |
+   | checks                     | read/write   | PR mergeability and status report                 |
    | repository contents        | read/write  | update PRs, read configuration  |
    | pull requests              | read/write  | PR mergeability, merge PR       |
    | commit statuses            | read-only   | PR mergeability                 |

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -55,6 +55,15 @@ class NotQueueable(BaseException):
     pass
 
 
+class MissingAppID(BaseException):
+    """
+    Application app_id doesn't match configuration
+
+    We do _not_ want to display this message to users as it could clobber
+    another instance of kodiak.
+    """
+
+
 class BranchMerged(BaseException):
     """branch has already been merged"""
 
@@ -101,7 +110,7 @@ def mergeable(
     # if we have an app_id in the config then we only want to work on this repo
     # if our app_id from the environment matches the configuration.
     if config.app_id is not None and config.app_id != app_id:
-        raise NotQueueable("missing required app_id")
+        raise MissingAppID("missing required app_id")
 
     if config.merge.automerge_label not in pull_request.labels:
         raise NotQueueable(

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -19,6 +19,7 @@ from kodiak import queries
 from kodiak.config import V1, BodyText, MergeBodyStyle, MergeTitleStyle
 from kodiak.evaluation import (
     BranchMerged,
+    MissingAppID,
     MissingGithubMergeabilityState,
     NeedsBranchUpdate,
     NotQueueable,
@@ -355,6 +356,8 @@ class PR:
             )
             self.log.info("okay")
             return MergeabilityResponse.OK, event
+        except MissingAppID:
+            return MergeabilityResponse.NOT_MERGEABLE, event
         except NotQueueable:
             self.log.info("not queueable")
             return MergeabilityResponse.NOT_MERGEABLE, event

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -333,9 +333,12 @@ class PR:
                 installation_id=self.installation_id,
             )
 
-    async def set_state(
+    async def set_status(
         self, summary: str, detail: typing.Optional[str] = None
     ) -> None:
+        """
+        Display a message to a user through a github check
+        """
         if detail is not None:
             message = f"{summary} ({detail})"
         else:
@@ -381,19 +384,21 @@ class PR:
         except MissingAppID:
             return MergeabilityResponse.NOT_MERGEABLE, self.event
         except NotQueueable as e:
-            await self.set_state(summary="cannot merge", detail=str(e))
+            await self.set_status(summary="cannot merge", detail=str(e))
             return MergeabilityResponse.NOT_MERGEABLE, self.event
         except MissingGithubMergeabilityState:
             self.log.info("missing mergeability state, need refresh")
             return MergeabilityResponse.NEED_REFRESH, self.event
         except WaitingForChecks:
-            await self.set_state(summary="waiting for checks")
+            await self.set_status(summary="waiting for checks")
             return MergeabilityResponse.WAIT, self.event
         except NeedsBranchUpdate:
-            await self.set_state(summary="need update")
+            await self.set_status(summary="need update")
             return MergeabilityResponse.NEEDS_UPDATE, self.event
         except BranchMerged:
-            await self.set_state(summary="cannot merge", detail="branch merged already")
+            await self.set_status(
+                summary="cannot merge", detail="branch merged already"
+            )
             async with self.Client() as client:
                 await client.delete_branch(
                     owner=self.owner,

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -359,39 +359,39 @@ class PR:
         if self.event is None:
             self.log.info("no event")
             return MergeabilityResponse.NOT_MERGEABLE, None
-        if not event.head_exists:
+        if not self.event.head_exists:
             self.log.info("branch deleted")
             return MergeabilityResponse.NOT_MERGEABLE, None
         try:
             self.log.info("check mergeable")
             mergeable(
-                config=event.config,
+                config=self.event.config,
                 app_id=os.getenv("GITHUB_APP_ID"),
-                pull_request=event.pull_request,
-                branch_protection=event.branch_protection,
-                review_requests_count=event.review_requests_count,
-                reviews=event.reviews,
-                contexts=event.status_contexts,
-                check_runs=event.check_runs,
-                valid_signature=event.valid_signature,
-                valid_merge_methods=event.valid_merge_methods,
+                pull_request=self.event.pull_request,
+                branch_protection=self.event.branch_protection,
+                review_requests_count=self.event.review_requests_count,
+                reviews=self.event.reviews,
+                contexts=self.event.status_contexts,
+                check_runs=self.event.check_runs,
+                valid_signature=self.event.valid_signature,
+                valid_merge_methods=self.event.valid_merge_methods,
             )
             self.log.info("okay")
-            return MergeabilityResponse.OK, event
+            return MergeabilityResponse.OK, self.event
         except MissingAppID:
-            return MergeabilityResponse.NOT_MERGEABLE, event
+            return MergeabilityResponse.NOT_MERGEABLE, self.event
         except NotQueueable as e:
             await self.set_state(summary="cannot merge", detail=str(e))
-            return MergeabilityResponse.NOT_MERGEABLE, event
+            return MergeabilityResponse.NOT_MERGEABLE, self.event
         except MissingGithubMergeabilityState:
             self.log.info("missing mergeability state, need refresh")
-            return MergeabilityResponse.NEED_REFRESH, event
+            return MergeabilityResponse.NEED_REFRESH, self.event
         except WaitingForChecks:
             await self.set_state(summary="waiting for checks")
-            return MergeabilityResponse.WAIT, event
+            return MergeabilityResponse.WAIT, self.event
         except NeedsBranchUpdate:
             await self.set_state(summary="need update")
-            return MergeabilityResponse.NEEDS_UPDATE, event
+            return MergeabilityResponse.NEEDS_UPDATE, self.event
         except BranchMerged:
             await self.set_state(summary="cannot merge", detail="branch merged already")
             async with self.Client() as client:
@@ -399,9 +399,9 @@ class PR:
                     owner=self.owner,
                     repo=self.repo,
                     installation_id=self.installation_id,
-                    branch=event.pull_request.headRefName,
+                    branch=self.event.pull_request.headRefName,
                 )
-            return MergeabilityResponse.NOT_MERGEABLE, event
+            return MergeabilityResponse.NOT_MERGEABLE, self.event
 
     async def update(self) -> None:
         async with self.Client() as client:

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 
+import arrow
 import jwt
 import requests_async as http
 import structlog
@@ -20,6 +21,8 @@ from kodiak.config import V1, MergeMethod
 from kodiak.github import events
 
 logger = structlog.get_logger()
+
+CHECK_RUN_NAME = "kodiakhq: status"
 
 
 class ErrorLocation(TypedDict):
@@ -373,7 +376,7 @@ class Client:
         token = await self.get_token_for_install(installation_id=installation_id)
         return dict(
             Authorization=f"token {token}",
-            Accept="application/vnd.github.machine-man-preview+json",
+            Accept="application/vnd.github.machine-man-preview+json,application/vnd.github.antiope-preview+json",
         )
 
     def generate_jwt(self) -> str:
@@ -694,3 +697,24 @@ class Client:
         headers = await self.get_headers(installation_id)
         url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}/merge"
         return await self.session.put(url, headers=headers, json=body)
+
+    async def create_notification(
+        self,
+        owner: str,
+        repo: str,
+        head_sha: str,
+        message: str,
+        installation_id: str,
+        summary: typing.Optional[str] = None,
+    ) -> http.Response:
+        headers = await self.get_headers(installation_id)
+        url = f"https://api.github.com/repos/{owner}/{repo}/check-runs"
+        body = {
+            "name": CHECK_RUN_NAME,
+            "head_sha": head_sha,
+            "status": "completed",
+            "completed_at": arrow.utcnow().isoformat(),
+            "conclusion": "neutral",
+            "output": {"title": message, "summary": summary or ""},
+        }
+        return await self.session.post(url, headers=headers, json=body)

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -709,12 +709,12 @@ class Client:
     ) -> http.Response:
         headers = await self.get_headers(installation_id)
         url = f"https://api.github.com/repos/{owner}/{repo}/check-runs"
-        body = {
-            "name": CHECK_RUN_NAME,
-            "head_sha": head_sha,
-            "status": "completed",
-            "completed_at": arrow.utcnow().isoformat(),
-            "conclusion": "neutral",
-            "output": {"title": message, "summary": summary or ""},
-        }
+        body = dict(
+            name=CHECK_RUN_NAME,
+            head_sha=head_sha,
+            status="completed",
+            completed_at=arrow.utcnow().isoformat(),
+            conclusion="neutral",
+            output=dict(title=message, summary=summary or ""),
+        )
         return await self.session.post(url, headers=headers, json=body)

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -5,6 +5,7 @@ import pytest
 from kodiak.config import V1, MergeMethod
 from kodiak.evaluation import (
     BranchMerged,
+    MissingAppID,
     MissingGithubMergeabilityState,
     NeedsBranchUpdate,
     NotQueueable,
@@ -789,7 +790,7 @@ def test_app_id(
     pull_request: PullRequest, config: V1, branch_protection: BranchProtectionRule
 ) -> None:
     config.app_id = "123"
-    with pytest.raises(NotQueueable, match="app_id"):
+    with pytest.raises(MissingAppID):
         mergeable(
             app_id="1234",
             config=config,
@@ -803,7 +804,7 @@ def test_app_id(
             valid_merge_methods=[],
         )
     # try without passing an app_id
-    with pytest.raises(NotQueueable, match="app_id"):
+    with pytest.raises(MissingAppID):
         mergeable(
             config=config,
             pull_request=pull_request,

--- a/kodiak/test_main.py
+++ b/kodiak/test_main.py
@@ -96,6 +96,11 @@ async def test_deleting_branch_after_merge(
         async def get_event(self) -> typing.Optional[queries.EventInfoResponse]:
             return event_response
 
+        async def set_state(
+            self, *args: typing.Any, **kwargs: typing.Any
+        ) -> typing.Any:
+            return None
+
     called = False
 
     class FakeClient(queries.Client):

--- a/kodiak/test_main.py
+++ b/kodiak/test_main.py
@@ -96,7 +96,7 @@ async def test_deleting_branch_after_merge(
         async def get_event(self) -> typing.Optional[queries.EventInfoResponse]:
             return event_response
 
-        async def set_state(
+        async def set_status(
             self, *args: typing.Any, **kwargs: typing.Any
         ) -> typing.Any:
             return None


### PR DESCRIPTION
Display information about merging process to users through a github check.

EXAMPLES

<img width="707" alt="Screen Shot 2019-06-15 at 3 35 19 PM" src="https://user-images.githubusercontent.com/1929960/59555618-3b4e8480-8f83-11e9-971a-6a19cd88f43f.png">

<img width="710" alt="Screen Shot 2019-06-15 at 3 35 28 PM" src="https://user-images.githubusercontent.com/1929960/59555620-3e497500-8f83-11e9-8d6d-ed78d52f18e7.png">
