### PR TITLE
remove commitSignatures warning for merge commits

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -239,11 +239,14 @@ async def mergeable(
             f"missing branch protection for baseRef: {pull_request.baseRefName!r}",
         )
         return
-    if branch_protection.requiresCommitSignatures:
+    if branch_protection.requiresCommitSignatures and config.merge.method in (
+        MergeMethod.rebase,
+        MergeMethod.squash,
+    ):
         await cfg_err(
             api,
             pull_request,
-            '"Require signed commits" branch protection is not supported. See Kodiak README for more info.',
+            '"Require signed commits" branch protection is only supported with merge commits. Squash and rebase are not supported by GitHub.',
         )
         return
 

--- a/kodiak/test_evaluation.py
+++ b/kodiak/test_evaluation.py
@@ -462,11 +462,66 @@ async def test_mergeable_requires_commit_signatures(
     check_run: CheckRun,
 ) -> None:
     """
-    requiresCommitSignatures doesn't work with Kodiak.
+    requiresCommitSignatures doesn't work with Kodiak when squash or rebase are configured
     
     https://github.com/chdsbd/kodiak/issues/89
     """
     branch_protection.requiresCommitSignatures = True
+    for method in (MergeMethod.squash, MergeMethod.rebase):
+        config.merge.method = method
+        await mergeable(
+            api=api,
+            config=config,
+            config_str=config_str,
+            config_path=config_path,
+            pull_request=pull_request,
+            branch_protection=branch_protection,
+            review_requests=[],
+            reviews=[review],
+            contexts=[context],
+            check_runs=[check_run],
+            valid_signature=False,
+            merging=False,
+            is_active_merge=False,
+            skippable_check_timeout=5,
+            api_call_retry_timeout=5,
+            api_call_retry_method_name=None,
+            #
+            valid_merge_methods=[method],
+        )
+        assert (
+            '"Require signed commits" branch protection is only supported'
+            in api.set_status.calls[0]["msg"]
+        )
+
+    assert api.set_status.call_count == 2
+    assert api.dequeue.call_count == 2
+    # verify we haven't tried to update/merge the PR
+    assert api.update_branch.called is False
+    assert api.merge.called is False
+    assert api.queue_for_merge.called is False
+
+
+@pytest.mark.asyncio
+async def test_mergeable_requires_commit_signatures_with_merge_commits(
+    api: MockPrApi,
+    config: V1,
+    config_path: str,
+    config_str: str,
+    pull_request: PullRequest,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+    check_run: CheckRun,
+) -> None:
+    """
+    requiresCommitSignatures works with merge commits
+    
+    https://github.com/chdsbd/kodiak/issues/89
+    """
+    branch_protection.requiresCommitSignatures = True
+    config.merge.method = MergeMethod.merge
+    api.queue_for_merge.return_value = 3
     await mergeable(
         api=api,
         config=config,
@@ -479,24 +534,22 @@ async def test_mergeable_requires_commit_signatures(
         contexts=[context],
         check_runs=[check_run],
         valid_signature=False,
-        valid_merge_methods=[MergeMethod.squash],
         merging=False,
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
         api_call_retry_method_name=None,
+        #
+        valid_merge_methods=[MergeMethod.merge],
     )
     assert api.set_status.call_count == 1
-    assert api.dequeue.call_count == 1
-    assert (
-        '"Require signed commits" branch protection is not supported'
-        in api.set_status.calls[0]["msg"]
-    )
+    assert "enqueued for merge" in api.set_status.calls[0]["msg"]
+    assert api.queue_for_merge.call_count == 1
+    assert api.dequeue.call_count == 0
 
     # verify we haven't tried to update/merge the PR
     assert api.update_branch.called is False
     assert api.merge.called is False
-    assert api.queue_for_merge.called is False
 
 
 @pytest.mark.asyncio
@@ -603,7 +656,7 @@ async def test_mergeable_has_blacklist_labels(
     check_run: CheckRun,
 ) -> None:
     """
-    requiresCommitSignatures doesn't work with Kodiak.
+    blacklist labels should prevent merge
     """
     config.merge.blacklist_labels = ["dont merge!"]
     pull_request.labels = ["bug", "dont merge!", "needs review"]


### PR DESCRIPTION
After testing, it appears that merge commits are supported when using requiresCommitSignatures (aka "Require signed commits" branch protection). This change updates the requiresCommitSignatures to only warn when rebase or squash merges are configured with requiresCommitSignatures.

related #89