### PR TITLE
WIP: enable updating branches immediately

### DIFF
--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -70,6 +70,7 @@ class Merge(BaseModel):
     # indefinite amount of time, like the wip-app checks or status checks
     # requiring manual approval.
     dont_wait_on_status_checks: List[str] = []
+    update_branch_immediately: bool = False
 
 
 class InvalidVersion(ValueError):


### PR DESCRIPTION
Kodiak's been designed around updating and merging PRs efficiently. This change enables us to bypass that functionality and update PRs immediately when their target branches are updating.

TODO
- [ ] add configuration checks
- [ ] test feature

Fixes #120