### PR TITLE
add(docs): detailed information about configuration options

### DIFF
--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -126,6 +126,8 @@ This option only applies when `merge.require_automerge_label` is enabled.
 
 Don't wait for in-progress status checks on a PR to finish before updating the branch.
 
+This setting can speed up merges but increases chance of running extra CI jobs.
+
 ### `merge.dont_wait_on_status_checks`
 
 - **type:** `string[]`

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -3,9 +3,237 @@ id: config-reference
 title: Configuration Reference
 ---
 
-Below is a Kodiak configuration with all options set and commented.
+Kodiak's configuration file is a TOML file and should be placed at `.kodiak.toml` (repository root) or `.github/.kodiak.toml`.
 
-The Kodiak `.kodiak.toml` configuration file can be placed at the repository root or at `.github/.kodiak.toml`.
+For Kodiak to run on a pull request:
+
+1. Kodiak must be installed on the repository.
+2. A configuration file must exist in the repository.
+3. GitHub branch protection must exist on the target branch.
+
+## fields
+
+### `version`
+- __type:__ `number`
+- __required:__ `true`
+
+`1` is the only valid setting for this field.
+
+```toml
+version = 1
+```
+
+### `merge.automerge_label`
+- __type:__ `string`
+- __default:__ `"automerge"`
+
+Label to enable Kodiak to merge a PR.
+
+By default, Kodiak will only act on PRs that have this label. You can disable this requirement via `merge.require_automerge_label`.
+
+```toml
+merge.automerge_label = "🚀 merge it!"
+```
+
+### `merge.require_automerge_label`
+- __type:__ `boolean`
+- __default:__ `true`
+
+Require that the automerge label (`merge.automerge_label`) be set for Kodiak to merge a PR.
+
+When disabled, Kodiak will immediately attempt to merge any PR that passes all GitHub branch protection requirements.
+
+### `merge.blacklist_title_regex`
+- __type:__ `string`
+- __default:__ `"^WIP:.*"`
+- __options:__ Regex pattern or `""`
+
+If this title regex matches, Kodiak will not merge the PR. This is useful
+to prevent merging work in progress PRs.
+
+Setting `merge.blacklist_title_regex = ""` disables this option.
+
+
+#### example
+```
+merge.blacklist_title_regex = ".*DONT\s*MERGE.*"
+```
+
+### `merge.blacklist_labels`
+- __type:__ `string[]`
+- __default:__ `[]`
+- __options:__ List of label names
+
+If these labels are set Kodiak will not merge the PR.
+
+#### example
+```
+merge.blacklist_labels = ["wip"]
+```
+
+### `merge.method`
+- __type:__ `string`
+- __default:__ `"merge"`
+- __options:__ `"merge"`, `"squash"`, `"rebase"`
+
+Choose merge method for Kodiak to use.
+
+Kodiak will report a configuration error if the selected merge method is disabled for a repository.
+
+### `merge.delete_branch_on_merge`
+- __type:__ `boolean`
+- __default:__ `false`
+
+Once a PR is merged, delete the branch.
+
+### `merge.block_on_reviews_requested`
+- __type:__ `boolean`
+- __default:__ `false`
+
+> __DEPRECATED__
+> 
+> Due to limitations with the GitHub API this feature is fundamentally broken and cannot be fixed. Prefer the GitHub branch protection "required reviewers" setting instead.
+>
+> When a user leaves a comment on a PR, GitHub counts that as satisfying a review request, so the PR will be allowed to merge, even though a reviewer was likely just starting a review. 
+>
+> See this issue comment for more information about why this feature is not fixable: https://github.com/chdsbd/kodiak/issues/153#issuecomment-523057332.
+
+If you request review from a user, don't merge until that user provides a review, even if the PR is passing all checks.
+
+### `merge.notify_on_conflict`
+- __type:__ `boolean`
+- __default:__ `true`
+
+> Only applies when `merge.require_automerge_label` is enabled.
+
+If there is a merge conflict, make a comment on the PR and remove the
+automerge label.
+
+### `merge.optimistic_updates`
+- __type:__ `boolean`
+- __default:__ `true`
+
+Don't wait for in-progress status checks on a PR to finish before updating the branch.
+
+### `merge.dont_wait_on_status_checks`
+- __type:__ `string[]`
+- __default:__ `[]`
+- __options:__ List of check names
+
+Don't wait for specified status checks when merging a PR. If a configured status check is incomplete when a PR is being merged, Kodiak will skip the PR.
+
+Use this option for status checks that run indefinitely, like deploy jobs or the WIP GitHub App.
+
+#### example
+
+```
+merge.dont_wait_on_status_checks = ["ci/circleci: deploy", "WIP"]
+```
+
+### `merge.update_branch_immediately`
+- __type:__ `boolean`
+- __default:__ `false`
+
+> DEPRECATED: See [`update.always`](#updatealways), which will deliver better behavior in most use cases.
+
+Update PRs that are passing all branch requirements or are waiting for status checks to pass.
+
+### `merge.prioritize_ready_to_merge`
+- __type:__ `boolean`
+- __default:__ `false`
+
+If a PR is passing all checks and is able to be merged, merge it without
+placing it in the merge queue.
+
+This option adds some unfairness where PRs waiting in the queue the longest are not served first.
+
+### `merge.do_not_merge`
+- __type:__ `boolean`
+- __default:__ `false`
+
+Never merge a PR. This option can be used with `update.always` to automatically update a PR without merging.
+
+### `merge.message.title`
+- __type:__ `enum`
+- __default:__ `"github_default"`
+- __options:__ `"github_default"`, `"pull_request_title"`
+
+By default (`"github_default"`), GitHub uses the title of a PR's first commit for the merge commit title. `"pull_request_title"` uses the PR title for the merge commit.
+
+### `merge.message.body`
+- __type:__ `enum`
+- __default:__ `"github_default"`
+- __options:__ `"github_default"`, `"pull_request_body"`, `"empty"`
+
+By default (`"github_default"`), GitHub combines the titles of a PR's commits to create the body
+text of a merge commit. `"pull_request_body"` uses the content of the PR to generate
+the body content while `"empty"` simply gives an empty string.
+
+### `merge.message.include_pr_number`
+- __type:__ `boolean`
+- __default:__ `true`
+
+> Only applies when `merge.message.title` does not equal `"github_default"`.
+
+Add the PR number to the merge commit title.
+
+This setting replicates GitHub's behavior of automatically adding the PR number to the title of merges created through the UI.
+
+### `merge.message.body_type`
+- __type:__ `enum`
+- __default:__ `"markdown"`
+- __options:__ `"markdown"`, `"plain_text"`, `"html"`
+
+> Only applies when `merge.message.body = "pull_request_body"`.
+
+Control the text used in the merge commit. The GitHub default is markdown, but `"plain_text"` or `"html"` can be used to render the pull request body as text or HTML.
+
+### `merge.message.strip_html_comments`
+- __type:__ `boolean`
+- __default:__ `false`
+
+> Only applies when `merge.message.body_type = "markdown"`.
+
+Strip HTML comments (`<!-- some HTML comment -->`) from merge commit body.
+
+This setting is useful for stripping HTML comments created by PR templates.
+
+### `update.always`
+- __type:__ `boolean`
+- __default:__ `false`
+
+> Kodiak will only update PRs with the `merge.automerge_label` label or if `update.require_automerge_label = false`.
+
+Update a PR whenever out of date with the base branch. The PR will be
+updated regardless of failing merge requirements (e.g. failing status
+checks, missing reviews, blacklist labels).
+
+When enabled, _Kodiak will not be able to efficiently update PRs._ If you have multiple PRs against a target like `master`, any time a commit
+is added to `master` _all_ of those PRs against `master` will update. For `N` PRs against a target you will potentially see `N(N-1)/2` updates. If
+this configuration option was disabled you would only see `N-1` updates.
+
+
+### `update.require_automerge_label`
+- __type:__ `boolean`
+- __default:__ `true`
+
+> This option only applies when `update.always = true`.
+
+When `true`, Kodiak will only update PRs that have an automerge label (configured via [`merge.automerge_label`](#mergeautomerge_label)).
+
+When `false`, Kodiak will update any PR.
+
+
+## full examples
+
+### minimal
+
+```toml
+version = 1
+```
+
+### all options
+Below is a Kodiak config with all options set and commented.
 
 ```toml
 # .kodiak.toml
@@ -32,7 +260,7 @@ blacklist_labels = [] # default: [], options: list of label names (e.g. ["wip"])
 # repository, Kodiak will report an error in a status message.
 method = "merge" # default: "merge", options: "merge", "squash", "rebase"
 
-# once a PR is merged into master, delete the branch
+# once a PR is merged, delete the branch
 delete_branch_on_merge = false # default: false
 
 # DEPRECATED
@@ -94,7 +322,7 @@ title = "github_default" # default: "github_default", options: "github_default",
 
 # by default, GitHub combines the titles of a PR's commits to create the body
 # text of a merge. "pull_request_body" uses the content of the PR to generate
-# the body content while "empty" simple gives an empty string.
+# the body content while "empty" simply gives an empty string.
 body = "github_default" # default: "github_default", options: "github_default", "pull_request_body", "empty"
 
 # GitHub adds the PR number to the title of merges created through the UI.
@@ -118,5 +346,7 @@ always = false # default: false
 # enable updating PRs missing automerge label. automerge label is defined by `merge.automerge_label`.
 require_automerge_label = true # default: true
 ```
+
+## other resources
 
 See [`kodiak/test/fixtures/config`](https://github.com/chdsbd/kodiak/tree/master/kodiak/test/fixtures/config) for more examples and [`kodiak/config.py`](https://github.com/chdsbd/kodiak/blob/master/kodiak/config.py) for the Python models.

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -413,4 +413,4 @@ require_automerge_label = true # default: true
 
 ## other resources
 
-See [`kodiak/test/fixtures/config`](https://github.com/chdsbd/kodiak/tree/master/kodiak/test/fixtures/config) for more examples and [`kodiak/config.py`](https://github.com/chdsbd/kodiak/blob/master/kodiak/config.py) for the Python models.
+See [`kodiak/test/fixtures/config`](https://github.com/chdsbd/kodiak/tree/master/kodiak/test/fixtures/config) for more examples and [`kodiak/config.py`](https://github.com/chdsbd/kodiak/blob/master/kodiak/config.py) for the Python models that codify this configuration.

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -262,115 +262,152 @@ Below is a Kodiak config with all options set and commented.
 
 ```toml
 # .kodiak.toml
+
+# Kodiak's configuration file should be placed at `.kodiak.toml` (repository
+# root) or `.github/.kodiak.toml`.
 # docs: https://kodiakhq.com/docs/config-reference
 
 # version is the only required setting in a kodiak config.
-# it must be set to 1
+# `1` is the only valid setting for this field.
 version = 1
 
 [merge]
-# label to use to enable Kodiak to merge a PR
+# Label to enable Kodiak to merge a PR.
+
+# By default, Kodiak will only act on PRs that have this label. You can disable
+# this requirement via `merge.require_automerge_label`.
 automerge_label = "automerge" # default: "automerge"
 
-# require that the automerge label be set for Kodiak to merge a PR. if you
-# disable this Kodiak will immediately attempt to merge every PR you create
+# Require that the automerge label (`merge.automerge_label`) be set for Kodiak
+# to merge a PR.
+# 
+# When disabled, Kodiak will immediately attempt to merge any PR that passes all
+# GitHub branch protection requirements.
 require_automerge_label = true
 
-# if this title regex matches, Kodiak will not merge the PR. this is useful
-# to prevent merging work in progress PRs
+# If a PR's title matches this regex, Kodiak will not merge the PR. This is
+# useful to prevent merging work-in-progress PRs.
+# 
+# Setting `merge.blacklist_title_regex = ""` disables this option.
 blacklist_title_regex = "" # default: "^WIP:.*", options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
 
-# if these labels are set Kodiak will not merge the PR
+# Kodiak will not merge a PR with any of these labels.
 blacklist_labels = [] # default: [], options: list of label names (e.g. ["wip"])
 
-# choose a merge method. If the configured merge method is disabled for a
-# repository, Kodiak will report an error in a status message.
+# Choose merge method for Kodiak to use.
+# 
+# Kodiak will report a configuration error if the selected merge method is
+# disabled for a repository.
+# 
+# If you're using the "Require signed commits" GitHub Branch Protection setting
+# to require commit signatures, _`"merge"` is the only compatible option_. Any
+# other option will cause Kodiak to raise a configuration error.
 method = "merge" # default: "merge", options: "merge", "squash", "rebase"
 
-# once a PR is merged, delete the branch
+# Once a PR is merged, delete the branch. This option behaves like the GitHub
+# repository setting "Automatically delete head branches", which automatically
+# deletes head branches after pull requests are merged.
 delete_branch_on_merge = false # default: false
 
 # DEPRECATED
-# Due to limitations with the GitHub API this feature is
-# fundamentally broken and cannot be fixed. Please use the GitHub branch
-# protection "required reviewers" setting instead. See this issue/comment
-# for more information about why this feature is not fixable
-# see: https://github.com/chdsbd/kodiak/issues/153#issuecomment-523057332.
 #
-# if you request review from a user, don't merge until that user provides a
-# review, even if the PR is passing all checks
+# Due to limitations with the GitHub API this feature is fundamentally broken
+# and cannot be fixed. Prefer the GitHub branch protection "required reviewers"
+# setting instead.
+#
+# When a user leaves a comment on a PR, GitHub counts that as satisfying a
+# review request, so the PR will be allowed to merge, even though a reviewer was
+# likely just starting a review.
+#
+# See this issue comment for more information:
+# https://github.com/chdsbd/kodiak/issues/153#issuecomment-523057332
+#
+# If you request review from a user, don't merge until that user provides a
+# review, even if the PR is passing all status checks.
 block_on_reviews_requested = false # default: false
 
-# if there is a merge conflict, make a comment on the PR and remove the
-# automerge label. this is disabled when require_automerge_label is enabled
+# If there is a merge conflict, make a comment on the PR and remove the
+# automerge label. This option only applies when `merge.require_automerge_label`
+# is enabled.
 notify_on_conflict = true # default: true
 
-# if there are running status checks on a PR when it's up for merge, don't
-# wait for those to finish before updating the branch
+# Don't wait for in-progress status checks on a PR to finish before updating the
+# branch.
 optimistic_updates = false # default: true
 
-# use this for status checks that run indefinitely, like deploy jobs or the
-# WIP GitHub App
+# Don't wait for specified status checks when merging a PR. If a configured
+# status check is incomplete when a PR is being merged, Kodiak will skip the PR.
+# Use this option for status checks that run indefinitely, like deploy jobs or
+# the WIP GitHub App.
 dont_wait_on_status_checks = [] # default: [], options: list of check names (e.g. ["ci/circleci: lint_api"])
 
 # DEPRECATED
-# This setting only updates PRs that are passing passing all requirements or
-# waiting for status checks to pass. `update.always = True` will deliver
-# better behavior in many use cases.
 #
-# immediately update a PR whenever the target updates. If enabled, Kodiak will
-# not be able to efficiently update PRs. Any time the target of a PR updates,
-# the PR will update.
+# Prefer `update.always`, which will deliver better behavior in most use cases.
+# `merge.update_branch_immediately` only affects PRs eligible for merging, while
+# `update.always` will keep all PRs up-to-date.
 #
-# If you have multiple PRs against a target like "master", any time a commit
-# is added to "master" _all_ of those PRs against "master" will update.
-#
-# For N PRs against a target you will potentially see N(N-1)/2 updates. If
-# this configuration option was disabled you would only see N-1 updates.
-#
-# If you have continuous integration (CI) run on every commit, enabling this
-# configuration option will likely increase your CI costs if you pay per
-# minute. If you pay per build host, this will likely increase job queueing.
+# Update PRs that are passing all branch requirements or are waiting for status
+# checks to pass.
 update_branch_immediately = false # default: false
 
-# if a PR is passing all checks and is able to be merged, merge it without
-# placing it in the queue. This will introduce some unfairness where those
-# waiting in the queue the longest will not be served first.
+# If a PR is passing all checks and is able to be merged, merge it without
+# placing it in the merge queue. This option adds some unfairness where PRs
+# waiting in the queue the longest are not served first.
 prioritize_ready_to_merge = false # default: false
 
-# never merge a PR. This can be used with merge.update_branch_immediately to
+# Never merge a PR. This option can be used with `update.always` to
 # automatically update a PR without merging.
 do_not_merge = false # default: false
 
 [merge.message]
-# by default, github uses the first commit title for the PR of a merge.
-# "pull_request_title" uses the PR title.
+# By default (`"github_default"`), GitHub uses the title of a PR's first commit
+# for the merge commit title. `"pull_request_title"` uses the PR title for the
+# merge commit.
 title = "github_default" # default: "github_default", options: "github_default", "pull_request_title"
 
-# by default, GitHub combines the titles of a PR's commits to create the body
-# text of a merge. "pull_request_body" uses the content of the PR to generate
-# the body content while "empty" simply gives an empty string.
+# By default (`"github_default"`), GitHub combines the titles of a PR's commits
+# to create the body text of a merge commit. `"pull_request_body"` uses the
+# content of the PR to generate the body content while `"empty"` sets an empty
+# body.
 body = "github_default" # default: "github_default", options: "github_default", "pull_request_body", "empty"
 
-# GitHub adds the PR number to the title of merges created through the UI.
-# This setting replicates that feature.
+# Add the PR number to the merge commit title. This setting replicates GitHub's
+# behavior of automatically adding the PR number to the title of merges created
+# through the UI. This option only applies when `merge.message.title` does not
+# equal `"github_default"`.
 include_pr_number = true # default: true
 
-# markdown is the normal format for GitHub merges
+# Control the text used in the merge commit. The GitHub default is markdown, but
+# `"plain_text"` or `"html"` can be used to render the pull request body as text
+# or HTML. This option only applies when `merge.message.body = "pull_request_body"`.
 body_type = "markdown" # default: "markdown", options: "plain_text", "markdown", "html"
 
-# useful for stripping HTML comments created by PR templates when the `markdown` `body_type` is used.
+
+# Strip HTML comments (`<!-- some HTML comment -->`) from merge commit body.
+# This setting is useful for stripping HTML comments created by PR templates.
+# This option only applies when `merge.message.body_type = "markdown"`.
 strip_html_comments = false # default: false
 
 [update]
-# update PR whenever out of date with the base branch. PR will be
-# updated regardless of failing requirements for merge (e.g. failing status
-# checks, missing reviews, blacklist labels).
+
+# Update a PR whenever out of date with the base branch. The PR will be updated
+# regardless of merge requirements (e.g. failing status checks, missing reviews,
+# blacklist labels).
 #
-# Kodiak will only update the PR if the automerge label is enabled or
-# `update.require_automerge_label` is false.
+# Kodiak will only update PRs with the `merge.automerge_label` label or if
+# `update.require_automerge_label = false`.
+#
+# When enabled, _Kodiak will not be able to efficiently update PRs._ If you have
+# multiple PRs against a target like `master`, any time a commit is added to
+# `master` _all_ of those PRs against `master` will update. For `N` PRs against
+# a target you will see at least `N(N-1)/2` updates. If this configuration
+# option was disabled you would only see at least `N-1` updates.
 always = false # default: false
-# enable updating PRs missing automerge label. automerge label is defined by `merge.automerge_label`.
+
+# When enabled, Kodiak will only update PRs that have an automerge label
+# (configured via `merge.automerge_label`). When disable, Kodiak will update any
+# PR. This option only applies when `update.always = true`.
 require_automerge_label = true # default: true
 ```
 

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -11,21 +11,19 @@ For Kodiak to run on a pull request:
 2. A configuration file must exist in the repository.
 3. GitHub branch protection must exist on the target branch.
 
-## fields
+## configuration fields
 
 ### `version`
-- __type:__ `number`
-- __required:__ `true`
+
+- **type:** `number`
+- **required:** `true`
 
 `1` is the only valid setting for this field.
 
-```toml
-version = 1
-```
-
 ### `merge.automerge_label`
-- __type:__ `string`
-- __default:__ `"automerge"`
+
+- **type:** `string`
+- **default:** `"automerge"`
 
 Label to enable Kodiak to merge a PR.
 
@@ -36,89 +34,103 @@ merge.automerge_label = "🚀 merge it!"
 ```
 
 ### `merge.require_automerge_label`
-- __type:__ `boolean`
-- __default:__ `true`
+
+- **type:** `boolean`
+- **default:** `true`
 
 Require that the automerge label (`merge.automerge_label`) be set for Kodiak to merge a PR.
 
 When disabled, Kodiak will immediately attempt to merge any PR that passes all GitHub branch protection requirements.
 
 ### `merge.blacklist_title_regex`
-- __type:__ `string`
-- __default:__ `"^WIP:.*"`
-- __options:__ Regex pattern or `""`
 
-If this title regex matches, Kodiak will not merge the PR. This is useful
-to prevent merging work in progress PRs.
+- **type:** `string`
+- **default:** `"^WIP:.*"`
+- **options:** Regex pattern or `""`
+
+If a PR's title matches this regex, Kodiak will not merge the PR. This is useful
+to prevent merging work-in-progress PRs.
 
 Setting `merge.blacklist_title_regex = ""` disables this option.
 
-
 #### example
+
 ```
 merge.blacklist_title_regex = ".*DONT\s*MERGE.*"
 ```
 
 ### `merge.blacklist_labels`
-- __type:__ `string[]`
-- __default:__ `[]`
-- __options:__ List of label names
 
-If these labels are set Kodiak will not merge the PR.
+- **type:** `string[]`
+- **default:** `[]`
+- **options:** List of label names
+
+Kodiak will not merge a PR with any of these labels.
 
 #### example
+
 ```
 merge.blacklist_labels = ["wip"]
 ```
 
 ### `merge.method`
-- __type:__ `string`
-- __default:__ `"merge"`
-- __options:__ `"merge"`, `"squash"`, `"rebase"`
+
+- **type:** `string`
+- **default:** `"merge"`
+- **options:** `"merge"`, `"squash"`, `"rebase"`
 
 Choose merge method for Kodiak to use.
 
 Kodiak will report a configuration error if the selected merge method is disabled for a repository.
 
+If you're using the "Require signed commits" GitHub Branch Protection setting to require commit signatures, _`"merge"` is the only compatible option_. Any other option will cause Kodiak to raise a configuration error.
+
 ### `merge.delete_branch_on_merge`
-- __type:__ `boolean`
-- __default:__ `false`
+
+- **type:** `boolean`
+- **default:** `false`
 
 Once a PR is merged, delete the branch.
 
-### `merge.block_on_reviews_requested`
-- __type:__ `boolean`
-- __default:__ `false`
+This option behaves like the GitHub repository setting "Automatically delete head branches", which automatically deletes head branches after pull requests are merged.
 
-> __DEPRECATED__
-> 
+### `merge.block_on_reviews_requested`
+
+- **type:** `boolean`
+- **default:** `false`
+
+> **DEPRECATED**
+>
 > Due to limitations with the GitHub API this feature is fundamentally broken and cannot be fixed. Prefer the GitHub branch protection "required reviewers" setting instead.
 >
-> When a user leaves a comment on a PR, GitHub counts that as satisfying a review request, so the PR will be allowed to merge, even though a reviewer was likely just starting a review. 
+> When a user leaves a comment on a PR, GitHub counts that as satisfying a review request, so the PR will be allowed to merge, even though a reviewer was likely just starting a review.
 >
-> See this issue comment for more information about why this feature is not fixable: https://github.com/chdsbd/kodiak/issues/153#issuecomment-523057332.
+> See this issue comment for more information: [chdsbd/kodiak#153 (comment)](https://github.com/chdsbd/kodiak/issues/153#issuecomment-523057332)
 
-If you request review from a user, don't merge until that user provides a review, even if the PR is passing all checks.
+If you request review from a user, don't merge until that user provides a review, even if the PR is passing all status checks.
 
 ### `merge.notify_on_conflict`
-- __type:__ `boolean`
-- __default:__ `true`
 
-> Only applies when `merge.require_automerge_label` is enabled.
+- **type:** `boolean`
+- **default:** `true`
 
 If there is a merge conflict, make a comment on the PR and remove the
 automerge label.
 
+This option only applies when `merge.require_automerge_label` is enabled.
+
 ### `merge.optimistic_updates`
-- __type:__ `boolean`
-- __default:__ `true`
+
+- **type:** `boolean`
+- **default:** `true`
 
 Don't wait for in-progress status checks on a PR to finish before updating the branch.
 
 ### `merge.dont_wait_on_status_checks`
-- __type:__ `string[]`
-- __default:__ `[]`
-- __options:__ List of check names
+
+- **type:** `string[]`
+- **default:** `[]`
+- **options:** List of check names
 
 Don't wait for specified status checks when merging a PR. If a configured status check is incomplete when a PR is being merged, Kodiak will skip the PR.
 
@@ -131,16 +143,20 @@ merge.dont_wait_on_status_checks = ["ci/circleci: deploy", "WIP"]
 ```
 
 ### `merge.update_branch_immediately`
-- __type:__ `boolean`
-- __default:__ `false`
 
-> DEPRECATED: See [`update.always`](#updatealways), which will deliver better behavior in most use cases.
+- **type:** `boolean`
+- **default:** `false`
+
+> **DEPRECATED**
+>
+> Prefer [`update.always`](#updatealways), which will deliver better behavior in most use cases. `merge.update_branch_immediately` only affects PRs eligible for merging, while `update.always` will keep all PRs up-to-date.
 
 Update PRs that are passing all branch requirements or are waiting for status checks to pass.
 
 ### `merge.prioritize_ready_to_merge`
-- __type:__ `boolean`
-- __default:__ `false`
+
+- **type:** `boolean`
+- **default:** `false`
 
 If a PR is passing all checks and is able to be merged, merge it without
 placing it in the merge queue.
@@ -148,95 +164,106 @@ placing it in the merge queue.
 This option adds some unfairness where PRs waiting in the queue the longest are not served first.
 
 ### `merge.do_not_merge`
-- __type:__ `boolean`
-- __default:__ `false`
+
+- **type:** `boolean`
+- **default:** `false`
 
 Never merge a PR. This option can be used with `update.always` to automatically update a PR without merging.
 
 ### `merge.message.title`
-- __type:__ `enum`
-- __default:__ `"github_default"`
-- __options:__ `"github_default"`, `"pull_request_title"`
+
+- **type:** `enum`
+- **default:** `"github_default"`
+- **options:** `"github_default"`, `"pull_request_title"`
 
 By default (`"github_default"`), GitHub uses the title of a PR's first commit for the merge commit title. `"pull_request_title"` uses the PR title for the merge commit.
 
 ### `merge.message.body`
-- __type:__ `enum`
-- __default:__ `"github_default"`
-- __options:__ `"github_default"`, `"pull_request_body"`, `"empty"`
+
+- **type:** `enum`
+- **default:** `"github_default"`
+- **options:** `"github_default"`, `"pull_request_body"`, `"empty"`
 
 By default (`"github_default"`), GitHub combines the titles of a PR's commits to create the body
 text of a merge commit. `"pull_request_body"` uses the content of the PR to generate
-the body content while `"empty"` simply gives an empty string.
+the body content while `"empty"` sets an empty body.
 
 ### `merge.message.include_pr_number`
-- __type:__ `boolean`
-- __default:__ `true`
 
-> Only applies when `merge.message.title` does not equal `"github_default"`.
+- **type:** `boolean`
+- **default:** `true`
 
 Add the PR number to the merge commit title.
 
 This setting replicates GitHub's behavior of automatically adding the PR number to the title of merges created through the UI.
 
-### `merge.message.body_type`
-- __type:__ `enum`
-- __default:__ `"markdown"`
-- __options:__ `"markdown"`, `"plain_text"`, `"html"`
+This option only applies when `merge.message.title` does not equal `"github_default"`.
 
-> Only applies when `merge.message.body = "pull_request_body"`.
+### `merge.message.body_type`
+
+- **type:** `enum`
+- **default:** `"markdown"`
+- **options:** `"markdown"`, `"plain_text"`, `"html"`
 
 Control the text used in the merge commit. The GitHub default is markdown, but `"plain_text"` or `"html"` can be used to render the pull request body as text or HTML.
 
-### `merge.message.strip_html_comments`
-- __type:__ `boolean`
-- __default:__ `false`
+This option only applies when `merge.message.body = "pull_request_body"`.
 
-> Only applies when `merge.message.body_type = "markdown"`.
+### `merge.message.strip_html_comments`
+
+- **type:** `boolean`
+- **default:** `false`
 
 Strip HTML comments (`<!-- some HTML comment -->`) from merge commit body.
 
 This setting is useful for stripping HTML comments created by PR templates.
 
-### `update.always`
-- __type:__ `boolean`
-- __default:__ `false`
+This option only applies when `merge.message.body_type = "markdown"`.
 
-> Kodiak will only update PRs with the `merge.automerge_label` label or if `update.require_automerge_label = false`.
+### `update.always`
+
+- **type:** `boolean`
+- **default:** `false`
 
 Update a PR whenever out of date with the base branch. The PR will be
-updated regardless of failing merge requirements (e.g. failing status
+updated regardless of merge requirements (e.g. failing status
 checks, missing reviews, blacklist labels).
 
-When enabled, _Kodiak will not be able to efficiently update PRs._ If you have multiple PRs against a target like `master`, any time a commit
-is added to `master` _all_ of those PRs against `master` will update. For `N` PRs against a target you will potentially see `N(N-1)/2` updates. If
-this configuration option was disabled you would only see `N-1` updates.
+Kodiak will only update PRs with the `merge.automerge_label` label or if `update.require_automerge_label = false`.
 
+When enabled, _Kodiak will not be able to efficiently update PRs._ If you have multiple PRs against a target like `master`, any time a commit
+is added to `master` _all_ of those PRs against `master` will update. For `N` PRs against a target you will see at least `N(N-1)/2` updates. If
+this configuration option was disabled you would only see at least `N-1` updates.
 
 ### `update.require_automerge_label`
-- __type:__ `boolean`
-- __default:__ `true`
 
-> This option only applies when `update.always = true`.
+- **type:** `boolean`
+- **default:** `true`
 
-When `true`, Kodiak will only update PRs that have an automerge label (configured via [`merge.automerge_label`](#mergeautomerge_label)).
+When enabled, Kodiak will only update PRs that have an automerge label (configured via `merge.automerge_label`).
 
-When `false`, Kodiak will update any PR.
+When disable, Kodiak will update any PR.
 
+This option only applies when `update.always = true`.
 
 ## full examples
 
 ### minimal
 
 ```toml
+# .kodiak.toml
+# docs: https://kodiakhq.com/docs/config-reference
 version = 1
 ```
 
 ### all options
+
 Below is a Kodiak config with all options set and commented.
 
 ```toml
 # .kodiak.toml
+# docs: https://kodiakhq.com/docs/config-reference
+
 # version is the only required setting in a kodiak config.
 # it must be set to 1
 version = 1

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -280,14 +280,14 @@ automerge_label = "automerge" # default: "automerge"
 
 # Require that the automerge label (`merge.automerge_label`) be set for Kodiak
 # to merge a PR.
-# 
+#
 # When disabled, Kodiak will immediately attempt to merge any PR that passes all
 # GitHub branch protection requirements.
 require_automerge_label = true
 
 # If a PR's title matches this regex, Kodiak will not merge the PR. This is
 # useful to prevent merging work-in-progress PRs.
-# 
+#
 # Setting `merge.blacklist_title_regex = ""` disables this option.
 blacklist_title_regex = "" # default: "^WIP:.*", options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
 
@@ -295,10 +295,10 @@ blacklist_title_regex = "" # default: "^WIP:.*", options: "" (disables regex), a
 blacklist_labels = [] # default: [], options: list of label names (e.g. ["wip"])
 
 # Choose merge method for Kodiak to use.
-# 
+#
 # Kodiak will report a configuration error if the selected merge method is
 # disabled for a repository.
-# 
+#
 # If you're using the "Require signed commits" GitHub Branch Protection setting
 # to require commit signatures, _`"merge"` is the only compatible option_. Any
 # other option will cause Kodiak to raise a configuration error.

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -121,3 +121,12 @@ header a {
 .mr-3 {
   margin-right: 0.75rem !important;
 }
+
+/* Prevent wrapping on right sidebar. */
+.toc-headings > li {
+    text-overflow: ellipsis;
+    overflow-x: hidden;
+}
+.toc-headings > li > a > code {
+    white-space: nowrap;
+}


### PR DESCRIPTION
CHANGES
- break out config information into HTML. This will allow algolia to index our config options.
- update the CSS for the right sidebar to hide overflowing text with an ellipsis instead of allowing wrapping.
- update large configuration example with updating documentation.