### PR TITLE
enable updating branches immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ updated when their targets were updated.
     # WIP GitHub App
     dont_wait_on_status_checks = [] # default: [], options: list of check names (e.g. ["ci/circleci: lint_api"])
 
+    # immediately update a PR whenever the target updates. This does not efficiently update PRs and will cause PRs to update multiple times as competing PRs are merged into the same target.
+    update_branch_immediately = false # default: false
+
 
     [merge.message]
     # by default, github uses the first commit title for the PR of a merge.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ updated when their targets were updated.
     # the PR will update.
     #
     # If you have multiple PRs against a target like "master", any time a commit
-    # is added to "master" _all_ of those PRs against master will update.
+    # is added to "master" _all_ of those PRs against "master" will update.
     #
     # For N PRs against a target you will potentially see N(N-1)/2 updates. If
     # this configuration option was disabled you would only see N-1 updates.

--- a/README.md
+++ b/README.md
@@ -145,10 +145,13 @@ updated when their targets were updated.
 
     # immediately update a PR whenever the target updates. If enabled Kodiak will
     # not be able to efficiently update PRs. Any time the target of a PR updates,
-    # the PR will update. If you have multiple PRs against a target like "master",
-    # any time a commit is added to "master" _all_ of those PRs will update. For
-    # N PRs against a target you will potentially see N(N-1)/2 updates. If this
-    # config was disabled you'd only see N-1 updates.
+    # the PR will update.
+    # 
+    # If you have multiple PRs against a target like "master", any time a commit
+    # is added to "master" _all_ of those PRs will update.
+
+    # For N PRs against a target you will potentially see N(N-1)/2 updates. If
+    # this configuration option was disabled you'd only see N-1 updates.
     update_branch_immediately = false # default: false
 
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ updated when their targets were updated.
     # immediately update a PR whenever the target updates. If enabled Kodiak will
     # not be able to efficiently update PRs. Any time the target of a PR updates,
     # the PR will update.
-    # 
+    #
     # If you have multiple PRs against a target like "master", any time a commit
     # is added to "master" _all_ of those PRs will update.
-
+    #
     # For N PRs against a target you will potentially see N(N-1)/2 updates. If
     # this configuration option was disabled you'd only see N-1 updates.
     update_branch_immediately = false # default: false

--- a/README.md
+++ b/README.md
@@ -143,9 +143,12 @@ updated when their targets were updated.
     # WIP GitHub App
     dont_wait_on_status_checks = [] # default: [], options: list of check names (e.g. ["ci/circleci: lint_api"])
 
-    # immediately update a PR whenever the target updates. This does not
-    # efficiently update PRs and will cause PRs to update multiple times as
-    # competing PRs are merged into the same target.
+    # immediately update a PR whenever the target updates. If enabled Kodiak will
+    # not be able to efficiently update PRs. Any time the target of a PR updates,
+    # the PR will update. If you have multiple PRs against a target like "master",
+    # any time a commit is added to "master" _all_ of those PRs will update. For
+    # N PRs against a target you will potentially see N(N-1)/2 updates. If this
+    # config was disabled you'd only see N-1 updates.
     update_branch_immediately = false # default: false
 
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ updated when their targets were updated.
     # WIP GitHub App
     dont_wait_on_status_checks = [] # default: [], options: list of check names (e.g. ["ci/circleci: lint_api"])
 
-    # immediately update a PR whenever the target updates. If enabled Kodiak will
+    # immediately update a PR whenever the target updates. If enabled, Kodiak will
     # not be able to efficiently update PRs. Any time the target of a PR updates,
     # the PR will update.
     #
@@ -152,6 +152,10 @@ updated when their targets were updated.
     #
     # For N PRs against a target you will potentially see N(N-1)/2 updates. If
     # this configuration option was disabled you'd only see N-1 updates.
+    #
+    # If you have continuous integration (CI) run on every commit, enabling this
+    # configuration option will likely increase your CI costs if you pay per
+    # minute. If you pay per build host, this will likely increase job queueing.
     update_branch_immediately = false # default: false
 
 

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ updated when their targets were updated.
     # the PR will update.
     #
     # If you have multiple PRs against a target like "master", any time a commit
