### PR TITLE
add: warning about limitations of updating forks

### DIFF
--- a/kodiak/conftest.py
+++ b/kodiak/conftest.py
@@ -60,6 +60,7 @@ def pull_request() -> queries.PullRequest:
         mergeStateStatus=queries.MergeStateStatus.BEHIND,
         state=queries.PullRequestState.OPEN,
         mergeable=queries.MergeableState.MERGEABLE,
+        isCrossRepository=False,
         labels=[],
         latest_sha="abcd",
         baseRefName="some-branch",

--- a/kodiak/messages.py
+++ b/kodiak/messages.py
@@ -1,0 +1,6 @@
+FORKS_CANNOT_BE_UPDATED = """\
+The [Github merging API](https://developer.github.com/v3/repos/merging/) only supports updating branches within a repository, not across forks. While Kodiak can still merge pull requests created from forked repositories, it cannot automatically update them.
+
+Please see [kodiak#104](https://github.com/chdsbd/kodiak/issues/104) for the most recent information on this limitation.
+
+"""

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -8,7 +8,7 @@ import structlog
 from markdown_html_finder import find_html_positions
 
 import kodiak.app_config as conf
-from kodiak import queries
+from kodiak import queries, messages
 from kodiak.config import V1, BodyText, MergeBodyStyle, MergeTitleStyle
 from kodiak.config_utils import get_markdown_for_config
 from kodiak.errors import (
@@ -220,7 +220,7 @@ class PR:
         if self.event is None:
             self.log.info("no event")
             return MergeabilityResponse.NOT_MERGEABLE, None
-        if not self.event.head_exists:
+        if not self.event.pull_request.isCrossRepository and not self.event.head_exists:
             self.log.info("branch deleted")
             return MergeabilityResponse.NOT_MERGEABLE, None
         if not isinstance(self.event.config, V1):
@@ -281,6 +281,12 @@ class PR:
                 )
             return MergeabilityResponse.WAIT, self.event
         except NeedsBranchUpdate:
