### PR TITLE
ref(notifications): improve github check messages for PR status

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -35,7 +35,7 @@ async def valid_merge_methods(cfg: config.V1, repo: RepoInfo) -> bool:
     raise TypeError("Unknown value")
 
 
-class Queueable(BaseException):
+class Queueable(Exception):
     pass
 
 
@@ -51,25 +51,30 @@ class WaitingForChecks(Queueable):
     pass
 
 
-class NotQueueable(BaseException):
+class NotQueueable(Exception):
     pass
 
 
-class MissingAppID(BaseException):
+class MissingAppID(Exception):
     """
     Application app_id doesn't match configuration
 
     We do _not_ want to display this message to users as it could clobber
     another instance of kodiak.
     """
+    def __str__(self) -> str:
+        return "missing Github app id"
 
 
-class BranchMerged(BaseException):
+
+class BranchMerged(Exception):
     """branch has already been merged"""
 
+class MergeConflict(Exception):
+    """Merge conflict in PR."""
+    def __str__(self) -> str:
+        return "merge conflict"
 
-class MergeConflict(BaseException):
-    """Merge conflict in the PR."""
 
 
 def review_status(reviews: typing.List[PRReview]) -> PRReviewState:

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -62,19 +62,20 @@ class MissingAppID(Exception):
     We do _not_ want to display this message to users as it could clobber
     another instance of kodiak.
     """
+
     def __str__(self) -> str:
         return "missing Github app id"
-
 
 
 class BranchMerged(Exception):
     """branch has already been merged"""
 
+
 class MergeConflict(Exception):
     """Merge conflict in PR."""
+
     def __str__(self) -> str:
         return "merge conflict"
-
 
 
 def review_status(reviews: typing.List[PRReview]) -> PRReviewState:

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -35,7 +35,7 @@ async def valid_merge_methods(cfg: config.V1, repo: RepoInfo) -> bool:
     raise TypeError("Unknown value")
 
 
-class Queueable(Exception):
+class Queueable(BaseException):
     pass
 
 
@@ -51,11 +51,11 @@ class WaitingForChecks(Queueable):
     pass
 
 
-class NotQueueable(Exception):
+class NotQueueable(BaseException):
     pass
 
 
-class MissingAppID(Exception):
+class MissingAppID(BaseException):
     """
     Application app_id doesn't match configuration
 
@@ -67,12 +67,12 @@ class MissingAppID(Exception):
         return "missing Github app id"
 
 
-class BranchMerged(Exception):
+class BranchMerged(BaseException):
     """branch has already been merged"""
 
 
-class MergeConflict(Exception):
-    """Merge conflict in PR."""
+class MergeConflict(BaseException):
+    """Merge conflict in the PR."""
 
     def __str__(self) -> str:
         return "merge conflict"

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -70,6 +70,9 @@ class MissingAppID(BaseException):
 class BranchMerged(BaseException):
     """branch has already been merged"""
 
+    def __str__(self) -> str:
+        return str(self.__doc__)
+
 
 class MergeConflict(BaseException):
     """Merge conflict in the PR."""

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -154,9 +154,11 @@ class PR:
             return MergeabilityResponse.OK, self.event
         except (NotQueueable, MissingAppID, MergeConflict) as e:
             await self.set_status(summary="🛑 cannot merge", detail=str(e))
-            if isinstance(e, MergeConflict):
-                if self.event.config.merge.notify_on_conflict:
-                    await self.notify_pr_creator()
+            if (
+                isinstance(e, MergeConflict)
+                and self.event.config.merge.notify_on_conflict
+            ):
+                await self.notify_pr_creator()
             return MergeabilityResponse.NOT_MERGEABLE, self.event
         except MissingGithubMergeabilityState:
             self.log.info("missing mergeability state, need refresh")

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -158,7 +158,7 @@ class PR:
                 and self.event.config.merge.notify_on_conflict
             ):
                 await self.notify_pr_creator()
-            
+
             if (
                 isinstance(e, BranchMerged)
                 and self.event.config.merge.delete_branch_on_merge

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -153,12 +153,12 @@ class PR:
             await self.set_status(summary="⛴ ready to merge")
             return MergeabilityResponse.OK, self.event
         except (NotQueueable, MissingAppID, MergeConflict, BranchMerged) as e:
-            await self.set_status(summary="🛑 cannot merge", detail=str(e))
             if (
                 isinstance(e, MergeConflict)
                 and self.event.config.merge.notify_on_conflict
             ):
                 await self.notify_pr_creator()
+            
             if (
                 isinstance(e, BranchMerged)
                 and self.event.config.merge.delete_branch_on_merge
@@ -167,6 +167,7 @@ class PR:
                     branch=self.event.pull_request.headRefName
                 )
 
+            await self.set_status(summary="🛑 cannot merge", detail=str(e))
             return MergeabilityResponse.NOT_MERGEABLE, self.event
         except MissingGithubMergeabilityState:
             self.log.info("missing mergeability state, need refresh")

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -152,13 +152,21 @@ class PR:
             self.log.info("okay")
             await self.set_status(summary="⛴ ready to merge")
             return MergeabilityResponse.OK, self.event
-        except (NotQueueable, MissingAppID, MergeConflict) as e:
+        except (NotQueueable, MissingAppID, MergeConflict, BranchMerged) as e:
             await self.set_status(summary="🛑 cannot merge", detail=str(e))
             if (
                 isinstance(e, MergeConflict)
                 and self.event.config.merge.notify_on_conflict
             ):
                 await self.notify_pr_creator()
+            if (
+                isinstance(e, BranchMerged)
+                and self.event.config.merge.delete_branch_on_merge
+            ):
+                await self.client.delete_branch(
+                    branch=self.event.pull_request.headRefName
+                )
+
             return MergeabilityResponse.NOT_MERGEABLE, self.event
         except MissingGithubMergeabilityState:
             self.log.info("missing mergeability state, need refresh")
@@ -169,15 +177,6 @@ class PR:
         except NeedsBranchUpdate:
             await self.set_status(summary="⏭ need update")
             return MergeabilityResponse.NEEDS_UPDATE, self.event
-        except BranchMerged:
-            await self.set_status(
-                summary="🛑 cannot merge", detail="branch merged already"
-            )
-            if self.event.config.merge.delete_branch_on_merge:
-                await self.client.delete_branch(
-                    branch=self.event.pull_request.headRefName
-                )
-            return MergeabilityResponse.NOT_MERGEABLE, self.event
 
     async def update(self) -> None:
         self.log.info("update")

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -44,7 +44,7 @@ class GraphQLResponse(TypedDict):
 
 
 @dataclass
-class ServerError(Exception):
+class ServerError(BaseException):
     response: Response
 
 

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -44,7 +44,7 @@ class GraphQLResponse(TypedDict):
 
 
 @dataclass
-class ServerError(BaseException):
+class ServerError(Exception):
     response: Response
 
 


### PR DESCRIPTION
CHANGES
- add message when PR is good to merge
- reduce some duplicated logic in mergeability for set_status

BEFORE
<img width="315" alt="Screen Shot 2019-07-17 at 7 22 52 PM" src="https://user-images.githubusercontent.com/1929960/61418371-4d944900-a8c8-11e9-80ca-b610b89bda10.png">
AFTER
<img width="307" alt="Screen Shot 2019-07-17 at 7 21 24 PM" src="https://user-images.githubusercontent.com/1929960/61418372-4d944900-a8c8-11e9-9fb3-336b838df0a4.png">
