### PR TITLE
add: support for configuring PRIVATE_KEY via base64

### DIFF
--- a/kodiak/app_config.py
+++ b/kodiak/app_config.py
@@ -21,9 +21,9 @@ LOGGING_LEVEL = get_logging_level(config("LOGGING_LEVEL", default="INFO"))
 
 
 if GITHUB_PRIVATE_KEY is not None:
-    PRIVATE_KEY = Path(GITHUB_PRIVATE_KEY_PATH).read_text()
-elif GITHUB_PRIVATE_KEY is not None:
     PRIVATE_KEY = GITHUB_PRIVATE_KEY
+elif GITHUB_PRIVATE_KEY_PATH is not None:
+    PRIVATE_KEY = Path(GITHUB_PRIVATE_KEY_PATH).read_text()
 elif GITHUB_PRIVATE_KEY_BASE64 is not None:
     PRIVATE_KEY = base64.decodebytes(GITHUB_PRIVATE_KEY_BASE64.encode()).decode()
 else:

--- a/kodiak/app_config.py
+++ b/kodiak/app_config.py
@@ -1,3 +1,4 @@
+import base64
 from pathlib import Path
 
 import databases
@@ -13,17 +14,19 @@ REDIS_URL = config("REDIS_URL", cast=databases.DatabaseURL, default=None) or con
 REDIS_POOL_SIZE = config("REDIS_POOL_SIZE", cast=int, default=20)
 SECRET_KEY = config("SECRET_KEY")
 GITHUB_APP_ID = config("GITHUB_APP_ID")
-GITHUB_PRIVATE_KEY_PATH = config("GITHUB_PRIVATE_KEY_PATH", default=None)
 GITHUB_PRIVATE_KEY = config("GITHUB_PRIVATE_KEY", default=None)
+GITHUB_PRIVATE_KEY_PATH = config("GITHUB_PRIVATE_KEY_PATH", default=None)
+GITHUB_PRIVATE_KEY_BASE64 = config("GITHUB_PRIVATE_KEY", default=None)
 LOGGING_LEVEL = get_logging_level(config("LOGGING_LEVEL", default="INFO"))
 
 
-if GITHUB_PRIVATE_KEY_PATH is None and GITHUB_PRIVATE_KEY is None:
-    raise ValueError("Either GITHUB_PRIVATE_KEY_PATH or GITHUB_PRIVATE_KEY must be set")
-
-
-PRIVATE_KEY = (
-    Path(GITHUB_PRIVATE_KEY_PATH).read_text()
-    if GITHUB_PRIVATE_KEY_PATH is not None
-    else GITHUB_PRIVATE_KEY
-)
+if GITHUB_PRIVATE_KEY is not None:
+    PRIVATE_KEY = Path(GITHUB_PRIVATE_KEY_PATH).read_text()
+elif GITHUB_PRIVATE_KEY is not None:
+    PRIVATE_KEY = GITHUB_PRIVATE_KEY
+elif GITHUB_PRIVATE_KEY_BASE64 is not None:
+    PRIVATE_KEY = base64.decodebytes(GITHUB_PRIVATE_KEY_BASE64.encode()).decode()
+else:
+    raise ValueError(
+        "Either GITHUB_PRIVATE_KEY_PATH, GITHUB_PRIVATE_KEY, or GITHUB_PRIVATE_KEY_BASE64 must be set"
+    )


### PR DESCRIPTION
Docker's env file support is broken and doesn't support multi-line configuration variables. The private key needs to be passed via the -e flag.

With base64 encoding we can convert the key file to base64 and pass the encode version in a single line of the env file.