### PR TITLE
ref(docs): rename detailed setup to configuration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you'd rather run Kodiak yourself, check out the [self hosting page]() in our 
 Helpful Links:
 
 - [Getting Started](https://kodiakhq.com/docs/quickstart)
-- [Configuration Guide](https://kodiakhq.com/docs/detailed-setup)
+- [Configuration Guide](https://kodiakhq.com/docs/config-reference)
 - [Why and How](https://kodiakhq.com/docs/why-and-how)
 - [Troubleshooting](https://kodiakhq.com/docs/troubleshooting)
 - [Help](https://kodiakhq.com/help)

--- a/docs/core/Footer.js
+++ b/docs/core/Footer.js
@@ -33,7 +33,7 @@ function Footer(props) {
           <a href="/docs/quickstart">Quick Start</a>
           <a href="/docs/recipes">Recipes</a>
           <a href="/docs/why-and-how">Why and How</a>
-          <a href="/docs/detailed-setup">Detailed Setup</a>
+          <a href="/docs/config-reference">Configuration Reference</a>
         </div>
         <div>
           <h5>More</h5>

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -1,6 +1,6 @@
 ---
-id: detailed-setup
-title: Detailed Setup
+id: config-reference
+title: Configuration Reference
 ---
 
 Below is a Kodiak config with all options set and commented.

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,5 @@
+# see: https://docs.netlify.com/configure-builds/file-based-configuration/
+[[redirects]]
+  from = "/docs/detailed-setup"
+  to = "/docs/config-reference"
+  status = 302

--- a/docs/sidebars.json
+++ b/docs/sidebars.json
@@ -2,7 +2,7 @@
   "docs": {
     "Getting Started": [
       "quickstart",
-      "detailed-setup",
+      "config-reference",
       "recipes",
       "why-and-how",
       "permissions",


### PR DESCRIPTION
Detailed setup doesn't actually provide much setup information but it does provide a config reference so that seems like a better name

Setup redirects using Netlify's config file https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file