### PR TITLE
fix: docker caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,10 @@
 .venv/
 Dockerfile
 *.pem
+*_cache/
+assets/
+.vscode/
+pip-wheel-metadata/
+*egg-info/
+.github
+.circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,15 @@ WORKDIR /var/app
 
 COPY pyproject.toml poetry.lock /var/app/
 
+# install deps
 RUN poetry install
 
 COPY . /var/app
+
+# workaround for: https://github.com/sdispater/poetry/issues/1123
+RUN rm -rf /var/app/pip-wheel-metadata/
+
+# install cli
+RUN poetry install
 
 CMD poetry run uvicorn kodiak.main:app --host 0.0.0.0 --port $PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM python:3.7
+FROM python:3.7@sha256:6eaf19442c358afc24834a6b17a3728a45c129de7703d8583392a138ecbdb092
 
 RUN set -ex && mkdir -p /var/app
 
-RUN pip install poetry
-WORKDIR /var/app
-COPY . /var/app
+RUN python3 -m pip install poetry===0.12.11
 
 RUN poetry config settings.virtualenvs.in-project true
+
+WORKDIR /var/app
+
+COPY pyproject.toml poetry.lock /var/app/
+
 RUN poetry install
 
+COPY . /var/app
 
 CMD poetry run uvicorn kodiak.main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
Before we were installing deps after copying all of the code from the
repo into the container.

This breaks caching anytime the code changes.

Now the cache only breaks when either of the pyproject.toml and poetry.lock files change.