### PR TITLE
add support for bot reviews

### DIFF
--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -625,7 +625,9 @@ class Client:
         self, *, reviews: List[PRReviewSchema]
     ) -> List[PRReview]:
         reviewer_names: Set[str] = {
-            review.author.login for review in reviews if review.type != ReviewerTypes.Bot
+            review.author.login
+            for review in reviews
+            if review.type != ReviewerTypes.Bot
         }
 
         bot_reviews: List[PRReview] = []

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -658,17 +658,22 @@ class Client:
             for username, permission in zip(reviewer_names, permissions)
         }
 
-        return bot_reviews + [
-            PRReview(
-                state=review.state,
-                createdAt=review.createdAt,
-                author=PRReviewAuthor(
-                    login=review.author.login,
-                    permission=user_permission_mapping[review.author.login],
-                ),
-            )
-            for review in reviews
-        ]
+        return sorted(
+            bot_reviews
+            + [
+                PRReview(
+                    state=review.state,
+                    createdAt=review.createdAt,
+                    author=PRReviewAuthor(
+                        login=review.author.login,
+                        permission=user_permission_mapping[review.author.login],
+                    ),
+                )
+                for review in reviews
+                if review.type == ReviewerTypes.User
+            ],
+            key=lambda x: x.createdAt,
+        )
 
     async def get_event_info(
         self, config_file_expression: str, pr_number: int

--- a/kodiak/test/fixtures/api/get_event/behind.json
+++ b/kodiak/test/fixtures/api/get_event/behind.json
@@ -69,35 +69,40 @@
               "state": "COMMENTED",
               "author": {
                 "login": "ghost"
-              }
+              },
+              "type": "User"
             },
             {
               "createdAt": "2019-05-22T15:29:52Z",
               "state": "CHANGES_REQUESTED",
               "author": {
                 "login": "ghost"
-              }
+              },
+              "type": "User"
             },
             {
               "createdAt": "2019-05-22T15:30:52Z",
               "state": "COMMENTED",
               "author": {
                 "login": "kodiak"
-              }
+              },
+              "type": "User"
             },
             {
               "createdAt": "2019-05-22T15:43:17Z",
               "state": "APPROVED",
               "author": {
                 "login": "ghost"
-              }
+              },
+              "type": "User"
             },
             {
               "createdAt": "2019-05-23T15:13:29Z",
               "state": "APPROVED",
               "author": {
                 "login": "walrus"
-              }
+              },
+              "type": "User"
             }
           ],
           "totalCount": 2

--- a/kodiak/test/fixtures/api/get_event/behind.json
+++ b/kodiak/test/fixtures/api/get_event/behind.json
@@ -68,49 +68,49 @@
               "createdAt": "2019-05-22T15:29:34Z",
               "state": "COMMENTED",
               "author": {
-                "login": "ghost"
-              },
-              "type": "User"
+                "login": "ghost",
+                "type": "User"
+              }
             },
             {
               "createdAt": "2019-05-22T15:29:52Z",
               "state": "CHANGES_REQUESTED",
               "author": {
-                "login": "ghost"
-              },
-              "type": "User"
+                "login": "ghost",
+                "type": "User"
+              }
             },
             {
               "createdAt": "2019-05-22T15:30:52Z",
               "state": "COMMENTED",
               "author": {
-                "login": "kodiak"
-              },
-              "type": "User"
+                "login": "kodiak",
+                "type": "User"
+              }
             },
             {
               "createdAt": "2019-05-22T15:43:17Z",
               "state": "APPROVED",
               "author": {
-                "login": "ghost"
-              },
-              "type": "User"
+                "login": "ghost",
+                "type": "User"
+              }
             },
             {
               "createdAt": "2019-05-23T15:13:29Z",
               "state": "APPROVED",
               "author": {
-                "login": "walrus"
-              },
-              "type": "User"
+                "login": "walrus",
+                "type": "User"
+              }
             },
             {
               "createdAt": "2019-05-24T10:21:32Z",
               "state": "APPROVED",
               "author": {
-                "login": "kodiakhq"
-              },
-              "type": "Bot"
+                "login": "kodiakhq",
+                "type": "Bot"
+              }
             }
           ],
           "totalCount": 2

--- a/kodiak/test/fixtures/api/get_event/behind.json
+++ b/kodiak/test/fixtures/api/get_event/behind.json
@@ -103,6 +103,14 @@
                 "login": "walrus"
               },
               "type": "User"
+            },
+            {
+              "createdAt": "2019-05-24T10:21:32Z",
+              "state": "APPROVED",
+              "author": {
+                "login": "kodiakhq"
+              },
+              "type": "Bot"
             }
           ],
           "totalCount": 2

--- a/kodiak/test_queries.py
+++ b/kodiak/test_queries.py
@@ -161,6 +161,11 @@ method = "squash"
                 state=PRReviewState.APPROVED,
                 author=PRReviewAuthor(login="walrus", permission=Permission.WRITE),
             ),
+            PRReview(
+                createdAt=arrow.get("2019-05-24T10:21:32Z").datetime,
+                state=PRReviewState.APPROVED,
+                author=PRReviewAuthor(login="kodiakhq", permission=Permission.WRITE),
+            ),
         ],
         status_contexts=[
             StatusContext(


### PR DESCRIPTION
The collaborators API we use to check permissions on GitHub users does not work with bots, so we were getting API errors when a bot reviewed a PR. This change adds support for bot reviews.

If a bot reviews a PR, it means they have write access to a PR, so their review "counts" as a review of a user with write access to a repository.