### PR TITLE
fix(docs): dependabot recipe to use correct username

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -23,11 +23,15 @@ While Dependabot can [automerge dependency updates](https://dependabot.com/docs/
 
 Kodiak can help us here by automatically adding an approval to all Dependabot PRs, which will allow Dependabot PRs to be automatically merged without human intervention.
 
+> **NOTE:** Remove the `[bot]` suffix from GitHub Bot usernames. Instead of `"dependabot-preview[bot]"` use `"dependabot-preview"`.
+
 ```
 # .kodiak.toml
 version = 1
 
 [approve]
+# note: remove the "[bot]" suffix from GitHub Bot usernames.
+# Instead of "dependabot-preview[bot]" use "dependabot-preview".
 auto_approve_usernames = ["dependabot-preview"]
 ```
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -28,7 +28,7 @@ Kodiak can help us here by automatically adding an approval to all Dependabot PR
 version = 1
 
 [approve]
-auto_approve_usernames = ["dependabot-preview[bot]"]
+auto_approve_usernames = ["dependabot-preview"]
 ```
 
 ## The Favourite


### PR DESCRIPTION
The GitHub v3 API and the v4 api return difference results for the username of bots. The v3 API returns the name, appended with `[bot]`, like "kodiakhq[bot]", but the v4 api simply returns "kodiakhq". We were using the incorrect name for dependabot because we use the v4 API.

related: https://github.com/chdsbd/kodiak/issues/208#issuecomment-584639603