### PR TITLE
fix: travis-ci check compression

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -244,6 +244,20 @@ def mergeable(
             failing = set(failing_contexts)
             # we have failing statuses that are required
             failing_required_status_checks = failing & required
+            # GitHub has undocumented logic for travis-ci checks in GitHub
+            # branch protection rules. GitHub compresses
+            # "continuous-integration/travis-ci/{pr,pull}" to
+            # "continuous-integration/travis-ci". There is only special handling
+            # for these specific checks.
+            if "continuous-integration/travis-ci" in required:
+                if "continuous-integration/travis-ci/pr" in failing:
+                    failing_required_status_checks.add(
+                        "continuous-integration/travis-ci/pr"
+                    )
+                if "continuous-integration/travis-ci/pull" in failing:
+                    failing_required_status_checks.add(
+                        "continuous-integration/travis-ci/pull"
+                    )
             if failing_required_status_checks:
                 # NOTE(chdsbd): We need to skip this PR because it would block
                 # the merge queue. We may be able to bump it to the back of the

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -1,6 +1,6 @@
 import re
 from collections import defaultdict
-from typing import Iterable, List, MutableMapping, Optional, Set
+from typing import List, MutableMapping, Optional, Set
 
 import structlog
 

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -63,18 +63,6 @@ def review_status(reviews: List[PRReview]) -> PRReviewState:
     return status
 
 
-def match_required_status_checks(
-    required_status_checks: Iterable[str], status_check: str
-) -> Optional[str]:
-    """
-    Github compresses _some_ check names into one, but only for travis-ci
-    
-    continuous-integration/travis-ci/{pr,push} => continuous-integration/travis-ci
-    continuous-integration/travis-ci/foo => continuous-integration/travis-ci/foo
-    """
-    return None
-
-
 def mergeable(
     config: config.V1,
     pull_request: PullRequest,

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -1,6 +1,6 @@
 import re
 from collections import defaultdict
-from typing import List, MutableMapping, Optional, Set
+from typing import Iterable, List, MutableMapping, Optional, Set
 
 import structlog
 
@@ -61,6 +61,18 @@ def review_status(reviews: List[PRReview]) -> PRReviewState:
         ):
             status = review.state
     return status
+
+
+def match_required_status_checks(
+    required_status_checks: Iterable[str], status_check: str
+) -> Optional[str]:
+    """
+    Github compresses _some_ check names into one, but only for travis-ci
+    
+    continuous-integration/travis-ci/{pr,push} => continuous-integration/travis-ci
+    continuous-integration/travis-ci/foo => continuous-integration/travis-ci/foo
+    """
+    return None
 
 
 def mergeable(

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List, Optional
+from typing import List
 
 import pytest
 

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -15,7 +15,7 @@ from kodiak.errors import (
     NotQueueable,
     WaitingForChecks,
 )
-from kodiak.evaluation import match_required_status_checks, mergeable
+from kodiak.evaluation import mergeable
 from kodiak.queries import (
     BranchProtectionRule,
     CheckConclusionState,
@@ -1145,57 +1145,4 @@ def test_partial_branch_protection(
             check_runs=[],
             valid_signature=False,
             valid_merge_methods=[MergeMethod.squash],
-        )
-
-
-@pytest.mark.parametrize(
-    "required_status_checks,status_checks,match",
-    [
-        (
-            ["continuous-integration/circle-ci"],
-            [
-                "continuous-integration/circle-ci/deploy/floral-pond-9810",
-                "continuous-integration/circle-ci/deploy",
-                "continuous-integration/circle-ci/pull",
-                "continuous-integration/circle-ci/push",
-                "continuous-integration/circle-ci/pr",
-            ],
-            None,
-        ),
-        (
-            ["continuous-integration/circle-ci"],
-            ["continuous-integration/circle-ci"],
-            "continuous-integration/circle-ci",
-        ),
-        (
-            ["continuous-integration/travis-ci"],
-            [
-                "continuous-integration/travis-ci/deploy/floral-pond-9810",
-                "continuous-integration/travis-ci/deploy",
-                "continuous-integration/travis-ci/pull",
-            ],
-            None,
-        ),
-        (
-            ["continuous-integration/travis-ci"],
-            [
-                "continuous-integration/travis-ci/push",
-                "continuous-integration/travis-ci/pr",
-                "continuous-integration/travis-ci",
-            ],
-            "continuous-integration/travis-ci",
-        ),
-    ],
-)
-def test_match_required_status_checks(
-    required_status_checks: List[str], status_checks: List[str], match: Optional[str]
-) -> None:
-    """
-    Github compresses _some_ check names into one, but only for travis-ci. See the parameters for a full list
-    
-    continuous-integration/travis-ci/{pr,push} => continuous-integration/travis-ci
-    """
-    for status_check in status_checks:
-        assert (
-            match_required_status_checks(required_status_checks, status_check) == match
         )

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -1191,11 +1191,9 @@ def test_match_required_status_checks(
     required_status_checks: List[str], status_checks: List[str], match: Optional[str]
 ) -> None:
     """
-    Github compresses _some_ check names into one, but only for travis-ci
+    Github compresses _some_ check names into one, but only for travis-ci. See the parameters for a full list
     
-    continuous-integration/travis-ci/{pr,pull,build} => continuous-integration/travis-ci
-
-    Fix #163
+    continuous-integration/travis-ci/{pr,push} => continuous-integration/travis-ci
     """
     for status_check in status_checks:
         assert (


### PR DESCRIPTION
This is blocked until I can find all the possible status checks that map to `continuous-integration/travis-ci`. I've opened an issue with GitHub, so hopefully they will have information.

fixes #163