### PR TITLE
add: config to ignore select pending status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,19 +74,21 @@ updated when their targets were updated.
 
    [merge]
    automerge_label = "automerge" # default: "automerge"
-   blacklist_title_regex = "^WIP.*" # default: "^WIP.*"
-   blacklist_labels = [] # default: []
+   blacklist_title_regex = "^WIP.*" # default: "^WIP.*" options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
+   blacklist_labels = [] # default: [], options: list of label names (e.g. ["wip"])
    method = "squash" # default: "merge", options: "merge", "squash", "rebase"
    delete_branch_on_merge = true # default: false
    block_on_reviews_requested = false # default: false
    notify_on_conflict = true # default: true
    optimistic_updates = true # default: true
+   dont_wait_on_status_checks = [] # default: [], options: list of check names (e.g. ["ci/circleci: lint_api"])
 
    [merge.message]
-   title = "pull_request_title" # default: "github_default"
-   body = "pull_request_body" # default: "github_default"
+   title = "pull_request_title" # default: "github_default", options: "github_default", "pull_request_title"
+   body = "pull_request_body" # default: "github_default", options: "github_default", "pull_request_body", "empty"
    include_pr_number = false # default: true
-   body_type = "markdown" # default: "markdown"
+   body_type = "markdown" # default: "markdown", options: "plain_text", "markdown", "html"
+   strip_html_comments = false # default: false
    ```
 
 2. Setup Kodiak

--- a/README.md
+++ b/README.md
@@ -67,14 +67,20 @@ updated when their targets were updated.
    branch with the following contents (see [`kodiak/test/fixtures/config`](kodiak/test/fixtures/config) for more examples):
 
    ```toml
-   # version is the only required field
+   # Minimal config. version is the only required field. 
+   version = 1
+   ```
+
+
+   ```toml
+   # Complex config. version is the only required field.
    version = 1
 
    # the following settings can be omitted since they have defaults
 
    [merge]
    automerge_label = "automerge" # default: "automerge"
-   blacklist_title_regex = "^WIP.*" # default: "^WIP.*" options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
+   blacklist_title_regex = "^WIP.*" # default: "^WIP.*", options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
    blacklist_labels = [] # default: [], options: list of label names (e.g. ["wip"])
    method = "squash" # default: "merge", options: "merge", "squash", "rebase"
    delete_branch_on_merge = true # default: false

--- a/README.md
+++ b/README.md
@@ -67,21 +67,15 @@ updated when their targets were updated.
    branch with the following contents (see [`kodiak/test/fixtures/config`](kodiak/test/fixtures/config) for more examples):
 
    ```toml
-   # Minimal config. version is the only required field. 
-   version = 1
-   ```
-
-
-   ```toml
-   # Complex config. version is the only required field.
+   # version is the only required field
    version = 1
 
    # the following settings can be omitted since they have defaults
 
    [merge]
    automerge_label = "automerge" # default: "automerge"
-   blacklist_title_regex = "^WIP.*" # default: "^WIP.*", options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
-   blacklist_labels = [] # default: [], options: list of label names (e.g. ["wip"])
+   blacklist_title_regex = "^WIP.*" # default: "^WIP.*"
+   blacklist_labels = [] # default: []
    method = "squash" # default: "merge", options: "merge", "squash", "rebase"
    delete_branch_on_merge = true # default: false
    block_on_reviews_requested = false # default: false
@@ -90,11 +84,10 @@ updated when their targets were updated.
    dont_wait_on_status_checks = [] # default: [], options: list of check names (e.g. ["ci/circleci: lint_api"])
 
    [merge.message]
-   title = "pull_request_title" # default: "github_default", options: "github_default", "pull_request_title"
-   body = "pull_request_body" # default: "github_default", options: "github_default", "pull_request_body", "empty"
+   title = "pull_request_title" # default: "github_default"
+   body = "pull_request_body" # default: "github_default"
    include_pr_number = false # default: true
-   body_type = "markdown" # default: "markdown", options: "plain_text", "markdown", "html"
-   strip_html_comments = false # default: false
+   body_type = "markdown" # default: "markdown"
    ```
 
 2. Setup Kodiak

--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -65,6 +65,11 @@ class Merge(BaseModel):
     optimistic_updates: bool = True
     # configuration for commit message of merge
     message: MergeMessage = MergeMessage()
