### PR TITLE
fix: missing config log to be info

### DIFF
--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -670,7 +670,7 @@ class Client:
         if config_str is None:
             # NOTE(chdsbd): we don't want to show a message for this as the lack
             # of a config allows kodiak to be selectively installed
-            log.warning("could not find configuration file")
+            log.info("could not find configuration file")
             return None
 
         pull_request = get_pull_request(repo=repository)


### PR DESCRIPTION
This log was causing a lot of errors being reported to sentry.