### PR TITLE
add(conf): respect delete_branch_on_merge configuration option

### DIFF
--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -417,13 +417,14 @@ class PR:
             await self.set_status(
                 summary="🛑 cannot merge", detail="branch merged already"
             )
-            async with self.Client() as client:
-                await client.delete_branch(
-                    owner=self.owner,
-                    repo=self.repo,
-                    installation_id=self.installation_id,
-                    branch=self.event.pull_request.headRefName,
-                )
+            if self.event.config.merge.delete_branch_on_merge:
+                async with self.Client() as client:
+                    await client.delete_branch(
+                        owner=self.owner,
+                        repo=self.repo,
+                        installation_id=self.installation_id,
+                        branch=self.event.pull_request.headRefName,
+                    )
             return MergeabilityResponse.NOT_MERGEABLE, self.event
 
     async def update(self) -> None:

--- a/kodiak/test_main.py
+++ b/kodiak/test_main.py
@@ -91,6 +91,7 @@ async def test_deleting_branch_after_merge(
 
     event_response.pull_request.state = queries.PullRequestState.MERGED
     event_response.pull_request.labels = labels
+    event_response.config.merge.delete_branch_on_merge = True
 
     class FakePR(PR):
         async def get_event(self) -> typing.Optional[queries.EventInfoResponse]:


### PR DESCRIPTION
We now will only automatically delete branches if delete_branch_on_merge
is set.