### PR TITLE
add(web): logic to redirect on auth failure

### DIFF
--- a/web_api/core/auth.py
+++ b/web_api/core/auth.py
@@ -1,9 +1,9 @@
 from functools import wraps
 from typing import Callable, cast
 
-from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse
 
+from core.exceptions import AuthenticationRequired
 from core.models import AnonymousUser, User
 
 
@@ -14,7 +14,7 @@ def login_required(view_func: Callable) -> Callable:
     ) -> HttpResponse:
         if request.user.is_authenticated:
             return view_func(request, *args, **kwargs)
-        raise PermissionDenied("authentication required")
+        raise AuthenticationRequired
 
     return wrapped_view
 

--- a/web_api/core/exceptions.py
+++ b/web_api/core/exceptions.py
@@ -1,0 +1,8 @@
+class ApiException(Exception):
+    code: int = 500
+    message: str = "Internal Server Error"
+
+
+class AuthenticationRequired(ApiException):
+    code = 401
+    message = "Authentication Required"

--- a/web_api/core/middleware.py
+++ b/web_api/core/middleware.py
@@ -1,11 +1,12 @@
-from typing import Callable
+from typing import Callable, Optional
 
 from django.conf import settings
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
 
 from core.auth import get_user
+from core.exceptions import ApiException
 
 
 class AuthenticationMiddleware(MiddlewareMixin):
@@ -33,3 +34,12 @@ class CORSMiddleware:
         response["Access-Control-Allow-Headers"] = "content-type"
 
         return response
+
+
+class ExceptionMiddleware(MiddlewareMixin):
+    def process_exception(
+        self, request: HttpRequest, exception: Exception
+    ) -> Optional[HttpResponse]:
+        if isinstance(exception, ApiException):
+            return JsonResponse(dict(message=exception.message), status=exception.code)
+        return None

--- a/web_api/web_api/settings.py
+++ b/web_api/web_api/settings.py
@@ -28,6 +28,7 @@ ALLOWED_HOSTS: List[str] = ["*"]
 INSTALLED_APPS = ["django.contrib.sessions", "core"]
 
 MIDDLEWARE = [
+    "core.middleware.ExceptionMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/web_ui/src/world.ts
+++ b/web_ui/src/world.ts
@@ -6,10 +6,26 @@ interface World {
   api: api.Api
 }
 
-const httpClient = axios.create({
+const openRoute = axios.create({
   baseURL: API_ROOT,
   withCredentials: true,
 })
+
+const authRoute = axios.create({
+  baseURL: API_ROOT,
+  withCredentials: true,
+})
+
+authRoute.interceptors.response.use(
+  res => res,
+  err => {
+    // tslint:disable-next-line no-unsafe-any
+    if (err?.response?.status === 401) {
+      location.pathname = "/login"
+    }
+    return Promise.reject(err)
+  },
+)
 
 /** Convert JSON to FormData
  *
@@ -29,7 +45,7 @@ export const Current: World = {
   api: {
     loginUser: async (args: api.ILoginUserArgs) => {
       try {
-        const res = await httpClient.post<api.ILoginUserResponse>(
+        const res = await openRoute.post<api.ILoginUserResponse>(
           "/v1/oauth_complete",
           jsonToFormData(args),
         )
@@ -45,7 +61,7 @@ export const Current: World = {
     },
     logoutUser: async () => {
       try {
-        await httpClient.post("/v1/logout")
+        await openRoute.post("/v1/logout")
         return { ok: true }
       } catch (e) {
         // pass
@@ -54,25 +70,25 @@ export const Current: World = {
     },
     getUsageBilling: async (args: api.IUsageBillingPageArgs) => {
       return (
-        await httpClient.get<api.IUsageBillingPageApiResponse>(
+        await authRoute.get<api.IUsageBillingPageApiResponse>(
           `/v1/t/${args.teamId}/usage_billing`,
         )
       ).data
     },
     getActivity: async (args: api.IActivityArgs) => {
       return (
-        await httpClient.get<api.IActivityApiResponse>(
+        await authRoute.get<api.IActivityApiResponse>(
           `/v1/t/${args.teamId}/activity`,
         )
       ).data
     },
     getAccounts: async () => {
-      return (await httpClient.get<api.IAccountsApiResponse>("/v1/accounts"))
+      return (await authRoute.get<api.IAccountsApiResponse>("/v1/accounts"))
         .data
     },
     getCurrentAccount: async () => {
       return (
-        await httpClient.get<api.ICurrentAccountApiResponse>(
+        await authRoute.get<api.ICurrentAccountApiResponse>(
           "/v1/current_account",
         )
       ).data


### PR DESCRIPTION
When a user is logged out or session expires they will get 401s from the API. This change makes it so when a user tries to access a page that requests one of these endpoints they will be redirect to login.