### PR TITLE
WIP: fix: partial requiredStatusCheckContexts

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -63,6 +63,22 @@ def review_status(reviews: List[PRReview]) -> PRReviewState:
     return status
 
 
+def match_required_status_checks(
+    required_status_checks: List[str], status_check: str
+) -> bool:
+    """
+    Github will combine/abbreviate some required status checks, like `ci/pr` and `ci/push` would be abbreviated to `ci` in the Github api response. So if we have a status_check like `ci/pr` we should match `ci` to that response.
+    """
+    for required_status_check in required_status_checks:
+        if required_status_check == status_check:
+            return True
+        if status_check.startswith(required_status_check):
+            _start, end = status_check.split(required_status_check)
+            if end.startswith("/"):
+                return True
+    return False
+
+
 def mergeable(
     config: config.V1,
     pull_request: PullRequest,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -15,7 +15,7 @@ from kodiak.errors import (
     NotQueueable,
     WaitingForChecks,
 )
-from kodiak.evaluation import match_required_status_checks, mergeable
+from kodiak.evaluation import mergeable, match_required_status_checks
 from kodiak.queries import (
     BranchProtectionRule,
     CheckConclusionState,
@@ -1159,6 +1159,11 @@ def test_partial_branch_protection(
         (
             ["continuous-integration/travis-ci"],
             "continuous-integration/travis-ci-pull",
+            None,
+        ),
+        (
+            ["continuous-integration/appengine/push"],
+            "continuous-integration/appengine/push/1234",
             None,
         ),
         (["continuous-integration/travis-ci"], "kodiakhq: status", None),

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -1123,14 +1123,14 @@ def test_partial_branch_protection(
     In some cases the github api returns partial branch protection contexts
     """
     branch_protection.requiredStatusCheckContexts = ["continuous-integration/travis-ci"]
+    branch_protection.requiresApprovingReviews = False
+    pull_request.mergeStateStatus = MergeStateStatus.BLOCKED
     contexts = [
         StatusContext(
-            context="continuous-integration/travis-ci/pr",
-            state=queries.StatusState.ERROR,
+            context="continuous-integration/travis-ci/pr", state=StatusState.ERROR
         ),
         StatusContext(
-            context="continuous-integration/travis-ci/push",
-            state=queries.StatusState.ERROR,
+            context="continuous-integration/travis-ci/push", state=StatusState.ERROR
         ),
     ]
     with pytest.raises(NotQueueable, match="failing required status checks"):

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Optional
 
 import pytest
 
@@ -15,7 +15,7 @@ from kodiak.errors import (
     NotQueueable,
     WaitingForChecks,
 )
-from kodiak.evaluation import mergeable, match_required_status_checks
+from kodiak.evaluation import match_required_status_checks, mergeable
 from kodiak.queries import (
     BranchProtectionRule,
     CheckConclusionState,
@@ -1152,30 +1152,20 @@ def test_partial_branch_protection(
     "required_status_checks,status_check,is_match",
     [
         (
-            [
-                "continuous-integration/travis-ci",
-            ],
+            ["continuous-integration/travis-ci"],
             "continuous-integration/travis-ci/push",
-            True,
+            "continuous-integration/travis-ci",
         ),
         (
-            [
-                "continuous-integration/travis-ci",
-            ],
+            ["continuous-integration/travis-ci"],
             "continuous-integration/travis-ci-pull",
-            False,
+            None,
         ),
-        (
-            [
-                "continuous-integration/travis-ci",
-            ],
-            "kodiakhq: status",
-            False,
-        ),
+        (["continuous-integration/travis-ci"], "kodiakhq: status", None),
     ],
 )
 def test_match_required_status_checks(
-    required_status_checks: List[str], status_check: str, is_match: bool
+    required_status_checks: List[str], status_check: str, is_match: Optional[str]
 ) -> None:
     assert (
         match_required_status_checks(required_status_checks, status_check) == is_match

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -15,7 +15,7 @@ from kodiak.errors import (
     NotQueueable,
     WaitingForChecks,
 )
-from kodiak.evaluation import mergeable
+from kodiak.evaluation import mergeable, match_required_status_checks
 from kodiak.queries import (
     BranchProtectionRule,
     CheckConclusionState,
@@ -1146,3 +1146,37 @@ def test_partial_branch_protection(
             valid_signature=False,
             valid_merge_methods=[MergeMethod.squash],
         )
+
+
+@pytest.mark.parametrize(
+    "required_status_checks,status_check,is_match",
+    [
+        (
+            [
+                "continuous-integration/travis-ci",
+            ],
+            "continuous-integration/travis-ci/push",
+            True,
+        ),
+        (
+            [
+                "continuous-integration/travis-ci",
+            ],
+            "continuous-integration/travis-ci-pull",
+            False,
+        ),
+        (
+            [
+                "continuous-integration/travis-ci",
+            ],
+            "kodiakhq: status",
+            False,
+        ),
+    ],
+)
+def test_match_required_status_checks(
+    required_status_checks: List[str], status_check: str, is_match: bool
+) -> None:
+    assert (
+        match_required_status_checks(required_status_checks, status_check) == is_match
+    )


### PR DESCRIPTION
It appears that it's possible to configure requiredStatusCheckContexts with partial contexts. This change adds support for this behavior.

TODO
- replace set operations with substring matches. I think we want to check if the context starts with the required branch protection