### PR TITLE
Add ability to do smart updating without merging 

### DIFF
--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -76,8 +76,8 @@ class Merge(BaseModel):
     # placing it in the queue. This will introduce some unfairness where those
     # waiting in the queue the longest will not be served first.
     prioritize_ready_to_merge: bool = False
-    # Will stop the PR from ever being merge. This can be used with the
-    # update_branch_immediately to perform auto updating without merging.
+    # never merge a PR. This can be used with merge.update_branch_immediately to
+    # automatically update a PR without merging.
     do_not_merge: bool = False
 
 

--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -76,6 +76,9 @@ class Merge(BaseModel):
     # placing it in the queue. This will introduce some unfairness where those
     # waiting in the queue the longest will not be served first.
     prioritize_ready_to_merge: bool = False
+    # Will stop the PR from ever being merge. This can be used with the 
+    # update_branch_immediately to perform auto updating without merging.
+    do_not_merge: bool = False
 
 
 class InvalidVersion(ValueError):

--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -76,7 +76,7 @@ class Merge(BaseModel):
     # placing it in the queue. This will introduce some unfairness where those
     # waiting in the queue the longest will not be served first.
     prioritize_ready_to_merge: bool = False
-    # Will stop the PR from ever being merge. This can be used with the 
+    # Will stop the PR from ever being merge. This can be used with the
     # update_branch_immediately to perform auto updating without merging.
     do_not_merge: bool = False
 

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -125,8 +125,14 @@ async def process_webhook_event(
             isinstance(event.config, V1)
             and event.config.merge.do_not_merge
         ):
+            # we duplicate the status messages found in the mergeability
+            # function here because status messages for WAIT and NEEDS_UPDATE
+            # are only set when Kodiak hits the merging logic.
+            if m_res == MergeabilityResponse.WAIT:
+                await pull_request.set_status(summary="⌛️ waiting for checks")
+            if m_res in (MergeabilityResponse.OK, MergeabilityResponse.SKIPPABLE_CHECKS):
+                await pull_request.set_status(summary="✅ okay to merge")
             log.debug("skipping merging for PR because `merge.do_not_merge` is configured.")
