### PR TITLE
add: nicer error message for unknown block reason

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -260,7 +260,7 @@ def mergeable(
             if need_branch_update:
                 raise NeedsBranchUpdate("behind branch. need update")
 
-        raise NotQueueable("Could not determine why PR is blocked")
+        raise NotQueueable("Merging blocked by branch protection settings")
 
     # okay to merge
     return None

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -564,7 +564,7 @@ def test_unknown_blockage(
     branch_protection.requiredApprovingReviewCount = 0
     branch_protection.requiresStatusChecks = False
     pull_request.mergeStateStatus = MergeStateStatus.BLOCKED
-    with pytest.raises(NotQueueable, match="determine why PR is blocked"):
+    with pytest.raises(NotQueueable, match="blocked by branch protection settings"):
         mergeable(
             config=config,
             pull_request=pull_request,


### PR DESCRIPTION
Kodiak will merge PRs even if it doesn't know why it's blocked. This should cover the case of CODEOWNERS while a fix is built.