### PR TITLE
fix: bug with status event logic

### DIFF
--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -125,6 +125,7 @@ async def status_event(status_event: events.StatusEvent) -> None:
     owner = status_event.repository.owner.login
     repo = status_event.repository.name
     installation_id = str(status_event.installation.id)
+    log = logger.bind(owner=owner, repo=repo, install=installation_id)
 
     refs = find_branch_names_latest(
         sha=status_event.commit.sha, branches=status_event.branches
@@ -142,6 +143,7 @@ async def status_event(status_event: events.StatusEvent) -> None:
             # I worry that we might miss some events where `branches` is empty,
             # but not because of a fork.
             pr_results = [await api_client.get_open_pull_requests()]
+            log.warning("could not find refs for status_event")
         else:
             pr_requests = [
                 api_client.get_open_pull_requests(head=f"{owner}:{ref}") for ref in refs

--- a/kodiak/main.py
+++ b/kodiak/main.py
@@ -114,10 +114,8 @@ def find_ref(sha: str, branches: List[Branch]) -> Optional[str]:
 @webhook()
 async def status_event(status_event: events.StatusEvent) -> None:
     """
-    When we get a status event we want to find the PR that has the commit.
-
-    If we get a status event for master, we want to find all the PRs that depend
-    against that branch so we can update them if configured.
+    When we get a status event we want to find the PRs associated with the
+    status event commit.
     """
     assert status_event.installation
     sha = status_event.commit.sha

--- a/kodiak/queries.py
+++ b/kodiak/queries.py
@@ -801,14 +801,17 @@ class Client:
             valid_merge_methods=get_valid_merge_methods(repo=repository),
         )
 
-    async def get_pull_requests_for_sha(
-        self, sha: str
+    async def get_pull_requests_for_ref(
+        self, ref_name: str
     ) -> Optional[List[events.BasePullRequest]]:
-        log = self.log.bind(sha=sha)
+        """
+        Find all the pull requests that depend on a ref.
+        """
+        log = self.log.bind(ref_name=ref_name)
         headers = await get_headers(installation_id=self.installation_id)
         async with self.throttler:
             res = await self.session.get(
-                f"https://api.github.com/repos/{self.owner}/{self.repo}/pulls?state=open&sort=updated&head={sha}",
+                f"https://api.github.com/repos/{self.owner}/{self.repo}/pulls?state=open&sort=updated&ref={ref_name}",
                 headers=headers,
             )
         if res.status_code != 200:

--- a/kodiak/queue.py
+++ b/kodiak/queue.py
@@ -38,6 +38,14 @@ class WebhookEvent(BaseModel):
     def get_merge_target_queue_name(self) -> str:
         return self.get_merge_queue_name() + ":target"
 
+    def __hash__(self) -> int:
+        return (
+            hash(self.repo_owner)
+            + hash(self.repo_name)
+            + hash(self.pull_request_number)
+            + hash(self.installation_id)
+        )
+
 
 async def process_webhook_event(
     connection: RedisConnection,


### PR DESCRIPTION
When we receive a status webhook event we look at the commit information to determine which PRs are associated with this event.

Previously our API call to GitHub incorrectly used the `head` query param by passing a SHA when it wanted a "org_name:ref_name". This error meant that our API call was returning _all_ open PRs instead of just the ones that depended on the branch.

Now we only fetch all open PRs in case we cannot find references for the current commit. This covers the case of PRs opened from forks, which the status event doesn't provide an owner for to make a GitHub API query.