+            if self.event.pull_request.isCrossRepository:
+                await self.set_status(
+                    summary='🚨 forks cannot updated via the github api. Click "Details" for more info',
+                    markdown_content=messages.FORKS_CANNOT_BE_UPDATED,
+                )
+                return MergeabilityResponse.NOT_MERGEABLE, self.event
             if merging:
                 await self.set_status(
                     summary="⛴ attempting to merge PR", detail="updating branch"

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -8,7 +8,7 @@ import structlog
 from markdown_html_finder import find_html_positions
 
 import kodiak.app_config as conf
-from kodiak import queries, messages
+from kodiak import messages, queries
 from kodiak.config import V1, BodyText, MergeBodyStyle, MergeTitleStyle
 from kodiak.config_utils import get_markdown_for_config
 from kodiak.errors import (

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -220,6 +220,8 @@ class PR:
         if self.event is None:
             self.log.info("no event")
             return MergeabilityResponse.NOT_MERGEABLE, None
+        # PRs from forks will always appear deleted because the v4 api doesn't
+        # return head information for forks like the v3 api does.
         if not self.event.pull_request.isCrossRepository and not self.event.head_exists:
             self.log.info("branch deleted")
             return MergeabilityResponse.NOT_MERGEABLE, None

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -81,6 +81,7 @@ query GetEventInfo($owner: String!, $repo: String!, $configFileExpression: Strin
       mergeStateStatus
       state
       mergeable
+      isCrossRepository
       reviewRequests(first: 100) {
         nodes {
           requestedReviewer {
@@ -209,6 +210,7 @@ class PullRequest(BaseModel):
     mergeStateStatus: MergeStateStatus
     state: PullRequestState
     mergeable: MergeableState
+    isCrossRepository: bool
     labels: List[str]
     # the SHA of the most recent commit
     latest_sha: str

--- a/kodiak/test/fixtures/api/get_event/behind.json
+++ b/kodiak/test/fixtures/api/get_event/behind.json
@@ -34,6 +34,7 @@
         "mergeStateStatus": "BEHIND",
         "state": "OPEN",
         "mergeable": "MERGEABLE",
+        "isCrossRepository": false,
         "reviewRequests": {
           "nodes": [
             {

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -40,6 +40,7 @@ def pull_request() -> PullRequest:
         mergeStateStatus=MergeStateStatus.CLEAN,
         state=PullRequestState.OPEN,
         mergeable=MergeableState.MERGEABLE,
+        isCrossRepository=True,
         labels=["bugfix", "automerge"],
         latest_sha="f89be6c",
         baseRefName="master",

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -88,7 +88,7 @@ async def test_cross_repo_missing_head(
 ) -> None:
     """
     if a repository is from a fork (isCrossRepository), we will not be able to
-    see head information do to a problem with the v4 api failing to return head
+    see head information due to a problem with the v4 api failing to return head
     information for forks, unlike the v3 api.
     """
 

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -95,7 +95,7 @@ async def test_cross_repo_missing_head(
 
     event_response.head_exists = False
     event_response.pull_request.isCrossRepository = True
-    event_response.pull_request.mergeStateStatus == MergeStateStatus.BEHIND
+    assert event_response.pull_request.mergeStateStatus == MergeStateStatus.BEHIND
     event_response.pull_request.labels = ["automerge"]
     assert event_response.branch_protection is not None
     event_response.branch_protection.requiresApprovingReviews = False

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -97,6 +97,7 @@ async def test_cross_repo_missing_head(
     event_response.pull_request.isCrossRepository = True
     event_response.pull_request.mergeStateStatus == MergeStateStatus.BEHIND
     event_response.pull_request.labels = ["automerge"]
+    assert event_response.branch_protection is not None
     event_response.branch_protection.requiresApprovingReviews = False
     event_response.branch_protection.requiresStrictStatusChecks = True
     mocker.patch.object(PR, "get_event", return_value=wrap_future(event_response))

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_mock import MockFixture
 from starlette.testclient import TestClient
 
-from kodiak import queries
+from kodiak import messages, queries
 from kodiak.config import (
     V1,
     Merge,
@@ -19,6 +19,7 @@ from kodiak.pull_request import (
     get_merge_body,
     strip_html_comments_from_markdown,
 )
+from kodiak.queries import MergeStateStatus
 from kodiak.test_utils import wrap_future
 
 
@@ -94,8 +95,12 @@ async def test_cross_repo_missing_head(
 
     event_response.head_exists = False
     event_response.pull_request.isCrossRepository = True
-    mergeable = mocker.patch("kodiak.pull_request.mergeable")
+    event_response.pull_request.mergeStateStatus == MergeStateStatus.BEHIND
+    event_response.pull_request.labels = ["automerge"]
+    event_response.branch_protection.requiresApprovingReviews = False
+    event_response.branch_protection.requiresStrictStatusChecks = True
     mocker.patch.object(PR, "get_event", return_value=wrap_future(event_response))
+    set_status = mocker.patch.object(PR, "set_status", return_value=wrap_future(None))
     pr = PR(
         number=123,
         owner="tester",
@@ -104,9 +109,11 @@ async def test_cross_repo_missing_head(
         client=queries.Client(owner="tester", repo="repo", installation_id="abc"),
     )
     await pr.mergeability()
-    assert (
-        mergeable.call_count == 1
-    ), "we should not return early from mergeability when head is missing and isCrossRepository is true, because the head could still be there."
+
+    assert set_status.call_count == 1
+    set_status.assert_called_with(
+        summary=mocker.ANY, markdown_content=messages.FORKS_CANNOT_BE_UPDATED
+    )
 
 
 def test_pr(api_client: queries.Client) -> None:

--- a/kodiak/test_queries.py
+++ b/kodiak/test_queries.py
@@ -79,6 +79,7 @@ def block_event(config_file_expression: str, config_str: str) -> EventInfoRespon
         mergeStateStatus=MergeStateStatus.BEHIND,
         state=PullRequestState.OPEN,
         mergeable=MergeableState.MERGEABLE,
+        isCrossRepository=False,
         labels=["automerge"],
         latest_sha="8d728d017cac4f5ba37533debe65730abe65730a",
         baseRefName="master",


### PR DESCRIPTION
Forks cannot be updated through the github API. This change provides a warning in this case. Kodiak can still merge the PR, just not update.

Related #104