### PR TITLE
fix: bug w/ notifying on merge conflict & not required labels

### DIFF
--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -310,6 +310,10 @@ class PR:
         event = self.event
         if not event:
             return False
+
+        if not event.config.merge.require_automerge_label:
+            return False
+
         label = event.config.merge.automerge_label
         if not await self.delete_label(label=label):
             return False

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -134,6 +134,38 @@ def test_pr_get_merge_body_empty(pull_request: queries.PullRequest) -> None:
     assert actual == expected
 
 
+@pytest.mark.asyncio
+async def test_attempting_to_notify_pr_author_with_no_automerge_label(
+    api_client: queries.Client,
+    mocker: MockFixture,
+    event_response: queries.EventInfoResponse,
+) -> None:
+    """
+    ensure that when Kodiak encounters a merge conflict it doesn't notify
+    the user if an automerge label isn't required.
+    """
+
+    pr = PR(
+        number=123,
+        owner="ghost",
+        repo="ghost",
+        installation_id="abc123",
+        client=api_client,
+    )
+
+    event_response.config.merge.require_automerge_label = False
+    pr.event = event_response
+
+    create_comment = mocker.patch.object(
+        PR, "create_comment", return_value=wrap_future(None)
+    )
+    # mock to ensure we have a chance of hitting the create_comment call
+    mocker.patch.object(PR, "delete_label", return_value=wrap_future(True))
+
+    assert await pr.notify_pr_creator() == False
+    assert not create_comment.called
+
+
 @pytest.mark.parametrize(
     "original,stripped",
     [

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -162,7 +162,7 @@ async def test_attempting_to_notify_pr_author_with_no_automerge_label(
     # mock to ensure we have a chance of hitting the create_comment call
     mocker.patch.object(PR, "delete_label", return_value=wrap_future(True))
 
-    assert await pr.notify_pr_creator() == False
+    assert await pr.notify_pr_creator() is False
     assert not create_comment.called
 
 


### PR DESCRIPTION
Previously, before commenting on a PR with an `automerge` label & a merge-conflict, Kodiak would remove the `automerge` label to ensure we don't post a comment twice.

After adding the feature to not require `automerge` labels this assumption no longer holds true.

Ideally we would just check to see if there is an `automerge` label before posting, but just not notifying is easier in the mean time and doesn't use up any more of our rate limited api requests.