### PR TITLE
add(docs): agolia doc search

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,4 +19,5 @@ yarn install
 yarn start
 yarn typecheck --watch
 yarn fmt
+AGOLIA_API_KEY= AGOLIA_INDEX_NAME= yarn build
 ```

--- a/docs/siteConfig.js
+++ b/docs/siteConfig.js
@@ -29,6 +29,11 @@ const siteConfig = {
   // e.g., for the https://JoelMarcey.github.io site, it would be set like...
   //   organizationName: 'JoelMarcey'
 
+  algolia: {
+    apiKey: process.env.AGOLIA_API_KEY,
+    indexName: process.env.AGOLIA_INDEX_NAME,
+  },
+
   repoUrl,
   installUrl,
   changeLogUrl,
@@ -50,6 +55,7 @@ const siteConfig = {
       href: installUrl,
       label: "Install",
     },
+    { search: true },
   ],
 
   /* path to images for header/footer */


### PR DESCRIPTION
docusaurus has an easy integration with https://community.algolia.com/docsearch/

Now there are two `env vars` required for build:

`AGOLIA_API_KEY` and `AGOLIA_INDEX_NAME`

note these env vars aren't secret as they are included in the build
artifacts.

Also updated the env vars in the netlify config section