### PR TITLE
fix: logging to be less noisy and provide more info

### DIFF
--- a/kodiak/logging.py
+++ b/kodiak/logging.py
@@ -7,30 +7,30 @@ from sentry_sdk import capture_event
 from sentry_sdk.utils import event_from_exception
 from typing_extensions import Literal
 
-"""
-based on https://github.com/kiwicom/structlog-sentry/blob/18adbfdac85930ca5578e7ef95c1f2dc169c2f2f/structlog_sentry/__init__.py#L10-L86
-MIT License
+################################################################################
+# based on https://github.com/kiwicom/structlog-sentry/blob/18adbfdac85930ca5578e7ef95c1f2dc169c2f2f/structlog_sentry/__init__.py#L10-L86
+# MIT License
 
-Copyright (c) 2019 Kiwi.com
+# Copyright (c) 2019 Kiwi.com
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 EventDict = Dict[str, Any]
 SentryLevel = Literal["fatal", "error", "warning", "info", "debug"]
 SentryTagKeys = Optional[Union[List[str], Literal["__all__"]]]
@@ -100,6 +100,7 @@ class SentryProcessor:
 
 
 # end of copied code
+################################################################################
 
 
 def add_request_info_processor(_: Any, __: Any, event_dict: dict) -> dict:

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -32,7 +32,6 @@ sentry_sdk.init(
     integrations=[LoggingIntegration(level=None, event_level=None)]  # type: ignore
 )
 
-
 structlog.configure(
     processors=[
         structlog.stdlib.filter_by_level,

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import sys
-from logging import add_request_info_processor
 
 import sentry_sdk
 import structlog
@@ -13,7 +12,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from kodiak import app_config as conf
 from kodiak import queries
 from kodiak.github import Webhook, events
-from kodiak.logging import SentryProcessor
+from kodiak.logging import SentryProcessor, add_request_info_processor
 from kodiak.queries import Client
 from kodiak.queue import RedisWebhookQueue, WebhookEvent
 

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from logging import add_request_info_processor
 
 import sentry_sdk
 import structlog
@@ -31,6 +32,7 @@ sentry_sdk.init(
     integrations=[LoggingIntegration(level=None, event_level=None)]  # type: ignore
 )
 
+
 structlog.configure(
     processors=[
         structlog.stdlib.filter_by_level,
@@ -38,6 +40,7 @@ structlog.configure(
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
+        add_request_info_processor,
         SentryProcessor(level=logging.WARNING),
         structlog.processors.KeyValueRenderer(key_order=["event"], sort_keys=True),
     ],

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -178,7 +178,7 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                log.exception("failed to create notification", res=res)
+                self.log.exception("failed to create notification", res=res)
 
     async def delete_branch(self, branch_name: str) -> None:
         async with Client(

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -116,7 +116,7 @@ async def evaluate_pr(
             if api_call_retry_timeout:
                 api_call_retry_method_name = e.method
                 api_call_retry_timeout -= 1
-                log.exception("problem contacting remote api. retrying")
+                log.info("problem contacting remote api. retrying")
                 continue
             log.exception("api_call_retry_timeout")
         break

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -151,6 +151,7 @@ class PRV2:
         self.log = logger.bind(install=install, owner=owner, repo=repo, number=number)
 
     async def dequeue(self) -> None:
+        self.log.info('dequeue')
         await self.dequeue_callback()
 
     async def set_status(
@@ -167,6 +168,7 @@ class PRV2:
         status check. This detail view is accessible via the "Details" link
         alongside the summary/detail content.
         """
+        self.log.info('set_status')
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
@@ -181,6 +183,7 @@ class PRV2:
                 self.log.exception("failed to create notification", res=res)
 
     async def delete_branch(self, branch_name: str) -> None:
+        self.log.info('delete_branch')
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
@@ -194,6 +197,7 @@ class PRV2:
                     self.log.exception("failed to delete branch", res=res)
 
     async def update_branch(self) -> None:
+        self.log.info('update_branch')
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
@@ -206,6 +210,7 @@ class PRV2:
                 raise ApiCallException("update branch")
 
     async def trigger_test_commit(self) -> None:
+        self.log.info('trigger_test_commit')
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
@@ -223,6 +228,7 @@ class PRV2:
         commit_title: Optional[str],
         commit_message: Optional[str],
     ) -> None:
