### PR TITLE
ref: regex based blacklist to use linear matching

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -1,4 +1,4 @@
-import re
+import rure as re
 from collections import defaultdict
 from typing import List, MutableMapping, Optional, Set
 

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -1,7 +1,7 @@
-import rure as re
 from collections import defaultdict
 from typing import List, MutableMapping, Optional, Set
 
+import rure as re
 import structlog
 
 from kodiak import config

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -183,6 +183,36 @@ def test_blacklist_title_match(
     assert config.merge.blacklist_title_regex in str(e_info.value)
 
 
+@pytest.mark.timeout(1)
+def test_blacklist_title_match_with_exp_regex(
+    pull_request: PullRequest,
+    config: V1,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+) -> None:
+    """
+    Ensure Kodiak uses a linear time regex engine.
+
+    When using an exponential engine this test will timeout.
+    """
+    # a ReDos regex and accompanying string
+    # via: https://en.wikipedia.org/wiki/ReDoS#Vulnerable_regexes_in_online_repositories
+    config.merge.blacklist_title_regex = "^(a+)+$"
+    pull_request.title = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"
+    mergeable(
+        config=config,
+        pull_request=pull_request,
+        branch_protection=branch_protection,
+        review_requests=[],
+        reviews=[review],
+        contexts=[context],
+        check_runs=[],
+        valid_signature=False,
+        valid_merge_methods=[MergeMethod.merge, MergeMethod.squash],
+    )
+
+
 def test_bad_merge_method_config(
     pull_request: PullRequest,
     config: V1,

--- a/poetry.lock
+++ b/poetry.lock
@@ -378,6 +378,17 @@ python-versions = "*"
 version = "0.6.1"
 
 [[package]]
+category = "main"
+description = "A python library that extends setuptools for binary extensions."
+name = "milksnake"
+optional = false
+python-versions = "*"
+version = "0.1.5"
+
+[package.dependencies]
+cffi = ">=1.6.0"
+
+[[package]]
 category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 marker = "python_version > \"2.7\""
@@ -606,6 +617,17 @@ version = "1.10.4"
 pytest = ">=2.7"
 
 [[package]]
+category = "dev"
+description = "py.test plugin to abort hanging tests"
+name = "pytest-timeout"
+optional = false
+python-versions = "*"
+version = "1.3.3"
+
+[package.dependencies]
+pytest = ">=3.6.0"
+
+[[package]]
 category = "main"
 description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
@@ -641,6 +663,19 @@ version = "0.4.1"
 [package.dependencies]
 httpcore = ">=0.2.0,<0.3.0"
 requests = ">=2.0.0,<3.0.0"
+
+[[package]]
+category = "main"
+description = "Python bindings for the Rust `regex` crate. This implementation uses finite automata and guarantees linear time matching on all inputs."
+name = "rure"
+optional = false
+python-versions = "*"
+version = "0.2.2"
+
+[package.dependencies]
+cffi = ">=1.5.0"
+milksnake = "*"
+six = "*"
 
 [[package]]
 category = "main"
@@ -811,7 +846,7 @@ python-versions = ">=2.7"
 version = "0.5.1"
 
 [metadata]
-content-hash = "2ddd31effb741d463b29924e3a71f78ff37ad7b5c74aa740a1cc2fd78c291ef4"
+content-hash = "647967493d91db556cc84403fcc4cecf69765ee7264585a6421bf03d750703a3"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -852,6 +887,7 @@ lazy-object-proxy = ["159a745e61422217881c4de71f9eafd9d703b93af95618635849fe469a
 markdown-html-finder = ["6c38c12051ffd98aa3a56e93a72d977fe7abf2c014b0f701379519ce67e6c09e", "6ea240b1b51f5f05d2b4484bcbb4d533b1681a08b021a1322ac42aca72b21ebf", "94f0674031be994ba2dccab1315b04e41a6e43ddf43c677d0276e5e457207e57", "e094e9dbee1f033df495a2178d2cc28704f7968976b127c4aa612040cb3ecd9b"]
 markupsafe = ["00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473", "09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161", "09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235", "1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5", "24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff", "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b", "43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1", "46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e", "500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183", "535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66", "62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1", "6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1", "717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e", "79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b", "7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905", "88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735", "8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d", "98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e", "9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d", "9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c", "ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21", "b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2", "b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5", "b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b", "ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6", "c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f", "cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f", "e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"]
 mccabe = ["ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42", "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"]
+milksnake = ["550ca1fc4222724149ee5a933e6bb8347630c0ed023a2a97701ab94fa256f6b4", "dfcd43b78bcf93897a75eea1dadf71c848319f19451cff4f3f3a628a5abe1688"]
 more-itertools = ["2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7", "c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"]
 mypy = ["2afe51527b1f6cdc4a5f34fc90473109b22bf7f21086ba3e9451857cf11489e6", "56a16df3e0abb145d8accd5dbb70eba6c4bd26e2f89042b491faa78c9635d1e2", "5764f10d27b2e93c84f70af5778941b8f4aa1379b2430f85c827e0f5464e8714", "5bbc86374f04a3aa817622f98e40375ccb28c4836f36b66706cf3c6ccce86eda", "6a9343089f6377e71e20ca734cd8e7ac25d36478a9df580efabfe9059819bf82", "6c9851bc4a23dc1d854d3f5dfd5f20a016f8da86bcdbb42687879bb5f86434b0", "b8e85956af3fcf043d6f87c91cbe8705073fc67029ba6e22d3468bfee42c4823", "b9a0af8fae490306bc112229000aa0c2ccc837b49d29a5c42e088c132a2334dd", "bbf643528e2a55df2c1587008d6e3bda5c0445f1240dfa85129af22ae16d7a9a", "c46ab3438bd21511db0f2c612d89d8344154c0c9494afc7fbc932de514cf8d15", "f7a83d6bd805855ef83ec605eb01ab4fa42bcef254b13631e451cbb44914a9b0"]
 mypy-extensions = ["37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812", "b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"]
@@ -874,9 +910,11 @@ pyparsing = ["1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
 pytest = ["4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45", "926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da"]
 pytest-asyncio = ["9fac5100fd716cbecf6ef89233e8590a4ad61d729d1732e0a96b84182df1daaf", "d734718e25cfc32d2bf78d346e99d33724deeba774cc4afdf491530c6184b63b"]
 pytest-mock = ["43ce4e9dd5074993e7c021bb1c22cbb5363e612a2b5a76bc6d956775b10758b7", "5bf5771b1db93beac965a7347dc81c675ec4090cb841e49d9d34637a25c30568"]
+pytest-timeout = ["4a30ba76837a32c7b7cd5c84ee9933fde4b9022b0cd20ea7d4a577c2a1649fb1", "d49f618c6448c14168773b6cdda022764c63ea80d42274e3156787e8088d04c6"]
 python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
 requests-async = ["484221fb41ccc47b475cdc2634b37884ca78ca291160664e9b8b8c5e53fdd4af"]
+rure = ["c99524e4000b105ed0c4a6f51f58139758652f4fb2fba4862eff775f84de1733", "f8ccec9bea1651ba2334029b12e1665f0f076fadf6ea66402f0554506c30de6c"]
 sentry-sdk = ["d491aa6399eaa3eded433972751a9770180730fd8b4c225b0b7f49c4fa2af70b", "d68003cdffbbfcadaa2c445b72e1050b0a44406f94199866f192986c016b23f5"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
 sqlalchemy = ["c7fef198b43ef31dfd783d094fd5ee435ce8717592e6784c45ba337254998017"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ markupsafe = "^1.1"
 fastapi = "^0.33.0"
 sentry-sdk = "^0.10.2"
 requests = "^2.22"
+rure = "^0.2.2"
 
 [tool.poetry.scripts]
 kodiak = 'kodiak.cli:cli'
@@ -39,6 +40,7 @@ pylint = "^2.3"
 flake8 = "^3.7"
 flake8-pie = "^0.2.1"
 isort = "^4.3"
+pytest-timeout = "^1.3"
 
 [tool.poetry.plugins."pytest11"]
 "pytest_plugin" = "pytest_plugin.plugin"


### PR DESCRIPTION
By throwing user provided regex into Python's regex module we ran the
risk of a ReDos, or more likely a blockage in the asyncio event loop.

This PR switches the logic to use `rure` which is a Python wrapper around
Rust's regex library.

rel: https://github.com/davidblewett/rure-python
rel: https://crates.io/crates/regex