-    # is added to "master" _all_ of those PRs will update.
+    # is added to "master" _all_ of those PRs against master will update.
     #
     # For N PRs against a target you will potentially see N(N-1)/2 updates. If
-    # this configuration option was disabled you'd only see N-1 updates.
+    # this configuration option was disabled you would only see N-1 updates.
     #
     # If you have continuous integration (CI) run on every commit, enabling this
     # configuration option will likely increase your CI costs if you pay per

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ updated when their targets were updated.
     # WIP GitHub App
     dont_wait_on_status_checks = [] # default: [], options: list of check names (e.g. ["ci/circleci: lint_api"])
 
-    # immediately update a PR whenever the target updates. This does not efficiently update PRs and will cause PRs to update multiple times as competing PRs are merged into the same target.
+    # immediately update a PR whenever the target updates. This does not
+    # efficiently update PRs and will cause PRs to update multiple times as
+    # competing PRs are merged into the same target.
     update_branch_immediately = false # default: false
 
 

--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -70,6 +70,7 @@ class Merge(BaseModel):
     # indefinite amount of time, like the wip-app checks or status checks
     # requiring manual approval.
     dont_wait_on_status_checks: List[str] = []
+    update_branch_immediately: bool = False
 
 
 class InvalidVersion(ValueError):

--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -70,6 +70,7 @@ class Merge(BaseModel):
     # indefinite amount of time, like the wip-app checks or status checks
     # requiring manual approval.
     dont_wait_on_status_checks: List[str] = []
+    # immediately update a PR whenever the target updates
     update_branch_immediately: bool = False
 
 

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -53,7 +53,7 @@ def find_position(x: typing.Iterable[T], v: T) -> typing.Optional[int]:
     return None
 
 
