### PR TITLE
fix(docs): mobile CSS & broken links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,4 +18,5 @@ Add another markdown file to the `docs/` folder and update the
 yarn install
 yarn start
 yarn typecheck --watch
+yarn fmt
 ```

--- a/docs/core/Footer.js
+++ b/docs/core/Footer.js
@@ -7,18 +7,8 @@
 
 const React = require("react")
 
-/** @param {{config: typeof import("../siteConfig"), language?: string}} props */
+/** @param {{config: typeof import("../siteConfig")}} props */
 function Footer(props) {
-  /**
-   * @param {string} doc
-   * @param {string=} language
-   */
-  function docUrl(doc, language) {
-    const baseUrl = props.config.baseUrl
-    const langPart = `${language ? `${language}/` : ""}`
-    return `${baseUrl}${langPart}${doc}`
-  }
-
   return (
     <footer className="nav-footer" id="footer">
       <section className="sitemap">
@@ -40,12 +30,10 @@ function Footer(props) {
         </a>
         <div>
           <h5>Docs</h5>
-          <a href={docUrl("quick-start.html", props.language)}>Quick Start</a>
-          <a href={docUrl("recipes.html", props.language)}>Recipes</a>
-          <a href={docUrl("why-and-how.html", props.language)}>Why and How</a>
-          <a href={docUrl("detailed-setup.html", props.language)}>
-            Detailed Setup
-          </a>
+          <a href="/docs/quickstart">Quick Start</a>
+          <a href="/docs/recipes">Recipes</a>
+          <a href="/docs/why-and-how">Why and How</a>
+          <a href="/docs/detailed-setup">Detailed Setup</a>
         </div>
         <div>
           <h5>More</h5>

--- a/docs/docs/self-hosting.md
+++ b/docs/docs/self-hosting.md
@@ -10,7 +10,7 @@ If you don't want to use the [GitHub App](https://github.com/marketplace/kodiakh
 
 These instructions describe setting up Kodiak on Heroku using a Docker container, but you should be able to adapt this for other container platforms.
 
-1.  Create a new GitHub app via https://github.com/settings/apps/new with the permissions described in the [Permissions](#permissions) sections of this document and with the event subscriptions specified below
+1.  Create a new GitHub app via https://github.com/settings/apps/new with the permissions described in the [Permissions](/docs/permissions) sections of this document and with the event subscriptions specified below
 
     More information on creating a GitHub app can be found at: https://developer.github.com/apps/building-github-apps/creating-a-github-app/
 

--- a/docs/pages/en/help.js
+++ b/docs/pages/en/help.js
@@ -13,26 +13,17 @@ const CompLibrary = require("../../core/CompLibrary.js")
 const Container = CompLibrary.Container
 const GridBlock = CompLibrary.GridBlock
 
-/** @param {{language?: string, config: typeof import("../../siteConfig")}} props */
+/** @param {{config: typeof import("../../siteConfig")}} props */
 function Help(props) {
-  const { config: siteConfig, language = "" } = props
-  const { baseUrl } = siteConfig
-  const langPart = `${language ? `${language}/` : ""}`
-
-  /** @param {string} doc */
-  const docUrl = doc => `${baseUrl}${langPart}${doc}`
-
   const supportLinks = [
     {
-      content: `If you need help installing or configuring Kodiak please open an issue on GitHub.
+      content: `If you need help installing or configuring Kodiak please [open an issue on GitHub](${props.config.issuesUrl}).
 
 The team is happy to help!`,
       title: `[File an Issue on GitHub](${props.config.issuesUrl})`,
     },
     {
-      content: `Take a look around Kodiak's [Troubleshooting page](${docUrl(
-        "troubleshooting.html"
-      )}) and [Quick Start Guide](${docUrl("quickstart.html")}).`,
+      content: `Take a look around Kodiak's [Troubleshooting page](/docs/troubleshooting) and [Quick Start Guide](/docs/quickstart).`,
       title: "Browse Docs",
     },
   ]

--- a/docs/pages/en/index.js
+++ b/docs/pages/en/index.js
@@ -12,17 +12,6 @@ const CompLibrary = require("../../core/CompLibrary.js")
 const Container = CompLibrary.Container
 const GridBlock = CompLibrary.GridBlock
 
-/**
- * @param {{baseUrl: string, docsUrl?: string}} siteConfig
- * @param {string} language
- */
-function createDocUrl({ baseUrl }, language) {
-  const langPart = `${language ? `${language}/` : ""}`
-  /** @param {string} doc */
-  const docUrl = doc => `${baseUrl}${langPart}${doc}`
-  return docUrl
-}
-
 /** @param {{language?: string, siteConfig: typeof import("../../siteConfig")}} props */
 function HomeSplash(props) {
   const { siteConfig } = props
@@ -116,8 +105,6 @@ function Index(props) {
   const { config: siteConfig, language = "" } = props
   const { baseUrl } = siteConfig
 
-  const docUrl = createDocUrl(siteConfig, language)
-
   /** @param {{id?: string, background?: string, children: React.ReactNode, layout?: string, align?: "center" | "left" | undefined, paddingTop?: boolean}} props */
   const Block = ({
     paddingTop = true,
@@ -153,7 +140,6 @@ function Index(props) {
 
     \`\`\`toml
     # .kodiak.toml
-    # Minimal config. version is the only required field.
     version = 1
     \`\`\`
 
@@ -165,7 +151,7 @@ function Index(props) {
 
     Label your PRs with your \`automerge\` label and let Kodiak do the rest! 🎉
 
-See the [docs](${docUrl("quickstart.html")}) for additional setup information.
+See the [docs](/docs/quickstart) for additional setup information.
 
 If you have any questions please review [our help page](./help).
 

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -45,6 +45,13 @@ header a {
   top: unset;
 }
 
+@media (max-width: 480px) {
+  /* by default the project title hides on mobile leaving just the logo */
+  .headerTitleWithLogo {
+    display: block !important;
+  }
+}
+
 @media only screen and (min-width: 1300px) {
   .homeContainer .homeWrapper .projLogo {
     align-items: center;


### PR DESCRIPTION
We had a decent number of broken links that I hopefully fixed.

Also fixed some issues with the `<pre>` tag for the config file on the
landing page overflowing and causing the page to scroll horizontally on
mobile.

Additionally the project name in the nav was hiding on mobile.