### PR TITLE
enable updating forks

### DIFF
--- a/kodiak/messages.py
+++ b/kodiak/messages.py
@@ -1,6 +1,0 @@
-FORKS_CANNOT_BE_UPDATED = """\
-The [Github merging API](https://developer.github.com/v3/repos/merging/) only supports updating branches within a repository, not across forks. While Kodiak can still merge pull requests created from forked repositories, it cannot automatically update them.
-
-Please see [kodiak#104](https://github.com/chdsbd/kodiak/issues/104) for the most recent information on this limitation.
-
-"""

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -758,12 +758,11 @@ class Client:
             return False
         return True
 
-    async def merge_branch(self, head: str, base: str) -> http.Response:
+    async def update_branch(self, *, pull_number: int) -> http.Response:
         headers = await get_headers(installation_id=self.installation_id)
         async with self.throttler:
-            return await self.session.post(
-                f"https://api.github.com/repos/{self.owner}/{self.repo}/merges",
-                json=dict(head=head, base=base),
+            return await self.session.put(
+                f"https://api.github.com/repos/{self.owner}/{self.repo}/pulls/{pull_number}/update-branch",
                 headers=headers,
             )
 
@@ -845,5 +844,5 @@ async def get_headers(*, installation_id: str) -> Mapping[str, str]:
     token = await get_token_for_install(installation_id=installation_id)
     return dict(
         Authorization=f"token {token}",
-        Accept="application/vnd.github.machine-man-preview+json,application/vnd.github.antiope-preview+json",
+        Accept="application/vnd.github.machine-man-preview+json,application/vnd.github.antiope-preview+json,application/vnd.github.lydian-preview+json",
     )

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -21,7 +21,6 @@ from kodiak.pull_request import (
     get_merge_body,
     strip_html_comments_from_markdown,
 )
-from kodiak.queries import MergeStateStatus
 from kodiak.test_utils import wrap_future
 
 

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -5,7 +5,7 @@ from pytest_mock import MockFixture
 from requests_async import Response
 from starlette.testclient import TestClient
 
-from kodiak import messages, queries
+from kodiak import queries
 from kodiak.config import (
     V1,
     Merge,
@@ -117,9 +117,7 @@ async def test_cross_repo_missing_head(
     await pr.mergeability()
 
     assert set_status.call_count == 1
-    set_status.assert_called_with(
-        summary=mocker.ANY, markdown_content=messages.FORKS_CANNOT_BE_UPDATED
-    )
+    assert False
 
 
 def test_pr(api_client: queries.Client) -> None:

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -122,34 +122,6 @@ async def test_deleting_branch_not_called_for_fork(
     assert delete_branch.called is False
 
 
-@pytest.mark.asyncio
-async def test_cross_repo_missing_head(
-    event_response: queries.EventInfoResponse, mocker: MockFixture
-) -> None:
-    """
-    if a repository is from a fork (isCrossRepository), we will not be able to
-    see head information.
-    """
-
-    event_response.head_exists = False
-    event_response.pull_request.isCrossRepository = True
-    assert event_response.pull_request.mergeStateStatus == MergeStateStatus.BEHIND
-    event_response.pull_request.labels = ["automerge"]
-    assert event_response.branch_protection is not None
-    event_response.branch_protection.requiresApprovingReviews = False
-    event_response.branch_protection.requiresStrictStatusChecks = True
-    mocker.patch.object(PR, "get_event", return_value=wrap_future(event_response))
-    set_status = mocker.patch.object(PR, "set_status", return_value=wrap_future(None))
-    pr = PR(
-        number=123,
-        owner="tester",
-        repo="repo",
-        installation_id="abc",
-        client=queries.Client(owner="tester", repo="repo", installation_id="abc"),
-    )
-    await pr.mergeability()
-
-
 def test_pr(api_client: queries.Client) -> None:
     a = PR(
         number=123,

--- a/kodiak/test_pull_request.py
+++ b/kodiak/test_pull_request.py
@@ -94,8 +94,7 @@ async def test_cross_repo_missing_head(
 ) -> None:
     """
     if a repository is from a fork (isCrossRepository), we will not be able to
-    see head information due to a problem with the v4 api failing to return head
-    information for forks, unlike the v3 api.
+    see head information.
     """
 
     event_response.head_exists = False
@@ -115,9 +114,6 @@ async def test_cross_repo_missing_head(
         client=queries.Client(owner="tester", repo="repo", installation_id="abc"),
     )
     await pr.mergeability()
-
-    assert set_status.call_count == 1
-    assert False
 
 
 def test_pr(api_client: queries.Client) -> None:
@@ -319,7 +315,7 @@ async def test_pr_update_ok(
     res = Response()
     res.status_code = 200
     mocker.patch(
-        "kodiak.pull_request.queries.Client.merge_branch", return_value=wrap_future(res)
+        "kodiak.pull_request.queries.Client.update_branch", return_value=wrap_future(res)
     )
 
     res = await pr.update()
@@ -338,7 +334,7 @@ async def test_pr_update_bad_merge(
     res.status_code = 409
     res._content = b"{}"
     mocker.patch(
-        "kodiak.pull_request.queries.Client.merge_branch", return_value=wrap_future(res)
+        "kodiak.pull_request.queries.Client.update_branch", return_value=wrap_future(res)
     )
 
     res = await pr.update()


### PR DESCRIPTION
Use pull request update-branch api instead of merge api to update branches. This new api allows us to update branches of forks, which wasn't possible with the merges api because of GitHub permissions.

fixes #104