### PR TITLE
fix: handling of rebase merge conflicts

### DIFF
--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -81,6 +81,7 @@ query GetEventInfo($owner: String!, $repo: String!, $configFileExpression: Strin
       mergeStateStatus
       state
       mergeable
+      canBeRebased
       isCrossRepository
       reviewRequests(first: 100) {
         nodes {
@@ -210,6 +211,7 @@ class PullRequest(BaseModel):
     mergeStateStatus: MergeStateStatus
     state: PullRequestState
     mergeable: MergeableState
+    canBeRebased: bool
     isCrossRepository: bool
     labels: List[str]
     # the SHA of the most recent commit

--- a/kodiak/test/fixtures/api/get_event/behind.json
+++ b/kodiak/test/fixtures/api/get_event/behind.json
@@ -34,6 +34,7 @@
         "mergeStateStatus": "BEHIND",
         "state": "OPEN",
         "mergeable": "MERGEABLE",
+        "canBeRebased": true,
         "isCrossRepository": false,
         "reviewRequests": {
           "nodes": [

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -212,6 +212,7 @@ def pull_request() -> PullRequest:
         mergeStateStatus=MergeStateStatus.CLEAN,
         state=PullRequestState.OPEN,
         mergeable=MergeableState.MERGEABLE,
+        canBeRebased=True,
         isCrossRepository=False,
         labels=["bugfix", "automerge"],
         latest_sha="f89be6c",
@@ -1116,7 +1117,65 @@ async def test_mergeable_pull_request_merge_conflict(
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
     assert "cannot merge" in api.set_status.calls[0]["msg"]
-    assert "merge conflict" in api.set_status.calls[0]["msg"]
+    assert api.set_status.calls[0]["msg"] == ("🛑 cannot merge (merge conflict)")
+    assert api.remove_label.call_count == 0
+    assert api.create_comment.call_count == 0
+
+    # verify we haven't tried to update/merge the PR
+    assert api.update_branch.called is False
+    assert api.merge.called is False
+    assert api.queue_for_merge.called is False
+
+
+@pytest.mark.asyncio
+async def test_mergeable_pull_request_merge_conflict_rebase(
+    api: MockPrApi,
+    config: V1,
+    config_path: str,
+    config_str: str,
+    pull_request: PullRequest,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+    check_run: CheckRun,
+) -> None:
+    """
+    if a PR has a merge conflict we can't merge. If configured, we should leave
+    a comment and remove the automerge label. If the merge conflict is a rebase conflict, we cannot merge.
+    """
+    pull_request.mergeStateStatus = MergeStateStatus.CLEAN
+    pull_request.mergeable = MergeableState.MERGEABLE
+    pull_request.canBeRebased = False
+    config.merge.notify_on_conflict = False
+    config.merge.method = MergeMethod.rebase
+
+    await mergeable(
+        api=api,
+        config=config,
+        config_str=config_str,
+        config_path=config_path,
+        pull_request=pull_request,
+        branch_protection=branch_protection,
+        review_requests=[],
+        reviews=[review],
+        contexts=[context],
+        check_runs=[check_run],
+        valid_signature=False,
+        merging=False,
+        is_active_merge=False,
+        skippable_check_timeout=5,
+        api_call_retry_timeout=5,
+        api_call_retry_method_name=None,
+        #
+        valid_merge_methods=[MergeMethod.rebase],
+    )
+    assert api.set_status.call_count == 1
+    assert api.dequeue.call_count == 1
+    assert "cannot merge" in api.set_status.calls[0]["msg"]
+    assert (
+        api.set_status.calls[0]["msg"]
+        == "🛑 cannot merge (merge conflict prevents rebase)"
+    )
     assert api.remove_label.call_count == 0
     assert api.create_comment.call_count == 0
 

--- a/kodiak/test_queries.py
+++ b/kodiak/test_queries.py
@@ -87,6 +87,7 @@ def block_event() -> EventInfoResponse:
         mergeStateStatus=MergeStateStatus.BEHIND,
         state=PullRequestState.OPEN,
         mergeable=MergeableState.MERGEABLE,
+        canBeRebased=True,
         isCrossRepository=False,
         labels=["automerge"],
         latest_sha="8d728d017cac4f5ba37533debe65730abe65730a",


### PR DESCRIPTION
Merge conflicts are not the same as rebase merge conflicts. It's possible for a PR to be mergeable for one method (like merge or squash) but for rebase to have it's own conflict. Now we check the canBeRebased property on pull requests to determine if there is a rebase merge conflict. We only check when the configured merge method is rebase.

fixes #222