### PR TITLE
fix(evaluation): handle draft state

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -131,6 +131,9 @@ def mergeable(
     ):
         raise NotQueueable("title matches blacklist_title_regex")
 
+    if pull_request.mergeStateStatus == MergeStateStatus.DRAFT:
+        raise NotQueueable("pull request is in draft state")
+
     if config.merge.method not in valid_merge_methods:
         # TODO: This is a fatal configuration error. We should provide some notification of this issue
         log.error(

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -866,3 +866,28 @@ def test_config_merge_optimistic_updates(
             valid_signature=False,
             valid_merge_methods=[MergeMethod.squash],
         )
+
+def test_merge_state_status_draft(
+    pull_request: PullRequest, config: V1, branch_protection: BranchProtectionRule
+) -> None:
+    """
+    If optimisitc_updates are enabled, branch updates should be prioritized over
+    waiting for running status checks to complete.
+
+    Otherwise, status checks should be checked before updating.
+    """
+    pull_request.mergeStateStatus = MergeStateStatus.DRAFT
+
+    with pytest.raises(NotQueueable, match="draft state"):
+        mergeable(
+            app_id="1234",
+            config=config,
+            pull_request=pull_request,
+            branch_protection=branch_protection,
+            review_requests_count=0,
+            reviews=[],
+            contexts=[],
+            check_runs=[],
+            valid_signature=False,
+            valid_merge_methods=[MergeMethod.squash],
+        )

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -867,6 +867,7 @@ def test_config_merge_optimistic_updates(
             valid_merge_methods=[MergeMethod.squash],
         )
 
+
 def test_merge_state_status_draft(
     pull_request: PullRequest, config: V1, branch_protection: BranchProtectionRule
 ) -> None:


### PR DESCRIPTION
Our previous logic would try to merge when a PR had the draft state, which is incorrect. Now we correctly abort.