+    # status checks that we don't want to wait to complete when they are in a
+    # pending state. This is useful for checks that will complete in an
+    # indefinite amount of time, like the wip-app checks or status checks
+    # requiring manual approval.
+    dont_wait_on_status_checks: List[str] = []
 
 
 class InvalidVersion(ValueError):

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -202,10 +202,16 @@ def mergeable(
             passing_contexts: List[str] = []
             required = set(branch_protection.requiredStatusCheckContexts)
             for status_context in contexts:
+                # handle dont_wait_on_status_checks. We want to consider a
+                # status_check failed if it is incomplete and in the
+                # configuration.
                 if (
                     status_context.context in config.merge.dont_wait_on_status_checks
-                    or status_context.state in (StatusState.ERROR, StatusState.FAILURE)
+                    and status_context.state
+                    in (StatusState.EXPECTED, StatusState.PENDING)
                 ):
+                    failing_contexts.append(status_context.context)
+                if status_context.state in (StatusState.ERROR, StatusState.FAILURE):
                     failing_contexts.append(status_context.context)
                 elif status_context.state in (
                     StatusState.EXPECTED,
@@ -216,8 +222,12 @@ def mergeable(
                     assert status_context.state == StatusState.SUCCESS
                     passing_contexts.append(status_context.context)
             for check_run in check_runs:
-                if check_run.name in config.merge.dont_wait_on_status_checks:
+                if (
+                    check_run.name in config.merge.dont_wait_on_status_checks
+                    and check_run.conclusion in (None, CheckConclusionState.NEUTRAL)
+                ):
                     failing_contexts.append(check_run.name)
+                    continue
                 if check_run.conclusion is None:
                     continue
                 if check_run.conclusion == CheckConclusionState.SUCCESS:

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -211,6 +211,7 @@ def mergeable(
                     in (StatusState.EXPECTED, StatusState.PENDING)
                 ):
                     failing_contexts.append(status_context.context)
+                    continue
                 if status_context.state in (StatusState.ERROR, StatusState.FAILURE):
                     failing_contexts.append(status_context.context)
                 elif status_context.state in (

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -239,7 +239,7 @@ def mergeable(
                 # is a similar question for the review counting.
 
                 raise NotQueueable(
-                    f"failing/missing required status checks: {failing_required_status_checks!r}"
+                    f"failing/incomplete required status checks: {failing_required_status_checks!r}"
                 )
             passing = set(passing_contexts)
 

--- a/kodiak/test/fixtures/config/config-schema.json
+++ b/kodiak/test/fixtures/config/config-schema.json
@@ -22,7 +22,8 @@
           "include_pr_number": true,
           "body_type": "markdown",
           "strip_html_comments": false
-        }
+        },
+        "dont_wait_on_status_checks": []
       },
       "allOf": [{ "$ref": "#/definitions/Merge" }]
     }
@@ -122,6 +123,14 @@
             "strip_html_comments": false
           },
           "allOf": [{ "$ref": "#/definitions/MergeMessage" }]