-async def update_pr_if_configured(
+async def update_pr_immediately_if_configured(
     m_res: MergeabilityResponse,
     event: EventInfoResponse,
     pull_request: PR,
@@ -106,7 +106,7 @@ async def process_webhook_event(
         if m_res == MergeabilityResponse.SKIPPABLE_CHECKS:
             log.info("skippable checks")
             return
-        await update_pr_if_configured(m_res, event, pull_request, log)
+        await update_pr_immediately_if_configured(m_res, event, pull_request, log)
 
         if m_res not in (
             MergeabilityResponse.NEEDS_UPDATE,

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -268,7 +268,7 @@ async def repo_queue_consumer(
     log = logger.bind(queue=queue_name)
     log.info("start repo_consumer")
     while True:
-        process_repo_queue(log, connection, queue_name)
+        await process_repo_queue(log, connection, queue_name)
 
 
 class RedisWebhookQueue:

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -13,9 +13,9 @@ from asyncio_redis.replies import BlockingZPopReply
 from pydantic import BaseModel
 
 import kodiak.app_config as conf
-from kodiak.pull_request import PR, MergeabilityResponse
-from kodiak.queries import Client
 from kodiak.config import V1
+from kodiak.pull_request import PR, EventInfoResponse, MergeabilityResponse
+from kodiak.queries import Client
 
 logger = structlog.get_logger()
 
@@ -51,6 +51,23 @@ def find_position(x: typing.Iterable[T], v: T) -> typing.Optional[int]:
             return count
         count += 1
     return None
+
+
+async def update_pr_if_configured(
+    m_res: MergeabilityResponse,
+    event: EventInfoResponse,
+    pull_request: PR,
+    log: structlog.BoundLogger,
+) -> None:
+    if (
+        m_res == MergeabilityResponse.NEEDS_UPDATE
+        and isinstance(event.config, V1)
+        and event.config.merge.update_branch_immediately
+    ):
+        log.info("updating pull request")
+        if not await update_pr_with_retry(pull_request):
+            log.error("failed to update branch")
+            await pull_request.set_status(summary="🛑 could not update branch")
 
 
 async def process_webhook_event(
@@ -89,15 +106,7 @@ async def process_webhook_event(
         if m_res == MergeabilityResponse.SKIPPABLE_CHECKS:
             log.info("skippable checks")
             return
-        if (
-            m_res == MergeabilityResponse.NEEDS_UPDATE
-            and isinstance(event, V1)
-            and event.config.merge.update_branch_immediately
-        ):
-            log.info("updating pull request")
-            if not await update_pr_with_retry(pull_request):
-                log.error("failed to update branch")
-                await pull_request.set_status(summary="🛑 could not update branch")
+        await update_pr_if_configured(m_res, event, pull_request, log)
 
         if m_res not in (
             MergeabilityResponse.NEEDS_UPDATE,

--- a/kodiak/test/fixtures/config/config-schema.json
+++ b/kodiak/test/fixtures/config/config-schema.json
@@ -23,7 +23,8 @@
           "body_type": "markdown",
           "strip_html_comments": false
         },
-        "dont_wait_on_status_checks": []
+        "dont_wait_on_status_checks": [],
+        "update_branch_immediately": false
       },
       "allOf": [{ "$ref": "#/definitions/Merge" }]
     }
@@ -131,6 +132,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "update_branch_immediately": {
+          "title": "Update_Branch_Immediately",
+          "default": false,
+          "type": "boolean"
         }
       }
     }

--- a/kodiak/test/fixtures/config/v1-default.toml
+++ b/kodiak/test/fixtures/config/v1-default.toml
@@ -12,6 +12,7 @@ block_on_reviews_requested = false
 notify_on_conflict = true
 optimistic_updates = true
 dont_wait_on_status_checks = []
+update_branch_immediately = false
 
 [merge.message]
 title = "github_default"

--- a/kodiak/test/fixtures/config/v1-opposite.1.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.1.toml
@@ -13,6 +13,7 @@ block_on_reviews_requested = true # default: false
 notify_on_conflict = false # default: true
 optimistic_updates = false # default: true
 dont_wait_on_status_checks = ["ci/circleci: deploy"] # default: []
+update_branch_immediately = true
 
 [merge.message]
 title = "pull_request_title" # default: "github_default"

--- a/kodiak/test/fixtures/config/v1-opposite.2.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.2.toml
@@ -13,6 +13,7 @@ block_on_reviews_requested = true # default: false
 notify_on_conflict = false # default: true
 optimistic_updates = false # default: true
 dont_wait_on_status_checks = ["ci/circleci: deploy"] # default: []
+update_branch_immediately = true
 
 [merge.message]
 title = "pull_request_title" # default: "github_default"

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -49,6 +49,7 @@ def test_config_default() -> None:
                     notify_on_conflict=False,
                     optimistic_updates=False,
                     dont_wait_on_status_checks=["ci/circleci: deploy"],
+                    update_branch_immediately=True,
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.pull_request_body,
@@ -75,6 +76,7 @@ def test_config_default() -> None:
                     notify_on_conflict=False,
                     optimistic_updates=False,
                     dont_wait_on_status_checks=["ci/circleci: deploy"],
+                    update_branch_immediately=True,
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.empty,

--- a/kodiak/test_queue.py
+++ b/kodiak/test_queue.py
@@ -1,6 +1,8 @@
+from unittest.mock import MagicMock
+
 import pytest
 import structlog
-from pytest_mock import MagicMock, MockFixture
+from pytest_mock import MockFixture
 
 from kodiak.config import V1
 from kodiak.pull_request import PR, EventInfoResponse, MergeabilityResponse

--- a/kodiak/test_queue.py
+++ b/kodiak/test_queue.py
@@ -6,7 +6,7 @@ from pytest_mock import MockFixture
 
 from kodiak.config import V1
 from kodiak.pull_request import PR, EventInfoResponse, MergeabilityResponse
-from kodiak.queue import update_pr_if_configured, update_pr_with_retry
+from kodiak.queue import update_pr_immediately_if_configured, update_pr_with_retry
 from kodiak.test_utils import wrap_future
 
 
@@ -44,7 +44,7 @@ def mock_logger(mocker: MockFixture) -> structlog.BoundLogger:
 
 
 @pytest.mark.asyncio
-async def test_update_pr_if_configured_successful_update(
+async def test_update_pr_immediately_if_configured_successful_update(
     mocker: MockFixture,
     mock_pull_request: MagicMock,
     mock_logger: structlog.BoundLogger,
@@ -59,7 +59,7 @@ async def test_update_pr_if_configured_successful_update(
     assert isinstance(event_response.config, V1)
     assert isinstance(event_response.config, V1)
     event_response.config.merge.update_branch_immediately = True
-    await update_pr_if_configured(
+    await update_pr_immediately_if_configured(
         m_res=MergeabilityResponse.NEEDS_UPDATE,
         event=event_response,
         pull_request=mock_pull_request,
@@ -70,7 +70,7 @@ async def test_update_pr_if_configured_successful_update(
 
 
 @pytest.mark.asyncio
-async def test_update_pr_if_configured_failed_update(
+async def test_update_pr_immediately_if_configured_failed_update(
     mocker: MockFixture,
     mock_pull_request: MagicMock,
     mock_logger: structlog.BoundLogger,
@@ -81,7 +81,7 @@ async def test_update_pr_if_configured_failed_update(
     )
     assert isinstance(event_response.config, V1)
     event_response.config.merge.update_branch_immediately = True
-    await update_pr_if_configured(
+    await update_pr_immediately_if_configured(
         m_res=MergeabilityResponse.NEEDS_UPDATE,
         event=event_response,
         pull_request=mock_pull_request,
@@ -94,7 +94,7 @@ async def test_update_pr_if_configured_failed_update(
 
 
 @pytest.mark.asyncio
-async def test_update_pr_if_configured_no_config(
+async def test_update_pr_immediately_if_configured_no_config(
     mocker: MockFixture,
     mock_pull_request: MagicMock,
     mock_logger: structlog.BoundLogger,
@@ -105,7 +105,7 @@ async def test_update_pr_if_configured_no_config(
     )
     assert isinstance(event_response.config, V1)
     event_response.config.merge.update_branch_immediately = False
-    await update_pr_if_configured(
+    await update_pr_immediately_if_configured(
         m_res=MergeabilityResponse.NEEDS_UPDATE,
         event=event_response,
         pull_request=mock_pull_request,

--- a/kodiak/test_queue.py
+++ b/kodiak/test_queue.py
@@ -24,3 +24,10 @@ async def test_update_pr_with_retry_failure(pr: PR, mocker: MockFixture) -> None
     assert not res
 
     assert asyncio_sleep.call_count == 5
+
+@pytest.mark.asyncio
+async def test_process_webhook_event_update_branch():
+    """
+    Verify that config.merge.update_branch_immediately triggers branch update immediately
+    """
+    assert False

--- a/kodiak/test_queue.py
+++ b/kodiak/test_queue.py
@@ -51,7 +51,8 @@ async def test_update_pr_immediately_if_configured_successful_update(
     event_response: EventInfoResponse,
 ) -> None:
     """
-    Verify that config.merge.update_branch_immediately triggers branch update immediately
+    Test successful case where merge.update_branch_immediately is set and
+    updating PR succeeds
     """
     update_pr_with_retry = mocker.patch(
         "kodiak.queue.update_pr_with_retry", return_value=wrap_future(True)
@@ -76,6 +77,9 @@ async def test_update_pr_immediately_if_configured_failed_update(
     mock_logger: structlog.BoundLogger,
     event_response: EventInfoResponse,
 ) -> None:
+    """
+    Test case where merge.update_branch_immediately is set and updating PR fails
+    """
     update_pr_with_retry = mocker.patch(
         "kodiak.queue.update_pr_with_retry", return_value=wrap_future(False)
     )
@@ -100,6 +104,9 @@ async def test_update_pr_immediately_if_configured_no_config(
     mock_logger: structlog.BoundLogger,
     event_response: EventInfoResponse,
 ) -> None:
+    """
+    If merge.update_branch_immediately is not set, we shouldn't update the PR
+    """
     update_pr_with_retry = mocker.patch(
         "kodiak.queue.update_pr_with_retry", return_value=wrap_future(True)
     )


### PR DESCRIPTION
This change enables us to update PRs immediately when their target branches update, instead of waiting until the PR is up for merge.

CHANGES
- add configuration `merge.update_branch_immediately`
- fix regression from #158 (this was never deployed, but we weren't awaiting a function)

Fixes #120