### PR TITLE
fix: requests structlog processor to be more robust

### DIFF
--- a/kodiak/logging.py
+++ b/kodiak/logging.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from requests import Response
 from sentry_sdk import capture_event
@@ -110,9 +110,9 @@ def add_request_info_processor(_: Any, __: Any, event_dict: dict) -> dict:
     """
     response = event_dict.get("res", None)
     if isinstance(response, Response):
-        event_dict["response_text"] = response.text
+        event_dict["response_content"] = cast(Any, response)._content
         event_dict["response_status_code"] = response.status_code
         event_dict["request_body"] = response.request.body
         event_dict["request_url"] = response.request.url
-        event_dict["request_method"] = response.request.url
+        event_dict["request_method"] = response.request.method
     return event_dict

--- a/kodiak/test_logging.py
+++ b/kodiak/test_logging.py
@@ -1,33 +1,38 @@
-"""
-MIT License
-
-Copyright (c) 2019 Kiwi.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
+import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from requests import PreparedRequest, Request, Response
 
-from kodiak.logging import SentryLevel, SentryProcessor, get_logging_level
+from kodiak.logging import (
+    SentryLevel,
+    SentryProcessor,
+    add_request_info_processor,
+    get_logging_level,
+)
+
+# MIT License
+
+# Copyright (c) 2019 Kiwi.com
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 
 def test_sentry_sent() -> None:
@@ -145,3 +150,30 @@ def test_sentry_log_specific_keys_as_tags(mocker: Any, level: SentryLevel) -> No
 )
 def test_get_logging_level(level: str, expected: int) -> None:
     assert get_logging_level(level) == expected
+
+
+# end of copied code
+#####################################################
+
+
+def test_add_request_info_processor() -> None:
+    url = "https://api.example.com/v1/me"
+    payload = dict(user_id=54321)
+    req = Request("POST", url, json=payload)
+    res = Response()
+    res.status_code = 500
+    res.url = url
+    res.reason = "Internal Server Error"
+    cast(
+        Any, res
+    )._content = b"Your request could not be completed due to an internal error."
+    res.request = cast(PreparedRequest, req.prepare())  # type: ignore
+    event_dict = add_request_info_processor(
+        None, None, dict(event="request failed", res=res)
+    )
+    assert event_dict["response_content"] == cast(Any, res)._content
+    assert event_dict["response_status_code"] == res.status_code
+    assert event_dict["request_body"] == json.dumps(payload).encode()
+    assert event_dict["request_url"] == req.url
+    assert event_dict["request_method"] == "POST"
+    assert event_dict["res"] is res


### PR DESCRIPTION
- fix issue where url was being used in place of method
- use ._content instead of .text because ._content won't raise an exception