### PR TITLE
doc: block_on_reviews_requested problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ updated when their targets were updated.
 - Due to permission limitations for GitHub Apps, Kodiak doesn't support updating forks of branches. ([kodiak#104](https://github.com/chdsbd/kodiak/issues/104))
 - GitHub CODEOWNERS are not supported. Kodiak will prematurely update PRs that still require a review from a Code Owner. However, Kodiak will be able to merge the PR once all checks pass. ([kodiak#87](https://github.com/chdsbd/kodiak/issues/87))
 - Travis-CI's [deprecated commit status updates](https://blog.travis-ci.com/2018-09-27-deprecating-github-commit-status-api-for-github-apps-managed-repositories) are not supported. [Please upgrade](https://blog.travis-ci.com/2018-05-07-announcing-support-for-github-checks-api-on-travis-ci-com#moving-to-github-apps) to the newer GitHub Check-based solution. ([kodiak#163](https://github.com/chdsbd/kodiak/pull/166))
-- If a PR is blocked by `merge.block_on_reviews_requested`, the reviewer's comment will allow the PR to be merged, not just a positive approval. Please try GitHub's required approvals branch protection setting instead. ([kodiak#153](https://github.com/chdsbd/kodiak/issues/153))
+- Using `merge.block_on_reviews_requested` is not recommended. If a PR is blocked by this rule a reviewer's comment will allow the PR to be merged, not just a positive approval. This is a limitation of the GitHub API. Please try GitHub's required approvals branch protection setting instead. ([kodiak#153](https://github.com/chdsbd/kodiak/issues/153))
 
 ## Setup
 
@@ -128,7 +128,12 @@ updated when their targets were updated.
 
     # once a PR is merged into master, delete the branch
     delete_branch_on_merge = false # default: false
-
+    
+    # Deprecated: Due to limitations with the GitHub API this feature is
+    # fundamentally broken and cannot be fixed. Please use the GitHub branch
+    # protection "required reviewers" setting instead. See this issue/comment
+    # for more information about why this feature is not fixable: https://github.com/chdsbd/kodiak/issues/153#issuecomment-523057332.
+    # 
     # if you request review from a user, don't merge until that user provides a
     # review, even if the PR is passing all checks
     block_on_reviews_requested = false # default: false


### PR DESCRIPTION
block_on_reviews_requested is fundamentally broken and cannot be fixed. This change documents this in the README.

closes #153