### PR TITLE
ref: improve backend architecture

### DIFF
--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -44,9 +44,56 @@ CONFIG_FILE_PATH = ".kodiak.toml"
 
 WEBHOOK_QUEUE_NAME = "kodiak_webhooks"
 
-REPO_WORKERS: typing.MutableMapping[str, asyncio.Task] = {}
+WORKER_TASKS: typing.MutableMapping[str, asyncio.Task] = {}
 
 MERGE_RETRY_RATE_SECONDS = 2
+
+
+async def webhook_event_consumer(*, connection: RedisConnection) -> typing.NoReturn:
+    """
+    Worker to process incoming webhook events from redis
+
+    1. process mergeability information and update github check status for pr
+    2. enqueue pr into repo queue for merging, if mergeability passed
+    """
+    log = logger.bind(queue=WEBHOOK_QUEUE_NAME)
+    log.info("start webhook event consumer")
+
+    while True:
+        log.info("block for new webhook event")
+        webhook_event_json: BlockingZPopReply = await connection.bzpopmin(
+            [WEBHOOK_QUEUE_NAME]
+        )
+        webhook_event = WebhookEvent.parse_raw(webhook_event_json.value)
+        pull_request = PR(
+            owner=webhook_event.repo_owner,
+            repo=webhook_event.repo_name,
+            number=webhook_event.pull_request_number,
+            installation_id=webhook_event.installation_id,
+        )
+
+        # trigger status updates
+        m_res, event = await pull_request.mergeability()
+        log = log.bind(res=m_res)
+        if event is None or m_res == MergeabilityResponse.NOT_MERGEABLE:
+            continue
+        if m_res not in (
+            MergeabilityResponse.NEEDS_UPDATE,
+            MergeabilityResponse.NEED_REFRESH,
+            MergeabilityResponse.WAIT,
+            MergeabilityResponse.OK,
+        ):
+            raise Exception("Unknown MergeabilityResponse")
+
+        # The following responses are okay to add to merge queue:
+        #   + NEEDS_UPDATE - okay for merging
+        #   + NEED_REFRESH - assume okay
+        #   + WAIT - assume checks pass
+        #   + OK - we've got the green
+        redis_webhook_queue.enqueue_for_repo(event=webhook_event_json)
+
+
+# TODO: Generalize this event processor boilerplate
 
 
 async def repo_queue_consumer(
@@ -56,13 +103,16 @@ async def repo_queue_consumer(
     Worker for a repo
 
     Pull webhook events off redis queue and process for mergeability.
+
+    We only run one of these per repo as we can only merge one PR at a time
+    to be efficient. This also alleviates the need of locks.
     """
     with sentry_sdk.configure_scope() as scope:
         scope.set_tag("queue", queue_name)
     log = logger.bind(queue=queue_name)
     log.info("start repo_consumer")
     while True:
-        log.info("block for new event")
+        log.info("block for new repo event")
         webhook_event_json: BlockingZPopReply = await connection.bzpopmin([queue_name])
         webhook_event = WebhookEvent.parse_raw(webhook_event_json.value)
         pull_request = PR(
@@ -79,6 +129,8 @@ async def repo_queue_consumer(
             #
             # otherwise we continue to poll the Github API for a status change
             # from the other states: NEEDS_UPDATE, NEED_REFRESH, WAIT
+
+            # TODO: Replace enum response with exceptions
             m_res, event = await pull_request.mergeability()
             log = log.bind(res=m_res)
             if event is None or m_res == MergeabilityResponse.NOT_MERGEABLE:
@@ -136,40 +188,56 @@ class RedisWebhookQueue:
             db=redis_db,
             poolsize=conf.REDIS_POOL_SIZE,
         )
-        # restart workers for queues
+
+        # restart repo workers
         queues = await self.connection.smembers(QUEUE_SET_NAME)
         for result in queues:
             queue_name = await result
-            self.start_worker(queue_name)
+            self.start_repo_worker(queue_name)
 
-    def start_worker(self, key: str) -> None:
-        repo_worker = REPO_WORKERS.get(key)
-        if repo_worker is not None:
-            if not repo_worker.done():
+        # start webhook worker
+        self.start_webhook_worker()
+
+    def start_webhook_worker(self) -> None:
+        self._start_worker(
+            WEBHOOK_QUEUE_NAME, webhook_event_consumer(connection=self.connection)
+        )
+
+    def start_repo_worker(self, queue_name: str) -> None:
+        self._start_worker(
+            queue_name,
+            repo_queue_consumer(queue_name=queue_name, connection=self.connection),
+        )
+
+    def _start_worker(self, key: str, fut: typing.Coroutine) -> None:
+        worker_task = WORKER_TASKS.get(key)
+        if worker_task is not None:
+            if not worker_task.done():
                 return
             logger.info("task failed")
             # task failed. record result and restart
-            exception = repo_worker.exception()
+            exception = worker_task.exception()
             logger.info("exception", excep=exception)
             sentry_sdk.capture_exception(exception)
         logger.info("creating task for queue")
         # create new task for queue
-        REPO_WORKERS[key] = asyncio.create_task(
-            repo_queue_consumer(queue_name=key, connection=self.connection)
-        )
+        WORKER_TASKS[key] = asyncio.create_task(fut)
 
     @staticmethod
     def get_queue_key(event: WebhookEvent) -> str:
         return f"kodiak_repo_queue:{event.repo_owner}/{event.repo_name}"
 
     async def enqueue(self, *, event: WebhookEvent) -> None:
+        await self.connection.zadd(WEBHOOK_QUEUE_NAME, {event.json(): time.time()})
+
+    async def enqueue_for_repo(self, *, event: WebhookEvent) -> None:
         key = self.get_queue_key(event)
         transaction = await self.connection.multi()
         await transaction.sadd(QUEUE_SET_NAME, [key])
         await transaction.zadd(key, {event.json(): time.time()})
         await transaction.exec()
 
-        self.start_worker(key)
+        self.start_repo_worker(key)
 
 
 def create_git_revision_expression(branch: str, file_path: str) -> str:

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -103,10 +103,11 @@ async def pr_check_worker(
     #   + NEED_REFRESH - assume okay
     #   + WAIT - assume checks pass
     #   + OK - we've got the green
-    redis_webhook_queue.enqueue_for_repo(event=webhook_event_json)
+    await redis_webhook_queue.enqueue_for_repo(event=webhook_event)
 
 
 # TODO(chdsbd): Generalize this event processor boilerplate
+
 
 async def repo_queue_consumer(
     *, queue_name: str, connection: RedisConnection

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -65,16 +65,10 @@ async def webhook_event_consumer(*, connection: RedisConnection) -> typing.NoRet
             [WEBHOOK_QUEUE_NAME]
         )
         # process event in separate task to increase concurrency
-        asyncio.create_task(
-            pr_check_worker(
-                webhook_event_json=webhook_event_json, connection=connection
-            )
-        )
+        asyncio.create_task(pr_check_worker(webhook_event_json=webhook_event_json))
 
 
-async def pr_check_worker(
-    *, webhook_event_json: BlockingZPopReply, connection: RedisConnection
-) -> None:
+async def pr_check_worker(*, webhook_event_json: BlockingZPopReply) -> None:
     """
     check status of PR
     If PR can be merged, add to its repo's merge queue


### PR DESCRIPTION
- support updating status of PRs when merge is in progress
- create tasks for incoming webhook events
- create _one_ task per repo merge queue