### PR TITLE
add(bot): config merge.message.include_pull_request_author

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -40,6 +40,7 @@ class MergeMessage(BaseModel):
     include_pr_number: bool = True
     body_type: BodyText = BodyText.markdown
     strip_html_comments: bool = False
+    include_pull_request_author: bool = False
 
 
 class Merge(BaseModel):

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -83,11 +83,16 @@ def get_merge_body(config: V1, pull_request: PullRequest) -> MergeBody:
             merge_body.commit_message if merge_body.commit_message is not None else ""
         )
         author_name = pull_request.author.login
+        author_login = pull_request.author.login
         if pull_request.author.type == "Bot":
             author_name += "[bot]"
+            author_login += "[bot]"
         if pull_request.author.name:
             author_name = pull_request.author.name
-        author_email = f"{pull_request.author.databaseId}+{pull_request.author.login}@users.noreply.github.com"
+
+        author_email = (
+            f"{pull_request.author.databaseId}+{author_login}@users.noreply.github.com"
+        )
         merge_body.commit_message = (
             commit_message + f"\n\nCo-authored-by: {author_name} <{author_email}>"
         )

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -78,6 +78,19 @@ def get_merge_body(config: V1, pull_request: PullRequest) -> MergeBody:
         merge_body.commit_title = pull_request.title
     if config.merge.message.include_pr_number and merge_body.commit_title is not None:
         merge_body.commit_title += f" (#{pull_request.number})"
+    if config.merge.message.include_pull_request_author:
+        commit_message = (
+            merge_body.commit_message if merge_body.commit_message is not None else ""
+        )
+        author_name = pull_request.author.login
+        if pull_request.author.type == "Bot":
+            author_name += "[bot]"
+        if pull_request.author.name:
+            author_name = pull_request.author.name
+        author_email = f"{pull_request.author.databaseId}+{pull_request.author.login}@users.noreply.github.com"
+        merge_body.commit_message = (
+            commit_message + f"\n\nCo-authored-by: {author_name} <{author_email}>"
+        )
     return merge_body
 
 

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -90,6 +90,9 @@ def get_merge_body(config: V1, pull_request: PullRequest) -> MergeBody:
         if pull_request.author.name:
             author_name = pull_request.author.name
 
+        # GitHub does not allow our GitHub App to view the email addresses of
+        # pull request authors, so we generate a noreply GitHub email address
+        # instead which works the same for the GitHub UI.
         author_email = (
             f"{pull_request.author.databaseId}+{author_login}@users.noreply.github.com"
         )

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -81,6 +81,14 @@ query GetEventInfo($owner: String!, $repo: String!, $rootConfigFileExpression: S
       id
       author {
         login
+        type: __typename
+        ... on User {
+          databaseId
+          name
+        }
+        ... on Bot {
+          databaseId
+        }
       }
       mergeStateStatus
       state
@@ -212,6 +220,9 @@ class PullRequestState(Enum):
 
 class PullRequestAuthor(BaseModel):
     login: str
+    databaseId: int
+    type: str
+    name: Optional[str] = None
 
 
 class PullRequest(BaseModel):

--- a/bot/kodiak/test/fixtures/api/get_event/behind.json
+++ b/bot/kodiak/test/fixtures/api/get_event/behind.json
@@ -36,7 +36,7 @@
         "mergeable": "MERGEABLE",
         "isCrossRepository": false,
         "author": {
-            "login": "arnold"
+            "login": "arnold", "databaseId": 49118, "type": "Bot"
         },
         "reviewRequests": {
           "nodes": [

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -27,7 +27,8 @@
           "body": "github_default",
           "include_pr_number": true,
           "body_type": "markdown",
-          "strip_html_comments": false
+          "strip_html_comments": false,
+          "include_pull_request_author": false
         },
         "dont_wait_on_status_checks": [],
         "update_branch_immediately": false,
@@ -108,6 +109,11 @@
           "title": "Strip Html Comments",
           "default": false,
           "type": "boolean"
+        },
+        "include_pull_request_author": {
+          "title": "Include Pull Request Author",
+          "default": false,
+          "type": "boolean"
         }
       }
     },
@@ -175,7 +181,8 @@
             "body": "github_default",
             "include_pr_number": true,
             "body_type": "markdown",
-            "strip_html_comments": false
+            "strip_html_comments": false,
+            "include_pull_request_author": false
           },
           "allOf": [
             {

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -85,9 +85,7 @@ def block_event() -> EventInfoResponse:
     pr = PullRequest(
         id="e14ff7599399478fb9dbc2dacb87da72",
         number=100,
-        author=PullRequestAuthor(
-            login="arnold", name="Arnold Weber", databaseId=49118, type="User"
-        ),
+        author=PullRequestAuthor(login="arnold", databaseId=49118, type="Bot"),
         mergeStateStatus=MergeStateStatus.BEHIND,
         state=PullRequestState.OPEN,
         mergeable=MergeableState.MERGEABLE,

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -85,7 +85,9 @@ def block_event() -> EventInfoResponse:
     pr = PullRequest(
         id="e14ff7599399478fb9dbc2dacb87da72",
         number=100,
-        author=PullRequestAuthor(login="arnold"),
+        author=PullRequestAuthor(
+            login="arnold", name="Arnold Weber", databaseId=49118, type="User"
+        ),
         mergeStateStatus=MergeStateStatus.BEHIND,
         state=PullRequestState.OPEN,
         mergeable=MergeableState.MERGEABLE,

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -222,6 +222,17 @@ This setting is useful for stripping HTML comments created by PR templates.
 
 This option only applies when `merge.message.body_type = "markdown"`.
 
+### `merge.message.include_pull_request_author`
+
+- **type:** `boolean`
+- **default:** `false`
+
+Add the pull request author as a coauthor of the merge commit using `Co-authored-by: jdoe <828352+jdoe@users.noreply.github.com>` syntax.
+
+This setting will override `merge.message.body = "github_default"` and `merge.message.body = "empty"`. In both cases the result will be an empty merge commit body with coauthor information at the end of the commit body.
+
+This setting is useful when GitHub strips authorship information for squashes.
+
 ### `update.always`
 
 - **type:** `boolean`

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -229,7 +229,7 @@ This option only applies when `merge.message.body_type = "markdown"`.
 
 Add the pull request author as a coauthor of the merge commit using `Co-authored-by: jdoe <828352+jdoe@users.noreply.github.com>` syntax.
 
-This setting will override `merge.message.body = "github_default"` and `merge.message.body = "empty"`. In both cases the result will be an empty merge commit body with coauthor information at the end of the commit body.
+This setting will override `merge.message.body = "github_default"` and `merge.message.body = "empty"`. In both cases, the commit message will only contain coauthor information.
 
 This setting is useful when GitHub strips authorship information for squashes.
 


### PR DESCRIPTION
Add option to add the pull request author as a trailer to the merge body using the `Co-authored-by: Jane Doe <j.doe@example.com>` format.

This change creates a workaround for #300.

The end result is not perfect, but I think it's the best we're going to be able to do for the moment.
<img width="461" alt="image" src="https://user-images.githubusercontent.com/1929960/75944759-8b99a980-5e66-11ea-98e6-0b0248ee9046.png">