### PR TITLE
add: require_automerge_label config

### DIFF
--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -44,6 +44,8 @@ class MergeMessage(BaseModel):
 class Merge(BaseModel):
     # label to enable merging of pull request.
     automerge_label: str = "automerge"
+    # if disabled, kodiak won't require a label to queue a PR for merge
+    require_automerge_label: bool = True
     # regex to match against title and block merging. Set to empty string to
     # disable check.
     blacklist_title_regex: str = "^WIP:.*"

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -94,7 +94,10 @@ def mergeable(
             f"missing branch protection for baseRef: {pull_request.baseRefName!r}"
         )
 
-    if config.merge.automerge_label not in pull_request.labels:
+    if (
+        config.merge.require_automerge_label
+        and config.merge.automerge_label not in pull_request.labels
+    ):
         raise NotQueueable(
             f"missing automerge_label: {repr(config.merge.automerge_label)}"
         )

--- a/kodiak/test/fixtures/config/v1-default.toml
+++ b/kodiak/test/fixtures/config/v1-default.toml
@@ -3,6 +3,7 @@ version = 1 # required
 
 [merge]
 automerge_label = "automerge"
+require_automerge_label = true
 blacklist_title_regex = "^WIP:.*"
 blacklist_labels = []
 method = "merge"

--- a/kodiak/test/fixtures/config/v1-opposite.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.toml
@@ -4,6 +4,7 @@ app_id = 12345 # default: None
 
 [merge]
 automerge_label = "mergeit!" # default: "automerge"
+require_automerge_label = false # default: true
 blacklist_title_regex = "" # default: "^WIP:.*"
 blacklist_labels = ["wip", "block-merge"] # default: []
 method = "squash" # default: "merge"

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -42,6 +42,7 @@ def test_config_parsing_opposite() -> None:
         app_id="12345",
         merge=Merge(
             automerge_label="mergeit!",
+            require_automerge_label=False,
             blacklist_title_regex="",
             blacklist_labels=["wip", "block-merge"],
             method=MergeMethod.squash,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -98,6 +98,7 @@ def test_missing_automerge_label(
             valid_merge_methods=[MergeMethod.merge, MergeMethod.squash],
         )
 
+
 def test_require_automerge_label_false(
     pull_request: PullRequest,
     config: V1,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -98,6 +98,32 @@ def test_missing_automerge_label(
             valid_merge_methods=[MergeMethod.merge, MergeMethod.squash],
         )
 
+def test_require_automerge_label_false(
+    pull_request: PullRequest,
+    config: V1,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+) -> None:
+    """
+    If the automerge_label is missing, but we have require_automerge_label set
+    to false, enqueue the PR for merge
+    """
+    pull_request.labels = []
+    config.merge.automerge_label = "automerge"
+    config.merge.require_automerge_label = False
+    mergeable(
+        config=config,
+        pull_request=pull_request,
+        branch_protection=branch_protection,
+        review_requests_count=0,
+        reviews=[review],
+        contexts=[context],
+        check_runs=[],
+        valid_signature=False,
+        valid_merge_methods=[MergeMethod.merge, MergeMethod.squash],
+    )
+
 
 def test_blacklisted(
     pull_request: PullRequest,


### PR DESCRIPTION
If `require_automerge_label` is set to false, Kodiak will not require `automerge_label` to enqueue a PR for merge.

Fixes #81