### PR TITLE
ref: reduce unnecessary pull request processing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - api-v0-{{ .Branch }}-{{ checksum "poetry.lock" }}
-            - api-v0-{{ .Branch }}-
-            - api-v0-
+            - api-v1-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - api-v1-{{ .Branch }}-
+            - api-v1-
       - run:
           name: install dependencies
           command: |
@@ -24,7 +24,7 @@ jobs:
           paths:
             - ./.mypy_cache
             - /root/.cache/
-          key: api-v0-{{ .Branch }}-{{ checksum "poetry.lock" }}
+          key: api-v1-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run tests
           command: ./s/test
@@ -37,9 +37,9 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - api-v0-{{ .Branch }}-{{ checksum "poetry.lock" }}
-            - api-v0-{{ .Branch }}-
-            - api-v0-
+            - api-v1-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - api-v1-{{ .Branch }}-
+            - api-v1-
       - run:
           name: install dependencies
           command: |
@@ -52,7 +52,7 @@ jobs:
           paths:
             - ./.mypy_cache
             - /root/.cache/
-          key: api-v0-{{ .Branch }}-{{ checksum "poetry.lock" }}
+          key: api-v1-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run lints
           command: ./s/lint

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Kodiak won't merge PRs if branch protection is disabled.
    **Self Hosted**
 
    You can run the `Dockerfile` provided in the repo on your platform of choice
