### PR TITLE
doc: add info about .github/.kodiak.toml. update commit signing issue.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Add another markdown file to the `docs/` folder and update the
 ## Dev
 
 ```shell
-# /docs/website/
+# docs/
 yarn install
 yarn start
 yarn typecheck --watch

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -3,7 +3,9 @@ id: config-reference
 title: Configuration Reference
 ---
 
-Below is a Kodiak config with all options set and commented.
+Below is a Kodiak configuration with all options set and commented.
+
+The Kodiak `.kodiak.toml` configuration file can be placed at the repository root or at `.github/.kodiak.toml`.
 
 ```toml
 # .kodiak.toml

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -10,8 +10,6 @@ If Kodiak isn't working as expected, feel free to file an [GitHub Issue](https:/
 
 - Kodiak intentionally requires branch protection to be enabled to function,
   Kodiak won't merge PRs if branch protection is disabled.
-- Due to a limitation with the GitHub API, Kodiak doesn't support [requiring
-  signed commits](https://help.github.com/en/articles/about-required-commit-signing).
-  ([kodiak#89](https://github.com/chdsbd/kodiak/issues/89))
+- Kodiak is able to [create signatures](https://help.github.com/en/articles/about-required-commit-signing) for merge commits, but not for squash and rebase merge methods due to GitHub API limitations. ([kodiak#89](https://github.com/chdsbd/kodiak/issues/89))
 - GitHub CODEOWNERS are not supported. Kodiak will prematurely update PRs that still require a review from a Code Owner. However, Kodiak will be able to merge the PR once all checks pass. ([kodiak#87](https://github.com/chdsbd/kodiak/issues/87))
 - Using `merge.block_on_reviews_requested` is not recommended. If a PR is blocked by this rule a reviewer's comment will allow the PR to be merged, not just a positive approval. This is a limitation of the GitHub API. Please try GitHub's required approvals branch protection setting instead. ([kodiak#153](https://github.com/chdsbd/kodiak/issues/153))


### PR DESCRIPTION
- Update the documentation to mention that the config can be placed in .github/.kodiak.toml in addition to the repository root.
- Update the known issue documentation to mention that commit signatures only work for merge commits.
- fix a typo in the docs README.