### PR TITLE
tools(kodiak): remove deprecated kodiak setting

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -2,7 +2,6 @@ version = 1
 
 [merge]
 method = "squash"
-block_on_reviews_requested = true
 delete_branch_on_merge = true
 
 [merge.message]


### PR DESCRIPTION
`merge.block_on_reviews_requested` is deprecated and doesn't work well, so we shouldn't use it.