### PR TITLE
add(web_ui): redirect for authed url

### DIFF
--- a/web_ui/s/dev
+++ b/web_ui/s/dev
@@ -1,4 +1,4 @@
 #!/bin/sh
 # configure react-scripts to open correct domain on start. Also configure API routing for JS bundle.
 # https://github.com/facebook/create-react-app/blob/8b0dd54c7a7488d46a43ff6d1c67a6b41c31feb1/packages/react-scripts/scripts/start.js#L61
-HOST=app-localhost.kodiakhq.com REACT_APP_KODIAK_API_ROOT=http://api-localhost.kodiakhq.com:8000 exec node scripts/start.js
+HOST=app.localhost.kodiakhq.com REACT_APP_KODIAK_API_ROOT=http://api.localhost.kodiakhq.com:8000 exec node scripts/start.js

--- a/web_ui/src/auth.ts
+++ b/web_ui/src/auth.ts
@@ -3,7 +3,9 @@ import uuid from "uuid/v4"
 
 export function startLogin() {
   const url = new URL(loginUrl)
-  const state = uuid()
+  const queryParams = new URLSearchParams(location.search)
+  const redirectUri = queryParams.get("redirect")
+  const state = JSON.stringify({ nonce: uuid(), redirect: redirectUri })
   url.searchParams.set("state", state)
   localStorage.setItem("oauth_state", state)
   // eslint-disable-next-line no-restricted-globals

--- a/web_ui/src/auth.ts
+++ b/web_ui/src/auth.ts
@@ -15,3 +15,15 @@ export function startLogin() {
 export function getOauthState() {
   return localStorage.getItem("oauth_state") || ""
 }
+
+export function getRedirectPath(x: string): string | undefined {
+  try {
+    const redirect = JSON.parse(x)["redirect"]
+    if (typeof redirect === "string") {
+      return redirect
+    }
+  } catch (_) {
+    // pass
+  }
+  return undefined
+}

--- a/web_ui/src/auth.ts
+++ b/web_ui/src/auth.ts
@@ -18,6 +18,7 @@ export function getOauthState() {
 
 export function getRedirectPath(x: string): string | undefined {
   try {
+    // tslint:disable-next-line: no-unsafe-any
     const redirect = JSON.parse(x)["redirect"]
     if (typeof redirect === "string") {
       return redirect

--- a/web_ui/src/components/OAuthPage.tsx
+++ b/web_ui/src/components/OAuthPage.tsx
@@ -1,20 +1,8 @@
 import React, { useEffect, useState } from "react"
-import { startLogin, getOauthState } from "../auth"
+import { startLogin, getOauthState, getRedirectPath } from "../auth"
 import { useLocation, useHistory } from "react-router-dom"
 import { Current } from "../world"
 import { Button } from "react-bootstrap"
-
-function getRedirectPath(x: string): string | undefined {
-  try {
-    const redirect = JSON.parse(x)["redirect"]
-    if (typeof redirect === "string") {
-      return redirect
-    }
-  } catch (_) {
-    // pass
-  }
-  return undefined
-}
 
 export function OAuthPage() {
   const location = useLocation()

--- a/web_ui/src/components/OAuthPage.tsx
+++ b/web_ui/src/components/OAuthPage.tsx
@@ -4,6 +4,18 @@ import { useLocation, useHistory } from "react-router-dom"
 import { Current } from "../world"
 import { Button } from "react-bootstrap"
 
+function getRedirectPath(x: string): string | undefined {
+  try {
+    const redirect = JSON.parse(x)["redirect"]
+    if (typeof redirect === "string") {
+      return redirect
+    }
+  } catch (_) {
+    // pass
+  }
+  return undefined
+}
+
 export function OAuthPage() {
   const location = useLocation()
   const history = useHistory()
@@ -16,8 +28,9 @@ export function OAuthPage() {
   useEffect(() => {
     Current.api.loginUser({ code, serverState, clientState }).then(res => {
       if (res.ok) {
-        // navigate to activity page on success.
-        history.push("/")
+        // navigate to redirect path if available, otherwise redirect to root page.
+        const redirectPath = getRedirectPath(clientState) || "/"
+        history.push(redirectPath)
         return
       } else {
         setError(`${res.error} – ${res.error_description}`)

--- a/web_ui/src/world.ts
+++ b/web_ui/src/world.ts
@@ -21,7 +21,8 @@ authRoute.interceptors.response.use(
   err => {
     // tslint:disable-next-line no-unsafe-any
     if (err?.response?.status === 401) {
-      location.pathname = "/login"
+      const redirectPath = location.pathname
+      location.href = `/login?redirect=${redirectPath}`
     }
     return Promise.reject(err)
   },


### PR DESCRIPTION
If a user attempts to access an authenticated page but is not logged in, they are redirected to the login page and are redirected to the root page upon successful authentication.

This change will result in the user being redirected to the page they attempted to access but were missing authentication. For example, if a user attempts to access https://app.kodiakhq.com/t/f8c69022-fcba-42a5-9e85-da3a466e6008/ without authentication, after they login successfully, the will be redirected back to that page!

CHANGES
- add login redirects
- update dev script to use new domain