### PR TITLE
fix: PRs not reevaluating on base branch update

### DIFF
--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -146,16 +146,17 @@ async def push(push_event: events.PushEvent) -> None:
     owner = push_event.repository.owner.login
     repo = push_event.repository.name
     assert push_event.installation
-    installation_id = push_event.installation.id
-    assert installation_id is not None
+    installation_id = str(push_event.installation.id)
     branch_name = get_branch_name(push_event.ref)
     if branch_name is None:
+        logger.info("could not extract branch name from ref", ref=push_event.ref)
         return
     async with Client(
-        owner=owner, repo=repo, installation_id=str(installation_id)
+        owner=owner, repo=repo, installation_id=installation_id
     ) as api_client:
         # find all the PRs that depend on the branch affected by this push and
         # queue them for evaluation.
+        # Any PR that has a base ref matching our event ref is dependent.
         prs = await api_client.get_open_pull_requests(base=branch_name)
         for pr in prs:
             await redis_webhook_queue.enqueue(
@@ -163,7 +164,7 @@ async def push(push_event: events.PushEvent) -> None:
                     repo_owner=owner,
                     repo_name=repo,
                     pull_request_number=pr.number,
-                    installation_id=str(installation_id),
+                    installation_id=installation_id,
                 )
             )
 

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -66,6 +66,9 @@ async def root() -> str:
 
 @webhook()
 async def pr_event(pr: events.PullRequestEvent) -> None:
+    """
+    Trigger evaluation of modified PR.
+    """
     assert pr.installation is not None
     await redis_webhook_queue.enqueue(
         event=WebhookEvent(
@@ -79,6 +82,9 @@ async def pr_event(pr: events.PullRequestEvent) -> None:
 
 @webhook()
 async def check_run(check_run_event: events.CheckRunEvent) -> None:
+    """
+    Trigger evaluation of all PRs included in check run.
+    """
     assert check_run_event.installation
     # Prevent an infinite loop when we update our check run
     if check_run_event.check_run.name == queries.CHECK_RUN_NAME:
@@ -96,6 +102,9 @@ async def check_run(check_run_event: events.CheckRunEvent) -> None:
 
 @webhook()
 async def status_event(status_event: events.StatusEvent) -> None:
+    """
+    Trigger evaluation of all PRs associated with the status event commit SHA.
+    """
     assert status_event.installation
     sha = status_event.commit.sha
     owner = status_event.repository.owner.login
@@ -121,6 +130,9 @@ async def status_event(status_event: events.StatusEvent) -> None:
 
 @webhook()
 async def pr_review(review: events.PullRequestReviewEvent) -> None:
+    """
+    Trigger evaluation of the modified PR.
+    """
     assert review.installation
     await redis_webhook_queue.enqueue(
         event=WebhookEvent(
@@ -143,6 +155,9 @@ def get_branch_name(raw_ref: str) -> Optional[str]:
 
 @webhook()
 async def push(push_event: events.PushEvent) -> None:
+    """
+    Trigger evaluation of PRs that depend on the pushed branch.
+    """
     owner = push_event.repository.owner.login
     repo = push_event.repository.name
     assert push_event.installation

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -189,7 +189,7 @@ class PRV2:
             prs = await api_client.get_open_pull_requests(base=ref)
             if prs is None:
                 # our api request failed.
-                log.warning("failed to get pull request info for ref")
+                log.info("failed to get pull request info for ref")
                 return None
             return len(prs)
 

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -181,13 +181,15 @@ class PRV2:
                 self.log.exception("failed to create notification", res=res)
 
     async def pull_requests_for_ref(self, ref: str) -> Optional[int]:
-        self.log.info("pull_requests_for_ref", ref=ref)
+        log = self.log.bind(ref=ref)
+        log.info("pull_requests_for_ref", ref=ref)
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             prs = await api_client.get_open_pull_requests(base=ref)
             if prs is None:
                 # our api request failed.
+                log.warning("failed to get pull request info for ref")
                 return None
             return len(prs)
 

--- a/kodiak/pull_request.py
+++ b/kodiak/pull_request.py
@@ -185,15 +185,11 @@ class PRV2:
         async with Client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
-            res = await api_client.get_open_pull_requests_for_ref(ref=ref)
-            try:
-                res.raise_for_status()
-            except HTTPError:
-                self.log.warning(
-                    "failed to get pull request info for ref", ref=ref, exc_info=True
-                )
+            prs = await api_client.get_open_pull_requests(base=ref)
+            if prs is None:
+                # our api request failed.
                 return None
-            return len(res.json())
+            return len(prs)
 
     async def delete_branch(self, branch_name: str) -> None:
         self.log.info("delete_branch", branch_name=branch_name)

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -838,9 +838,7 @@ class Client:
         try:
             res.raise_for_status()
         except http.HTTPError:
-            log.warning(
-                "problem finding prs", res=res, exc_info=True
-            )
+            log.warning("problem finding prs", res=res, exc_info=True)
             return []
         return [events.BasePullRequest.parse_obj(pr) for pr in res.json()]
 

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -812,7 +812,7 @@ class Client:
                 headers=headers,
             )
         if res.status_code != 200:
-            log.error("problem finding prs", res=res, res_json=res.json())
+            log.error("problem finding prs", res=res)
             return None
         return [events.BasePullRequest.parse_obj(pr) for pr in res.json()]
 
@@ -839,7 +839,7 @@ class Client:
             res.raise_for_status()
         except http.HTTPError:
             log.warning(
-                "problem finding prs", res=res, res_json=res.json(), exc_info=True
+                "problem finding prs", res=res, exc_info=True
             )
             return []
         return [events.BasePullRequest.parse_obj(pr) for pr in res.json()]

--- a/kodiak/test_main.py
+++ b/kodiak/test_main.py
@@ -1,7 +1,17 @@
 from starlette.testclient import TestClient
 
+from kodiak.main import get_branch_name
+
 
 def test_read_main(client: TestClient) -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == "OK"
+
+
+def test_get_branch_name() -> None:
+    assert get_branch_name("refs/heads/master") == "master"
+    assert (
+        get_branch_name("refs/heads/master/refs/heads/123") == "master/refs/heads/123"
+    )
+    assert get_branch_name("refs/tags/v0.1.0") is None


### PR DESCRIPTION
We now reevaluate all dependent PRs when their base branch updates (sends push webhook event).

Also remove unnecessary `res_json=res.json()` tags in logging because we cover those with `add_request_info_processor`.

fixes #244