### PR TITLE
add: better status messages for updating branch

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -261,7 +261,10 @@ async def mergeable(
         and config.update.always
         and meets_label_requirement
     ):
-        log.info("update.always")
+        await set_status(
+            "🔄 updating branch",
+            markdown_content="branch updated because `update.always = true` is configured.",
+        )
         await api.update_branch()
         return
 
@@ -508,7 +511,10 @@ async def mergeable(
         )
 
         if config.merge.update_branch_immediately and need_branch_update:
-            await set_status("🔄 updating branch")
+            await set_status(
+                "🔄 updating branch",
+                markdown_content="branch updated because `merge.update_branch_immediately = true` is configured.",
+            )
             await api.update_branch()
             return
 

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -2013,6 +2013,7 @@ async def test_mergeable_update_branch_immediately(
     assert api.dequeue.call_count == 0
     assert api.update_branch.call_count == 1
     assert "updating branch" in api.set_status.calls[0]["msg"]
+    assert "branch updated because" in api.set_status.calls[0]["markdown_content"]
 
     # verify we haven't tried to merge the PR
     assert api.merge.called is False
@@ -3380,10 +3381,12 @@ async def test_mergeable_update_always(
         api_call_retry_method_name=None,
     )
     assert api.update_branch.call_count == 1
+    assert api.set_status.call_count == 1
+    assert "updating branch" in api.set_status.calls[0]["msg"]
+    assert "branch updated because" in api.set_status.calls[0]["markdown_content"]
 
     assert api.queue_for_merge.call_count == 0
     assert api.merge.call_count == 0
-    assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 0
 
 
@@ -3488,10 +3491,12 @@ async def test_mergeable_update_always_no_require_automerge_label_missing_label(
         api_call_retry_method_name=None,
     )
     assert api.update_branch.call_count == 1
+    assert api.set_status.call_count == 1
+    assert "updating branch" in api.set_status.calls[0]["msg"]
+    assert "branch updated because" in api.set_status.calls[0]["markdown_content"]
 
     assert api.queue_for_merge.call_count == 0
     assert api.merge.call_count == 0
-    assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 0
 
 


### PR DESCRIPTION
This change adds a status message to updates triggered by `update.always` and adds a reason why the branch was update to the summary page.
I think we could probably make better use of the summary page for checks in the future to give more information about why Kodiak did something..