### PR TITLE
add(web_ui): netlify configuration for react app

### DIFF
--- a/web_ui/netlify.toml
+++ b/web_ui/netlify.toml
@@ -1,0 +1,5 @@
+# see: https://docs.netlify.com/configure-builds/file-based-configuration/
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
We need redirects to support React Router.

The API isn't running yet, but this configuration file should make the Netlify deploy work.

Now we have Netlify run for the docs and for the web app.