### PR TITLE
add: logging for throttle & vendor throttle pkg

### DIFF
--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -19,7 +19,7 @@ from starlette import status
 import kodiak.app_config as conf
 from kodiak.config import V1, MergeMethod
 from kodiak.github import events
-from kodiak.throttle import get_thottler_for_installation, Throttler
+from kodiak.throttle import Throttler, get_thottler_for_installation
 
 logger = structlog.get_logger()
 

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -12,7 +12,6 @@ import pydantic
 import requests_async as http
 import structlog
 import toml
-from asyncio_throttle import Throttler
 from mypy_extensions import TypedDict
 from pydantic import BaseModel
 from starlette import status
@@ -20,7 +19,7 @@ from starlette import status
 import kodiak.app_config as conf
 from kodiak.config import V1, MergeMethod
 from kodiak.github import events
-from kodiak.throttle import get_thottler_for_installation
+from kodiak.throttle import get_thottler_for_installation, Throttler
 
 logger = structlog.get_logger()
 
@@ -538,10 +537,14 @@ class Client:
         self.session.headers[
             "Accept"
         ] = "application/vnd.github.antiope-preview+json,application/vnd.github.merge-info-preview+json"
+        self.log = logger.bind(
+            repo=f"{self.owner}/{self.repo}", install=self.installation_id
+        )
 
     async def __aenter__(self) -> Client:
-        self.throttler = await get_thottler_for_installation(
-            installation_id=self.installation_id
+        self.throttler = get_thottler_for_installation(
+            installation_id=self.installation_id,
+            log=self.log
         )
         return self
 
@@ -555,7 +558,7 @@ class Client:
         installation_id: str,
         remaining_retries: int = 4,
     ) -> Optional[GraphQLResponse]:
-        log = logger.bind(install=installation_id)
+        log = self.log
 
         token = await get_token_for_install(installation_id=installation_id)
         self.session.headers["Authorization"] = f"Bearer {token}"
