### PR TITLE
fix(bot): convert redis password to bytes when BytesEncoder is used

### DIFF
--- a/bot/kodiak/event_handlers.py
+++ b/bot/kodiak/event_handlers.py
@@ -187,7 +187,9 @@ async def get_redis() -> asyncio_redis.Connection:
         _redis = await asyncio_redis.Pool.create(
             host=conf.REDIS_URL.hostname,
             port=conf.REDIS_URL.port,
-            password=conf.REDIS_URL.password,
+            password=(
+                conf.REDIS_URL.password.encode() if conf.REDIS_URL.password else None
+            ),
             poolsize=conf.USAGE_REPORTING_POOL_SIZE,
             encoder=asyncio_redis.encoders.BytesEncoder(),
         )


### PR DESCRIPTION
When connecting to a Redis server using password authentication, `asyncio_redis` throws an exception when a GitHub webhook is received:
```
INFO uvicorn:httptools_impl.py:436 ('10.xx.xx.xx', 35906) - "POST /api/github/hook HTTP/1.1" 500
ERROR uvicorn:httptools_impl.py:371 Exception in ASGI application
Traceback (most recent call last):
  File "/var/app/.venv/lib/python3.7/site-packages/uvicorn/protocols/http/httptools_impl.py", line 368, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/var/app/.venv/lib/python3.7/site-packages/fastapi/applications.py", line 140, in __call__
    await super().__call__(scope, receive, send)
  File "/var/app/.venv/lib/python3.7/site-packages/starlette/applications.py", line 134, in __call__
    await self.error_middleware(scope, receive, send)
  File "/var/app/.venv/lib/python3.7/site-packages/starlette/middleware/errors.py", line 178, in __call__
    raise exc from None
  File "/var/app/.venv/lib/python3.7/site-packages/starlette/middleware/errors.py", line 156, in __call__
    await self.app(scope, receive, _send)
  File "/var/app/.venv/lib/python3.7/site-packages/sentry_sdk/integrations/asgi.py", line 51, in _run_app
    raise exc from None
  File "/var/app/.venv/lib/python3.7/site-packages/sentry_sdk/integrations/asgi.py", line 48, in _run_app
    await callback()
  File "/var/app/.venv/lib/python3.7/site-packages/starlette/exceptions.py", line 73, in __call__
    raise exc from None
  File "/var/app/.venv/lib/python3.7/site-packages/starlette/exceptions.py", line 62, in __call__
    await self.app(scope, receive, sender)
  File "/var/app/.venv/lib/python3.7/site-packages/starlette/routing.py", line 590, in __call__
    await route(scope, receive, send)
  File "/var/app/.venv/lib/python3.7/site-packages/starlette/routing.py", line 208, in __call__
    await self.app(scope, receive, send)
  File "/var/app/.venv/lib/python3.7/site-packages/starlette/routing.py", line 41, in app
    response = await func(request)
  File "/var/app/.venv/lib/python3.7/site-packages/fastapi/routing.py", line 133, in app
    raw_response = await dependant.call(**values)
  File "./kodiak/main.py", line 99, in webhook_event
    await handle_webhook_event(event_name=github_event, payload=event)
  File "./kodiak/event_handlers.py", line 210, in handle_webhook_event
    redis = await get_redis()
  File "./kodiak/event_handlers.py", line 192, in get_redis
    encoder=asyncio_redis.encoders.BytesEncoder(),
  File "/var/app/.venv/src/asyncio-redis/asyncio_redis/pool.py", line 63, in create
    protocol_class=protocol_class)
  File "/var/app/.venv/src/asyncio-redis/asyncio_redis/connection.py", line 68, in create
    connection_lost_callback=connection_lost, loop=connection._loop)
  File "/var/app/.venv/src/asyncio-redis/asyncio_redis/protocol.py", line 793, in __init__
    assert not password or isinstance(password, encoder.native_type)
AssertionError
```

This happens because `event_handlers.py`'s Redis pool creation sets the non-default encoder `asyncio_redis.encoders.BytesEncoder()`. When this encoder is used, `asyncio_redis` expects the password to be in bytes -- which is not -- causing the error above.

This PR adds a condition to convert password to bytes in the Redis connection pool of `event_handlers.py` file -- which uses BytesEncoder.