### PR TITLE
fix: untemplated notify-on-conflict comment

### DIFF
--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -319,8 +319,8 @@ class PR:
 
         # TODO(sbdchd): add mentioning of PR author in comment.
         body = textwrap.dedent(
-            """
-        This PR currently has a merge conflict. Please resolve this and then re-add the `automerge` label.
+            f"""
+        This PR currently has a merge conflict. Please resolve this and then re-add the `{label}` label.
         """
         )
         return await self.create_comment(body)


### PR DESCRIPTION
We just had the `automerge` as in the body of the comment instead of the
user's actually configured automerge label.