### PR TITLE
fix(web-api): authentication issues

### DIFF
--- a/web_api/core/middleware.py
+++ b/web_api/core/middleware.py
@@ -1,4 +1,7 @@
-from django.http import HttpRequest
+from typing import Callable
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
 
@@ -16,3 +19,17 @@ class AuthenticationMiddleware(MiddlewareMixin):
 
     def process_request(self, request: HttpRequest) -> None:
         request.user = SimpleLazyObject(lambda: get_user(request))
+
+
+class CORSMiddleware:
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        response = self.get_response(request)
+
+        response["Access-Control-Allow-Origin"] = settings.KODIAK_WEB_APP_URL
+        response["Access-Control-Allow-Credentials"] = "true"
+        response["Access-Control-Allow-Headers"] = "content-type"
+
+        return response

--- a/web_api/core/test_views.py
+++ b/web_api/core/test_views.py
@@ -66,7 +66,7 @@ def test_oauth_login(client: Client, state_token: str) -> None:
     assert res.status_code == 302
     assert (
         res["Location"]
-        == f"https://github.com/login/oauth/authorize?client_id=Iv1.111FAKECLIENTID111&redirect_uri=https://app.kodiakhq.com/v1/oauth_complete&state={state_token}"
+        == f"https://github.com/login/oauth/authorize?client_id=Iv1.111FAKECLIENTID111&redirect_uri=https://app.kodiakhq.com/oauth&state={state_token}"
     )
 
 

--- a/web_api/core/test_views.py
+++ b/web_api/core/test_views.py
@@ -66,7 +66,7 @@ def test_oauth_login(client: Client, state_token: str) -> None:
     assert res.status_code == 302
     assert (
         res["Location"]
-        == f"https://github.com/login/oauth/authorize?client_id=Iv1.111FAKECLIENTID111&redirect_uri=http://testserver/v1/oauth_complete&state={state_token}"
+        == f"https://github.com/login/oauth/authorize?client_id=Iv1.111FAKECLIENTID111&redirect_uri=https://app.kodiakhq.com/v1/oauth_complete&state={state_token}"
     )
 
 

--- a/web_api/core/urls.py
+++ b/web_api/core/urls.py
@@ -4,7 +4,7 @@ from core import views
 
 urlpatterns = [
     path("oauth_login", views.oauth_login),
-    path("oauth_callback", views.oauth_callback, name="oauth_callback"),
+    path("oauth_complete", views.oauth_complete),
     path("logout", views.logout),
     path("installations", views.installations),
     path("ping", views.ping),

--- a/web_api/tox.ini
+++ b/web_api/tox.ini
@@ -4,7 +4,7 @@ DJANGO_SETTINGS_MODULE = web_api.settings
 env =
   KODIAK_API_GITHUB_CLIENT_ID=Iv1.111FAKECLIENTID111
   KODIAK_API_GITHUB_CLIENT_SECRET=888INVALIDSECRET8888
-  KODIAK_WEB_APP_URL=https://app.kodiahq.com/
+  KODIAK_WEB_APP_URL=https://app.kodiakhq.com/
   DEBUG=1
 filterwarnings =
   ; all warnings that are not ignored should raise an error

--- a/web_api/tox.ini
+++ b/web_api/tox.ini
@@ -4,7 +4,7 @@ DJANGO_SETTINGS_MODULE = web_api.settings
 env =
   KODIAK_API_GITHUB_CLIENT_ID=Iv1.111FAKECLIENTID111
   KODIAK_API_GITHUB_CLIENT_SECRET=888INVALIDSECRET8888
-  KODIAK_WEB_AUTHED_LANDING_PATH=https://app.kodiahq.com/login-landing
+  KODIAK_WEB_APP_URL=https://app.kodiahq.com/
   DEBUG=1
 filterwarnings =
   ; all warnings that are not ignored should raise an error

--- a/web_api/web_api/settings.py
+++ b/web_api/web_api/settings.py
@@ -1,9 +1,9 @@
 import os
 from typing import List
-from urllib.parse import urljoin, urlparse
 
 import dj_database_url
 from dotenv import load_dotenv
+from yarl import URL
 
 load_dotenv()
 
@@ -63,12 +63,15 @@ USE_L10N = True
 
 USE_TZ = True
 
+# we terminate SSL at the proxy server
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+# improve security for sessions to prevent interception
+if not DEBUG:
+    SESSION_COOKIE_SECURE = True
+
 # Configuration for App
 KODIAK_API_GITHUB_CLIENT_ID = os.environ["KODIAK_API_GITHUB_CLIENT_ID"]
 KODIAK_API_GITHUB_CLIENT_SECRET = os.environ["KODIAK_API_GITHUB_CLIENT_SECRET"]
 KODIAK_WEB_APP_URL = os.environ["KODIAK_WEB_APP_URL"]
-KODIAK_WEB_AUTHED_LANDING_PATH = urljoin(KODIAK_WEB_APP_URL, "/oauth")
-
-# we terminate SSL at the proxy server
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-SESSION_COOKIE_DOMAIN = urlparse(KODIAK_WEB_AUTHED_LANDING_PATH).netloc
+KODIAK_WEB_AUTHED_LANDING_PATH = str(URL(KODIAK_WEB_APP_URL).with_path("/oauth"))

--- a/web_api/web_api/settings.py
+++ b/web_api/web_api/settings.py
@@ -1,5 +1,6 @@
 import os
 from typing import List
+from urllib.parse import urljoin, urlparse
 
 import dj_database_url
 from dotenv import load_dotenv
@@ -33,6 +34,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "core.middleware.AuthenticationMiddleware",
+    "core.middleware.CORSMiddleware",
 ]
 
 ROOT_URLCONF = "web_api.urls"
@@ -61,10 +63,12 @@ USE_L10N = True
 
 USE_TZ = True
 
-# we terminate SSL at the proxy server
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-
 # Configuration for App
 KODIAK_API_GITHUB_CLIENT_ID = os.environ["KODIAK_API_GITHUB_CLIENT_ID"]
 KODIAK_API_GITHUB_CLIENT_SECRET = os.environ["KODIAK_API_GITHUB_CLIENT_SECRET"]
-KODIAK_WEB_AUTHED_LANDING_PATH = os.environ["KODIAK_WEB_AUTHED_LANDING_PATH"]
+KODIAK_WEB_APP_URL = os.environ["KODIAK_WEB_APP_URL"]
+KODIAK_WEB_AUTHED_LANDING_PATH = urljoin(KODIAK_WEB_APP_URL, "/oauth")
+
+# we terminate SSL at the proxy server
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SESSION_COOKIE_DOMAIN = urlparse(KODIAK_WEB_AUTHED_LANDING_PATH).netloc


### PR DESCRIPTION
Update authentication flow to work with web ui. I want the app and the api to have different hosting, so we won't have NGINX to do proxying. This means we have to fight around CORs, so the authentication process is a little tricky (at least to me).

I have an urge to use token authentication, but this session stuff appears to work for now.