+        self.log.info('merge')
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
@@ -245,12 +251,14 @@ class PRV2:
                 raise ApiCallException("merge")
 
     async def queue_for_merge(self) -> Optional[int]:
+        self.log.info('queue_for_merge')
         return await self.queue_for_merge_callback()
 
     async def remove_label(self, label: str) -> None:
         """
         remove the PR label specified by `label_id` for a given `pr_number`
         """
+        self.log.info('remove_label')
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
@@ -266,6 +274,7 @@ class PRV2:
         """
        create a comment on the specified `pr_number` with the given `body` as text.
         """
+        self.log.info('create_comment')
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -170,12 +170,12 @@ class PRV2:
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
+            res = await api_client.create_notification(
+                head_sha=self.event.pull_request.latest_sha,
+                message=msg,
+                summary=markdown_content,
+            )
             try:
-                res = await api_client.create_notification(
-                    head_sha=self.event.pull_request.latest_sha,
-                    message=msg,
-                    summary=markdown_content,
-                )
                 res.raise_for_status()
             except HTTPError:
                 self.log.exception("failed to create notification")
@@ -184,8 +184,8 @@ class PRV2:
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
+            res = await api_client.delete_branch(branch=branch_name)
             try:
-                res = await api_client.delete_branch(branch=branch_name)
                 res.raise_for_status()
             except HTTPError as e:
                 if e.response is not None and e.response.status_code == 422:
@@ -197,8 +197,8 @@ class PRV2:
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
+            res = await api_client.update_branch(pull_number=self.number)
             try:
-                res = await api_client.update_branch(pull_number=self.number)
                 res.raise_for_status()
             except HTTPError:
                 self.log.exception("failed to update branch")
@@ -209,8 +209,8 @@ class PRV2:
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
+            res = await api_client.get_pull_request(number=self.number)
             try:
-                res = await api_client.get_pull_request(number=self.number)
                 res.raise_for_status()
             except HTTPError:
                 self.log.exception("failed to get pull request for test commit trigger")
@@ -224,13 +224,13 @@ class PRV2:
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
-            try:
-                res = await api_client.merge_pull_request(
+            res = await api_client.merge_pull_request(
                     number=self.number,
                     merge_method=merge_method,
                     commit_title=commit_title,
                     commit_message=commit_message,
                 )
+            try:
                 res.raise_for_status()
             except HTTPError:
                 self.log.exception("failed to merge pull request")
@@ -247,8 +247,8 @@ class PRV2:
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
+            res = await api_client.delete_label(label, pull_number=self.number)
             try:
-                res = await api_client.delete_label(label, pull_number=self.number)
                 res.raise_for_status()
             except HTTPError:
                 self.log.exception("failed to delete label", label=label)
@@ -262,10 +262,10 @@ class PRV2:
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
+            res = await api_client.create_comment(
+                body=body, pull_number=self.number
+            )
             try:
-                res = await api_client.create_comment(
-                    body=body, pull_number=self.number
-                )
                 res.raise_for_status()
             except HTTPError:
                 self.log.exception("failed to create comment")

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -544,7 +544,7 @@ class Client:
             "Accept"
         ] = "application/vnd.github.antiope-preview+json,application/vnd.github.merge-info-preview+json"
         self.log = logger.bind(
-            repo=f"{self.owner}/{self.repo}", install=self.installation_id
+            owner=self.owner, repo=self.repo, install=self.installation_id
         )
 
     async def __aenter__(self) -> Client:
@@ -729,9 +729,7 @@ class Client:
     async def get_pull_requests_for_sha(
         self, sha: str
     ) -> Optional[List[events.BasePullRequest]]:
-        log = logger.bind(
-            repo=f"{self.owner}/{self.repo}", install=self.installation_id, sha=sha
-        )
+        log = self.log.bind(sha=sha)
         headers = await get_headers(installation_id=self.installation_id)
         async with self.throttler:
             res = await self.session.get(


### PR DESCRIPTION
CHANGES
- add logging processor to add detail to logs that have a requests Response object. Passing log.info("my message", res=Response()) gets rendered as Response<400> with no other information. Now we have more relevent information like response body, status code, request url and body.
- try to cut down on noisy logging where possible. We're going to get 500 errors from GitHub occasionally, so we can expect to get errors.