@@ -639,9 +642,9 @@ class Client:
 
         This is basically the "do-all-the-things" query
         """
-        log = logger.bind(
-            repo=f"{self.owner}/{self.repo}", pr=pr_number, install=self.installation_id
-        )
+
+        log = self.log.bind(pr=pr_number)
+
         res = await self.send_query(
             query=GET_EVENT_INFO_QUERY,
             variables=dict(
@@ -820,7 +823,7 @@ async def get_token_for_install(*, installation_id: str) -> str:
     app_token = generate_jwt(
         private_key=conf.PRIVATE_KEY, app_identifier=conf.GITHUB_APP_ID
     )
-    throttler = await get_thottler_for_installation(
+    throttler = get_thottler_for_installation(
         # this isn't a real installation ID, but it provides rate limiting
         # for our GithubApp instead of the installations we typically act as
         installation_id=APPLICATION_ID

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -543,8 +543,7 @@ class Client:
 
     async def __aenter__(self) -> Client:
         self.throttler = get_thottler_for_installation(
-            installation_id=self.installation_id,
-            log=self.log
+            installation_id=self.installation_id, log=self.log
         )
         return self
 

--- a/kodiak/throttle.py
+++ b/kodiak/throttle.py
@@ -1,7 +1,79 @@
 from collections import defaultdict
-from typing import Mapping
+from typing import Mapping, Any, Optional
+import time
+import asyncio
+from collections import deque
+from typing_extensions import Deque
+import structlog
 
-from asyncio_throttle import Throttler
+
+class Throttler:
+    """
+    via https://github.com/hallazzang/asyncio-throttle
+
+    The MIT License (MIT)
+
+    Copyright (c) 2017-2019 Hanjun Kim
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """
+
+    def __init__(
+        self,
+        rate_limit: float,
+        period: float = 1.0,
+        retry_interval: float = 0.01,
+        log: Optional[structlog.BoundLogger] = None,
+    ) -> None:
+        self.rate_limit = rate_limit
+        self.period = period
+        self.retry_interval = retry_interval
+        self.log = log
+
+        self._task_logs: Deque[float] = deque()
+
+    def flush(self) -> None:
+        now = time.time()
+        while self._task_logs:
+            if now - self._task_logs[0] > self.period:
+                self._task_logs.popleft()
+            else:
+                break
+
+    async def acquire(self) -> None:
+        while True:
+            self.flush()
+            if len(self._task_logs) < self.rate_limit:
+                break
+
+            if self.log is not None:
+                self.log.info("rate limit reached, waiting")
+            await asyncio.sleep(self.retry_interval)
+
+        self._task_logs.append(time.time())
+
+    async def __aenter__(self) -> None:
+        await self.acquire()
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        pass
+
 
 # installation_id => Throttler
 THROTTLER_CACHE: Mapping[str, Throttler] = defaultdict(
@@ -10,5 +82,9 @@ THROTTLER_CACHE: Mapping[str, Throttler] = defaultdict(
 )
 
 
-async def get_thottler_for_installation(*, installation_id: str) -> Throttler:
-    return THROTTLER_CACHE[installation_id]
+def get_thottler_for_installation(
+    *, installation_id: str, log: Optional[structlog.BoundLogger] = None
+) -> Throttler:
+    throttler = THROTTLER_CACHE[installation_id]
+    throttler.log = log
+    return throttler

--- a/kodiak/throttle.py
+++ b/kodiak/throttle.py
@@ -1,10 +1,10 @@
-from collections import defaultdict
-from typing import Mapping, Any, Optional
-import time
 import asyncio
-from collections import deque
-from typing_extensions import Deque
+import time
+from collections import defaultdict, deque
+from typing import Any, Mapping, Optional
+
 import structlog
+from typing_extensions import Deque
 
 
 class Throttler:

--- a/poetry.lock
+++ b/poetry.lock
@@ -73,14 +73,6 @@ type = "git"
 url = "https://github.com/chdsbd/asyncio-redis.git"
 
 [[package]]
-category = "main"
-description = "Simple, easy-to-use throttler for asyncio"
-name = "asyncio-throttle"
-optional = false
-python-versions = ">=3.5"
-version = "0.1.1"
-
-[[package]]
 category = "dev"
 description = "Atomic file writes."
 name = "atomicwrites"
@@ -828,7 +820,7 @@ python-versions = ">=2.7"
 version = "0.5.1"
 
 [metadata]
-content-hash = "87b062fd18765dce1a30150295a4eb3c21b636aaa498bf8504a1bf23a476a83b"
+content-hash = "9c900afa171eb605fe745d2fc31c8d0d12bc3e3ed1444bed9323e51106df118e"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -839,7 +831,6 @@ asn1crypto = ["2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87"
 astroid = ["6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4", "b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"]
 asyncio = ["83360ff8bc97980e4ff25c964c7bd3923d333d177aa4f7fb736b019f26c7cb41", "b62c9157d36187eca799c378e572c969f0da87cd5fc42ca372d92cdb06e7e1de", "c46a87b48213d7464f22d9a497b9eef8c1928b68320a2fa94240f969f6fec08c", "c4d18b22701821de07bd6aea8b53d21449ec0ec5680645e5317062ea21817d2d"]
 asyncio-redis = []
-asyncio-throttle = ["a01a56f3671e961253cf262918f3e0741e222fc50d57d981ba5c801f284eccfe"]
 atomicwrites = ["03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4", "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"]
 attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"]
 backcall = ["38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4", "bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ ujson = "^1.35"
 arrow = "^0.13.2"
 databases = "^0.2.2"
 asyncio_redis = {git = "https://github.com/chdsbd/asyncio-redis.git"}
-asyncio-throttle = "^0.1.1"
 inflection = "^0.3.1"
 markdown-html-finder = "^0.2.0"
 markupsafe = "^1.1"


### PR DESCRIPTION
The throttle package we were using was short and sweet but we couldn't
stick logging into it. Now we vendor it and add a logging option.

Hopefully this will make it more obvious when an installation reaches
their rate limit.