### PR TITLE
fix(notifications): ignore MissingAppID exceptions in status messages

### DIFF
--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -154,7 +154,7 @@ class PR:
             )
             self.log.info("okay")
             return MergeabilityResponse.OK, self.event
-        except (NotQueueable, MissingAppID, MergeConflict, BranchMerged) as e:
+        except (NotQueueable, MergeConflict, BranchMerged) as e:
             if (
                 isinstance(e, MergeConflict)
                 and self.event.config.merge.notify_on_conflict
@@ -170,6 +170,8 @@ class PR:
                 )
 
             await self.set_status(summary="🛑 cannot merge", detail=str(e))
+            return MergeabilityResponse.NOT_MERGEABLE, self.event
+        except MissingAppID:
             return MergeabilityResponse.NOT_MERGEABLE, self.event
         except MissingGithubMergeabilityState:
             self.log.info("missing mergeability state, need refresh")


### PR DESCRIPTION
MissingAppID exceptions are raised when we have multiple instances of kodiak running and only one is allowed to run based on a Github app ID specified in the configuration. We generally want to provide no response if we disabled via a mismatched app ID.