### PR TITLE
fix: approve.auto_approve_usernames to only affect open, non-draft PRs

### DIFF
--- a/kodiak/evaluation.py
+++ b/kodiak/evaluation.py
@@ -249,7 +249,11 @@ async def mergeable(
         )
         return
 
-    if pull_request.author.login in config.approve.auto_approve_usernames:
+    if (
+        pull_request.author.login in config.approve.auto_approve_usernames
+        and pull_request.state == PullRequestState.OPEN
+        and pull_request.mergeStateStatus != MergeStateStatus.DRAFT
+    ):
         # if the PR was created by an approve author and we have not previously
         # given an approval, approve the PR.
         sorted_reviews = sorted(reviews, key=lambda x: x.createdAt)

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --pdbcls IPython.terminal.debugger:TerminalPdb
 filterwarnings =
   ; all warnings that are not ignored should raise an error
   error


### PR DESCRIPTION
- add tests to cover pull requests in different states for `approve.auto_approve_usernames`
- add BaseMockFunc repr to make test failures more clear
- configure pytest to use ipdb for `--pdb`