-            await pull_request.set_status(summary="✅ okay to merge")
             return
 
         if (

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -117,7 +117,10 @@ async def process_webhook_event(
         ):
             raise Exception("Unknown MergeabilityResponse")
 
-        if event.config.merge.do_not_merge:
+        if (
+            isinstance(event.config, V1)
+            and event.config.merge.do_not_merge
+        ):
             return
 
         if (

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -117,6 +117,9 @@ async def process_webhook_event(
         ):
             raise Exception("Unknown MergeabilityResponse")
 
+        if event.config.merge.do_not_merge:
+            return
+
         if (
             isinstance(event.config, V1)
             and event.config.merge.prioritize_ready_to_merge

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -121,18 +121,20 @@ async def process_webhook_event(
         ):
             raise Exception("Unknown MergeabilityResponse")
 
-        if (
-            isinstance(event.config, V1)
-            and event.config.merge.do_not_merge
-        ):
+        if isinstance(event.config, V1) and event.config.merge.do_not_merge:
             # we duplicate the status messages found in the mergeability
             # function here because status messages for WAIT and NEEDS_UPDATE
             # are only set when Kodiak hits the merging logic.
             if m_res == MergeabilityResponse.WAIT:
                 await pull_request.set_status(summary="⌛️ waiting for checks")
-            if m_res in (MergeabilityResponse.OK, MergeabilityResponse.SKIPPABLE_CHECKS):
+            if m_res in (
+                MergeabilityResponse.OK,
+                MergeabilityResponse.SKIPPABLE_CHECKS,
+            ):
                 await pull_request.set_status(summary="✅ okay to merge")
-            log.debug("skipping merging for PR because `merge.do_not_merge` is configured.")
+            log.debug(
+                "skipping merging for PR because `merge.do_not_merge` is configured."
+            )
             return
 
         if (

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -127,10 +127,10 @@ async def process_webhook_event(
             # are only set when Kodiak hits the merging logic.
             if m_res == MergeabilityResponse.WAIT:
                 await pull_request.set_status(summary="⌛️ waiting for checks")
-            if m_res in (
+            if m_res in {
                 MergeabilityResponse.OK,
                 MergeabilityResponse.SKIPPABLE_CHECKS,
-            ):
+            }:
                 await pull_request.set_status(summary="✅ okay to merge")
             log.debug(
                 "skipping merging for PR because `merge.do_not_merge` is configured."

--- a/kodiak/test/fixtures/config/config-schema.json
+++ b/kodiak/test/fixtures/config/config-schema.json
@@ -25,7 +25,8 @@
         },
         "dont_wait_on_status_checks": [],
         "update_branch_immediately": false,
-        "prioritize_ready_to_merge": false
+        "prioritize_ready_to_merge": false,
+        "do_not_merge": false
       },
       "allOf": [{ "$ref": "#/definitions/Merge" }]
     }
@@ -141,6 +142,11 @@
         },
         "prioritize_ready_to_merge": {
           "title": "Prioritize_Ready_To_Merge",
+          "default": false,
+          "type": "boolean"
+        },
+        "do_not_merge": {
+          "title": "Do_Not_Merge",
           "default": false,
           "type": "boolean"
         }

--- a/kodiak/test/fixtures/config/v1-default.toml
+++ b/kodiak/test/fixtures/config/v1-default.toml
@@ -14,6 +14,7 @@ optimistic_updates = true
 dont_wait_on_status_checks = []
 update_branch_immediately = false
 prioritize_ready_to_merge = false
+do_not_merge = false
 
 [merge.message]
 title = "github_default"

--- a/kodiak/test/fixtures/config/v1-opposite.1.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.1.toml
@@ -15,6 +15,7 @@ optimistic_updates = false # default: true
 dont_wait_on_status_checks = ["ci/circleci: deploy"] # default: []
 update_branch_immediately = true
 prioritize_ready_to_merge = true
+do_not_merge = true
 
 [merge.message]
 title = "pull_request_title" # default: "github_default"

--- a/kodiak/test/fixtures/config/v1-opposite.2.toml
+++ b/kodiak/test/fixtures/config/v1-opposite.2.toml
@@ -15,6 +15,7 @@ optimistic_updates = false # default: true
 dont_wait_on_status_checks = ["ci/circleci: deploy"] # default: []
 update_branch_immediately = true
 prioritize_ready_to_merge = true
+do_not_merge = true
 
 [merge.message]
 title = "pull_request_title" # default: "github_default"

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -51,7 +51,7 @@ def test_config_default() -> None:
                     dont_wait_on_status_checks=["ci/circleci: deploy"],
                     update_branch_immediately=True,
                     prioritize_ready_to_merge=True,
-                    do_note_merge=False,
+                    do_not_merge=True,
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.pull_request_body,
@@ -80,7 +80,7 @@ def test_config_default() -> None:
                     dont_wait_on_status_checks=["ci/circleci: deploy"],
                     update_branch_immediately=True,
                     prioritize_ready_to_merge=True,
-                    do_note_merge=False,
+                    do_not_merge=True,
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.empty,

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -51,7 +51,7 @@ def test_config_default() -> None:
                     dont_wait_on_status_checks=["ci/circleci: deploy"],
                     update_branch_immediately=True,
                     prioritize_ready_to_merge=True,
-                    do_note_merge=Flase,
+                    do_note_merge=False,
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.pull_request_body,
@@ -80,7 +80,7 @@ def test_config_default() -> None:
                     dont_wait_on_status_checks=["ci/circleci: deploy"],
                     update_branch_immediately=True,
                     prioritize_ready_to_merge=True,
-                    do_note_merge=Flase,
+                    do_note_merge=False,
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.empty,

--- a/kodiak/test_config.py
+++ b/kodiak/test_config.py
@@ -51,6 +51,7 @@ def test_config_default() -> None:
                     dont_wait_on_status_checks=["ci/circleci: deploy"],
                     update_branch_immediately=True,
                     prioritize_ready_to_merge=True,
+                    do_note_merge=Flase,
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.pull_request_body,
@@ -79,6 +80,7 @@ def test_config_default() -> None:
                     dont_wait_on_status_checks=["ci/circleci: deploy"],
                     update_branch_immediately=True,
                     prioritize_ready_to_merge=True,
+                    do_note_merge=Flase,
                     message=MergeMessage(
                         title=MergeTitleStyle.pull_request_title,
                         body=MergeBodyStyle.empty,

--- a/kodiak/test_queue.py
+++ b/kodiak/test_queue.py
@@ -67,7 +67,9 @@ async def test_update_pr_immediately_if_configured_successful_update(
         log=mock_logger,
     )
     assert update_pr_with_retry.call_count == 1
-    assert mock_pull_request.set_status.call_count == 0
+    assert (
+        mock_pull_request.set_status.call_count == 1
+    ), "should call once for `attempting to update...` message"
 
 
 @pytest.mark.asyncio
@@ -93,8 +95,8 @@ async def test_update_pr_immediately_if_configured_failed_update(
     )
     assert update_pr_with_retry.call_count == 1
     assert (
-        mock_pull_request.set_status.call_count == 1
-    ), "we should call set_status on a failure"
+        mock_pull_request.set_status.call_count == 2
+    ), "we should call once for `attempting to update...` message and once for merge failure"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

In our workflow we need the ability to update a PR without merging it. This is because Kodiak does not support signed commits and as such we would like to keep our branches up to date once they are mergeable but wait to be manual merged. 

## What 

I think you were really close to this feature already. 

The first thing is your `update_pr_immediately_if_configured` already nicely waits for the PR to mergeable before it starts updating:

`update_pr_immediately_if_configured` only triggers if two things are true:
	1) `update_branch_immediately` flag is `true` 
	2) `m_res == MergeabilityResponse.NEEDS_UPDATE`
`1)` will protect this function from running for individuals who do not want this option. And `2)` actually already waits for the "smart updating" cycle because `MergeabilityResponse` prioritizes branch protection checks over `NEEDS_UPDATE` which means the branch will only be flagged as needing updating once it is ready to merge.

So the only thing I added was a new variable `do_not_merge` which will ensure that we always short circuit this function and do not add it to the merging queue. 

This will allow you to combine the flags `do_not_merge` and `update_pr_immediately_if_configured` to use kodiak to do smart auto updating in your PRs without merging. 

## Notes

If this idea looks like it's along the right path I can add more documentation/information to the README.

It looks like there are some other places Im missing the config variable. I can add those in as well shortly. 