### PR TITLE
update(readme): warn about usage with signed commits not being supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,13 @@ updated when their targets were updated.
 
 ## Setup
 
-**Warning:** Kodiak requires branch protection to be enabled to function,
-Kodiak won't merge PRs if branch protection is disabled.
+**Warnings:**
+
+- Kodiak requires branch protection to be enabled to function,
+  Kodiak won't merge PRs if branch protection is disabled.
+- Due to a limitation with the GitHub API, Kodiak doesn't support [requiring
+  signed commits](https://help.github.com/en/articles/about-required-commit-signing).
+  See [kodiak#89](https://github.com/chdsbd/kodiak/issues/89).
 
 1. Create a `.kodiak.toml` file in the root of your repository on the default
    branch with the following contents (see [`kodiak/test/fixtures/config`](kodiak/test/fixtures/config) for more examples):


### PR DESCRIPTION
We've never tested Kodiak with GitHub's required-signed-commits feature
and it turns out that GitHub's API prevents Kodiak from creating signed
commits -- aka, Kodiak doesn't work when this feature is enabled.