-   or you could use the Heroku app configuration below:
+   or you could use the Heroku app configuration below. Redis >=5 is required
+   for operation.
 
    ```shell
    # a unique name for the heroku app
@@ -127,6 +128,9 @@ Kodiak won't merge PRs if branch protection is disabled.
 
    # configure app environment (this can also be done through the Heroku web ui)
    heroku config:set -a $APP_NAME GITHUB_APP_ID='<GH_APP_ID>' SECRET_KEY='<GH_APP_SECRET>' GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nsome/private/key\nbits\n-----END RSA PRIVATE KEY-----\n"
+
+   # Redis v5 is required and provided by RedisCloud
+   heroku addons:create -a $APP_NAME rediscloud:30 --wait
 
    # release app
    heroku container:release web -a $APP_NAME

--- a/kodiak/app_config.py
+++ b/kodiak/app_config.py
@@ -3,7 +3,9 @@ from starlette.config import Config
 
 config = Config(".env")
 
-REDIS_URL = config("REDIS_URL", cast=databases.DatabaseURL)
+REDIS_URL = config("REDIS_URL", cast=databases.DatabaseURL, default=None) or config(
+    "REDISCLOUD_URL", cast=databases.DatabaseURL
+)
 SECRET_KEY = config("SECRET_KEY")
 GITHUB_APP_ID = config("GITHUB_APP_ID")
 GITHUB_PRIVATE_KEY_PATH = config("GITHUB_PRIVATE_KEY_PATH", default=None)

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -10,7 +10,7 @@ import asyncio_redis
 import sentry_sdk
 import structlog
 from asyncio_redis.connection import Connection as RedisConnection
-from asyncio_redis.replies import BlockingPopReply, ZRangeReply
+from asyncio_redis.replies import BlockingZPopReply
 from fastapi import FastAPI
 from pydantic import BaseModel
 from sentry_asgi import SentryMiddleware
@@ -61,7 +61,7 @@ async def repo_queue_consumer(
     log.info("start repo_consumer")
     while True:
         log.info("block for new event")
-        webhook_event_json: ZRangeReply = await connection.bzpopmin([queue_name])
+        webhook_event_json: BlockingZPopReply = await connection.bzpopmin([queue_name])
         webhook_event = WebhookEvent.parse_raw(webhook_event_json.value)
         pull_request = PR(
             owner=webhook_event.repo_owner,

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import typing
 from dataclasses import dataclass, field
 from enum import Enum, auto
@@ -9,7 +10,7 @@ import asyncio_redis
 import sentry_sdk
 import structlog
 from asyncio_redis.connection import Connection as RedisConnection
-from asyncio_redis.replies import BlockingPopReply
+from asyncio_redis.replies import BlockingPopReply, ZRangeReply
 from fastapi import FastAPI
 from pydantic import BaseModel
 from sentry_asgi import SentryMiddleware
@@ -60,7 +61,7 @@ async def repo_queue_consumer(
     log.info("start repo_consumer")
     while True:
         log.info("block for new event")
-        webhook_event_json: BlockingPopReply = await connection.blpop([queue_name])
+        webhook_event_json: ZRangeReply = await connection.bzpopmin([queue_name])
         webhook_event = WebhookEvent.parse_raw(webhook_event_json.value)
         pull_request = PR(
             owner=webhook_event.repo_owner,
@@ -160,8 +161,10 @@ class RedisWebhookQueue:
 
     async def enqueue(self, *, event: WebhookEvent) -> None:
         key = self.get_queue_key(event)
-        await self.connection.sadd(QUEUE_SET_NAME, [key])
-        await self.connection.rpush(key, [event.json()])
+        transaction = await self.connection.multi()
+        await transaction.sadd(QUEUE_SET_NAME, [key])
+        await transaction.zadd(key, {event.json(): time.time()})
+        await transaction.exec()
 
         self.start_worker(key)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,12 +50,27 @@ wrapt = "*"
 
 [[package]]
 category = "main"
+description = "reference implementation of PEP 3156"
+name = "asyncio"
+optional = false
+python-versions = "*"
+version = "3.4.3"
+
+[[package]]
+category = "main"
 description = "PEP 3156 implementation of the redis protocol."
 name = "asyncio-redis"
 optional = false
 python-versions = "*"
 version = "0.15.1"
 
+[package.dependencies]
+asyncio = "*"
+
+[package.source]
+reference = "12dbc66bc2bcefcf7cdbe46de7dbce5bcdefe1aa"
+type = "git"
+url = "https://github.com/chdsbd/asyncio-redis.git"
 [[package]]
 category = "dev"
 description = "Atomic file writes."
@@ -811,7 +826,7 @@ python-versions = ">=2.7"
 version = "0.5.1"
 
 [metadata]
-content-hash = "b3754a65849dcff250b590a95213a75a36cccc1129db13c543891cbdd28e63ba"
+content-hash = "131d0cd9323555ab60b49a0b0a57458e8cc123e8a09fc5793ae3837aa11387c2"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -820,7 +835,8 @@ appnope = ["5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0", "
 arrow = ["002f2315cf4c8404de737c42860441732d339bbc57fee584e2027520e055ecc1", "82dd5e13b733787d4eb0fef42d1ee1a99136dc1d65178f70373b3678b3181bfc"]
 asn1crypto = ["2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87", "9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"]
 astroid = ["6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4", "b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"]
-asyncio-redis = ["067dbc251ab84d6e53ef8b33dbfd8afd62987ab08f72ca922f6870c96be53b54", "f49e2c6626f3fcfddb478ee1d01f0335e22b6656add274e8a88fcdec9bd78745"]
+asyncio = ["83360ff8bc97980e4ff25c964c7bd3923d333d177aa4f7fb736b019f26c7cb41", "b62c9157d36187eca799c378e572c969f0da87cd5fc42ca372d92cdb06e7e1de", "c46a87b48213d7464f22d9a497b9eef8c1928b68320a2fa94240f969f6fec08c", "c4d18b22701821de07bd6aea8b53d21449ec0ec5680645e5317062ea21817d2d"]
+asyncio-redis = []
 atomicwrites = ["03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4", "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"]
 attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"]
 backcall = ["38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4", "bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ sentry-asgi = "^0.1.5"
 fastapi = "^0.17.0"
 ujson = "^1.35"
 arrow = "^0.13.2"
-asyncio_redis = "^0.15.1"
 databases = "^0.2.2"
+asyncio_redis = {git = "https://github.com/chdsbd/asyncio-redis.git"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.4"


### PR DESCRIPTION
By storing events in a set we can cut down on processing pull requests
multiple times in short succession.

Previously, events for a pull request could be entered multiple times
into the redis queue. Now a pull request can only be in the queue once.

We're using `bzpopmin`, which is only supported by redis v5 or later. It
is also not supported by asyncio_redis yet, so we need to make a change
there.