### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ updated when their targets were updated.
 
     # if this title regex matches, Kodiak will not merge the PR. this is useful
     # to prevent merging work in progress PRs
-    blacklist_title_regex = "" # default: "^WIP.*", options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
+    blacklist_title_regex = "" # default: "^WIP:.*", options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
 
     # if these labels are set Kodiak will not merge the PR
     blacklist_labels = [] # default: [], options: list of label names (e.g. ["wip"])


### PR DESCRIPTION
if I read the source correctly the default has a colon on the end:

https://github.com/chdsbd/kodiak/blob/f1e8910cd3efbd2a87936b38d6e7189d845ef20e/kodiak/config.py#L52

relates to https://github.com/chdsbd/kodiak/issues/168