### PR TITLE
add: merge.optimistic_merge configuration

### DIFF
--- a/kodiak/config.py
+++ b/kodiak/config.py
@@ -65,8 +65,10 @@ class Merge(BaseModel):
     block_on_reviews_requested: bool = False
     # comment on merge conflict and remove automerge label
     notify_on_conflict: bool = True
-    # don't wait for status checks to run before updating branch
+    # don't wait for status checks to run before updating branch during merge process
     optimistic_updates: bool = True
+    # don't wait for status checks to run before queuing PR for merge.
+    optimistic_merge: bool = True
     # configuration for commit message of merge
     message: MergeMessage = MergeMessage()
     # status checks that we don't want to wait to complete when they are in a

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -596,7 +596,7 @@ branch protection requirements.
             commit_title=merge_args.commit_title,
             commit_message=merge_args.commit_message,
         )
-    else:
+    elif ready_to_merge or config.merge.optimistic_merge:
         position_in_queue = await api.queue_for_merge()
         if position_in_queue is None:
             # this case should be rare/impossible.
@@ -609,4 +609,8 @@ branch protection requirements.
             log.info(
                 "not setting status message for enqueued job because is_active_merge=True"
             )
+    elif not config.merge.optimistic_merge and wait_for_checks:
+        await set_status(
+            f"⌛️ waiting for required status checks: {missing_required_status_checks!r}"
+        )
     return

--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -613,4 +613,10 @@ branch protection requirements.
         await set_status(
             f"⌛️ waiting for required status checks: {missing_required_status_checks!r}"
         )
+    else:
+        log.info(
+            "no action to take against mergeable PR.",
+            wait_for_checks=wait_for_checks,
+            need_branch_update=need_branch_update,
+        )
     return

--- a/kodiak/test/fixtures/config/config-schema.json
+++ b/kodiak/test/fixtures/config/config-schema.json
@@ -22,6 +22,7 @@
         "block_on_reviews_requested": false,
         "notify_on_conflict": true,
         "optimistic_updates": true,
+        "optimistic_merge": true,
         "message": {
           "title": "github_default",
           "body": "github_default",
@@ -154,6 +155,11 @@
         },
         "optimistic_updates": {
           "title": "Optimistic_Updates",
+          "default": true,
+          "type": "boolean"
+        },
+        "optimistic_merge": {
+          "title": "Optimistic_Merge",
           "default": true,
           "type": "boolean"
         },

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -2304,6 +2304,112 @@ async def test_mergeable_queue_in_progress_with_ready_to_merge(
 
 
 @pytest.mark.asyncio
+async def test_mergeable_queue_in_progress_with_ready_to_merge_merge_optimistic_disabled(
+    api: MockPrApi,
+    config: V1,
+    config_path: str,
+    config_str: str,
+    pull_request: PullRequest,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+    check_run: CheckRun,
+) -> None:
+    """
+    with merge.optimistic_merge enabled if a PR has in progress checks we assume they will pass and queue the PR for merge. With merge.optimistic_merge disabled we will wait for them to pass before queuing for merge.
+
+    """
+    pull_request.mergeStateStatus = MergeStateStatus.BLOCKED
+    branch_protection.requiresStrictStatusChecks = True
+    branch_protection.requiresStatusChecks = True
+    branch_protection.requiredStatusCheckContexts = ["ci/test-api"]
+    context.state = StatusState.PENDING
+    context.context = "ci/test-api"
+    config.merge.optimistic_merge = False
+
+    await mergeable(
+        api=api,
+        config=config,
+        config_str=config_str,
+        config_path=config_path,
+        pull_request=pull_request,
+        branch_protection=branch_protection,
+        review_requests=[],
+        reviews=[review],
+        check_runs=[check_run],
+        contexts=[context],
+        valid_signature=False,
+        valid_merge_methods=[MergeMethod.squash],
+        merging=False,
+        is_active_merge=False,
+        skippable_check_timeout=5,
+        api_call_retry_timeout=5,
+        api_call_retry_method_name=None,
+    )
+    assert api.set_status.call_count == 1
+    assert "waiting for required status checks" in api.set_status.calls[0]["msg"]
+    assert api.dequeue.call_count == 0
+    assert api.queue_for_merge.call_count == 0
+
+    # verify we haven't tried to merge the PR
+    assert api.merge.called is False
+    assert api.update_branch.called is False
+
+@pytest.mark.asyncio
+async def test_mergeable_ready_to_merge_merge_optimistic_disabled(
+    api: MockPrApi,
+    config: V1,
+    config_path: str,
+    config_str: str,
+    pull_request: PullRequest,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+    check_run: CheckRun,
+) -> None:
+    """
+    with merge.optimistic_merge enabled if a PR has in progress checks we assume they will pass and queue the PR for merge. With merge.optimistic_merge disabled we will wait for them to pass before queuing for merge.
+
+    """
+    pull_request.mergeStateStatus = MergeStateStatus.CLEAN
+    branch_protection.requiresStrictStatusChecks = True
+    branch_protection.requiresStatusChecks = True
+    branch_protection.requiredStatusCheckContexts = ["ci/test-api"]
+    context.state = StatusState.SUCCESS
+    context.context = "ci/test-api"
+    config.merge.optimistic_merge = False
+    api.queue_for_merge.return_value = 4
+
+    await mergeable(
+        api=api,
+        config=config,
+        config_str=config_str,
+        config_path=config_path,
+        pull_request=pull_request,
+        branch_protection=branch_protection,
+        review_requests=[],
+        reviews=[review],
+        check_runs=[check_run],
+        contexts=[context],
+        valid_signature=False,
+        valid_merge_methods=[MergeMethod.squash],
+        merging=False,
+        is_active_merge=False,
+        skippable_check_timeout=5,
+        api_call_retry_timeout=5,
+        api_call_retry_method_name=None,
+    )
+    assert api.set_status.call_count == 1
+    assert "enqueued for merge" in api.set_status.calls[0]["msg"]
+    assert api.dequeue.call_count == 0
+    assert api.queue_for_merge.call_count == 1
+
+    # verify we haven't tried to merge the PR
+    assert api.merge.called is False
+    assert api.update_branch.called is False
+
+
+@pytest.mark.asyncio
 async def test_mergeable_optimistic_update_wait_for_checks(
     api: MockPrApi,
     config: V1,

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -2355,6 +2355,7 @@ async def test_mergeable_queue_in_progress_with_ready_to_merge_merge_optimistic_
     assert api.merge.called is False
     assert api.update_branch.called is False
 
+
 @pytest.mark.asyncio
 async def test_mergeable_ready_to_merge_merge_optimistic_disabled(
     api: MockPrApi,


### PR DESCRIPTION
merge.optimistic_merge is the default behavior of Kodiak at the moment. This change allows users to turn off this behavior of queuing a PR for merge while its status checks are still pending.