### PR TITLE
add(docs): edit url to enable edit button on doc pages

### DIFF
--- a/docs/siteConfig.js
+++ b/docs/siteConfig.js
@@ -12,6 +12,7 @@ const repoUrl = "https://github.com/chdsbd/kodiak"
 const installUrl = "https://github.com/marketplace/kodiakhq#pricing-and-setup"
 const changeLogUrl = "https://github.com/chdsbd/kodiak/releases"
 const issuesUrl = "https://github.com/chdsbd/kodiak/issues/new/choose"
+const editUrl = "https://github.com/chdsbd/kodiak/tree/master/docs/docs/"
 
 const siteConfig = {
   title: "Kodiak", // Title for your website.
@@ -38,6 +39,8 @@ const siteConfig = {
   installUrl,
   changeLogUrl,
   issuesUrl,
+
+  editUrl,
 
   customDocsPath: "docs/docs",
 


### PR DESCRIPTION
With this url, docusaurus adds an Edit button to each doc page.

rel: https://docusaurus.io/docs/en/site-config.html#editurl-string