+        },
+        "dont_wait_on_status_checks": {
+          "title": "Dont_Wait_On_Status_Checks",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/kodiak/test/fixtures/config/v1-default.toml
+++ b/kodiak/test/fixtures/config/v1-default.toml
@@ -11,6 +11,7 @@ delete_branch_on_merge = false
 block_on_reviews_requested = false
 notify_on_conflict = true
 optimistic_updates = true
+dont_wait_on_status_checks = []
 
 [merge.message]
 title = "github_default"

--- a/kodiak/test/fixtures/config/v1-opposite.1.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.1.toml
@@ -12,6 +12,7 @@ delete_branch_on_merge = true # default: false
 block_on_reviews_requested = true # default: false
 notify_on_conflict = false # default: true
 optimistic_updates = false # default: true
+dont_wait_on_status_checks = ["ci/circleci: deploy"] # default: []
 
 [merge.message]
 title = "pull_request_title" # default: "github_default"

--- a/kodiak/test/fixtures/config/v1-opposite.2.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.2.toml
@@ -12,6 +12,7 @@ delete_branch_on_merge = true # default: false
 block_on_reviews_requested = true # default: false
 notify_on_conflict = false # default: true
 optimistic_updates = false # default: true
+dont_wait_on_status_checks = ["ci/circleci: deploy"] # default: []
 
 [merge.message]
 title = "pull_request_title" # default: "github_default"

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -48,6 +48,7 @@ def test_config_default() -> None:
                     block_on_reviews_requested=True,
                     notify_on_conflict=False,
                     optimistic_updates=False,
+                    dont_wait_on_status_checks=["ci/circleci: deploy"],
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.pull_request_body,
@@ -73,6 +74,7 @@ def test_config_default() -> None:
                     block_on_reviews_requested=True,
                     notify_on_conflict=False,
                     optimistic_updates=False,
+                    dont_wait_on_status_checks=["ci/circleci: deploy"],
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.empty,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -411,7 +411,7 @@ def test_failing_contexts(
     context.context = "ci/backend"
     context.state = StatusState.FAILURE
     with pytest.raises(
-        NotQueueable, match="failing/missing required status checks"
+        NotQueueable, match="failing/incomplete required status checks"
     ) as e:
         mergeable(
             config=config,
@@ -497,7 +497,7 @@ def test_incomplete_checks_with_dont_wait_on_status_checks(
     check_run.conclusion = None
     config.merge.dont_wait_on_status_checks = ["wip-app"]
     with pytest.raises(
-        NotQueueable, match="failing/missing required status checks"
+        NotQueueable, match="failing/incomplete required status checks"
     ) as e:
         mergeable(
             config=config,
@@ -528,7 +528,7 @@ def test_failing_checks(
     check_run.name = "wip-app"
     check_run.conclusion = CheckConclusionState.FAILURE
     with pytest.raises(
-        NotQueueable, match="failing/missing required status checks"
+        NotQueueable, match="failing/incomplete required status checks"
     ) as e:
         mergeable(
             config=config,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -490,6 +490,13 @@ def test_incomplete_checks_with_dont_wait_on_status_checks_check_run(
     review: PRReview,
     check_run: CheckRun,
 ) -> None:
+    """
+    If we have status checks that are in progress and have not completed, but we
+    have enabled dont_wait_on_status_checks for them, mark them as "failed" so
+    we don't spend time waiting for them to finish.
+
+    This case checks our handle of CheckRuns
+    """
     pull_request.mergeStateStatus = MergeStateStatus.BLOCKED
     branch_protection.requiredStatusCheckContexts = ["wip-app"]
     check_run.name = "wip-app"
@@ -519,6 +526,13 @@ def test_incomplete_checks_with_dont_wait_on_status_checks_status_check(
     review: PRReview,
     context: StatusContext,
 ) -> None:
+    """
+    If we have status checks that are in progress and have not completed, but we
+    have enabled dont_wait_on_status_checks for them, mark them as "failed" so
+    we don't spend time waiting for them to finish.
+
+    This case checks our handle of StatusContexts
+    """
     pull_request.mergeStateStatus = MergeStateStatus.BLOCKED
     branch_protection.requiredStatusCheckContexts = ["wip-app"]
     context.context = "wip-app"
@@ -549,6 +563,13 @@ def test_passing_checks_with_dont_wait_on_status_checks(
     context: StatusContext,
     check_run: CheckRun,
 ) -> None:
+    """
+    Regression test to ensure that if dont_wait_on_status_checks is enabled and
+    our configured check is passing, we merge the PR.
+
+    In this specific case we set mergeStateStatus = MergeStateStatus.BLOCKED so
+    we can test the code path.
+    """
     pull_request.mergeStateStatus = MergeStateStatus.BLOCKED
     branch_protection.requiredStatusCheckContexts = ["ci/backend", "wip-app"]
     context.context = "ci/backend"

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -540,6 +540,7 @@ def test_incomplete_checks_with_dont_wait_on_status_checks_status_check(
         )
     assert "wip-app" in str(e.value)
 
+
 def test_passing_checks_with_dont_wait_on_status_checks(
     pull_request: PullRequest,
     config: V1,
@@ -598,7 +599,6 @@ def test_failing_checks(
             valid_merge_methods=[MergeMethod.squash],
         )
     assert "wip-app" in str(e.value)
-
 
 
 def test_missing_required_context(


### PR DESCRIPTION
Sometimes a check will never succeed and will always stay in a pending state. We should be able to configure these checks so that kodiak doesn't wait infinitely while these checks stay in the pending state.

Fixes #118