### PR TITLE
add(docs): links to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 > A GitHub bot to automatically update and merge GitHub PRs
 
+[install app](https://github.com/marketplace/kodiakhq) | [documentation](https://kodiakhq.com/docs/quickstart) | [web dashboard](https://app.kodiakhq.com)
+
 Kodiak automates your GitHub workflow:
 
 - Simple & Configurable — a simple configuration file with smart defaults will get you started in minutes
@@ -19,7 +21,9 @@ Kodiak is available through the GitHub Marketplace.
 
 [![install](https://3c7446e0-cd7f-4e98-a123-1875fcbf3182.s3.amazonaws.com/button-small.svg?v=123)](https://github.com/marketplace/kodiakhq)
 
-If you'd rather run Kodiak yourself, check out the [self hosting page]() in our docs.
+_If you'd rather run Kodiak yourself, check out the [self hosting page](https://kodiakhq.com/docs/self-hosting) in our docs._
+
+View activity via dashboard at <https://app.kodiakhq.com>.
 
 ## [Documentation](https://kodiakhq.com)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Kodiak is available through the GitHub Marketplace.
 
 _If you'd rather run Kodiak yourself, check out the [self hosting page](https://kodiakhq.com/docs/self-hosting) in our docs._
 
-View activity via dashboard at <https://app.kodiakhq.com>.
+View activity via the dashboard at <https://app.kodiakhq.com>.
 
 ## [Documentation](https://kodiakhq.com)
 

--- a/docs/pages/en/index.js
+++ b/docs/pages/en/index.js
@@ -93,7 +93,7 @@ function HomeSplash(props) {
         <PromoSection>
           <Button href="#quickstart">Quick Start</Button>
           <Button href="#why">Why?</Button>
-          <Button href={siteConfig.changeLogUrl}>Changelog</Button>
+          <Button href={siteConfig.dashboardUrl}>Dashboard</Button>
         </PromoSection>
       </div>
     </SplashContainer>

--- a/docs/siteConfig.js
+++ b/docs/siteConfig.js
@@ -13,6 +13,7 @@ const installUrl = "https://github.com/marketplace/kodiakhq#pricing-and-setup"
 const changeLogUrl = "https://github.com/chdsbd/kodiak/releases"
 const issuesUrl = "https://github.com/chdsbd/kodiak/issues/new/choose"
 const editUrl = "https://github.com/chdsbd/kodiak/tree/master/docs/docs/"
+const dashboardUrl = "https://app.kodiakhq.com"
 
 const siteConfig = {
   title: "Kodiak", // Title for your website.
@@ -39,6 +40,7 @@ const siteConfig = {
   installUrl,
   changeLogUrl,
   issuesUrl,
+  dashboardUrl,
 
   editUrl,
 
@@ -53,6 +55,10 @@ const siteConfig = {
     {
       href: repoUrl,
       label: "GitHub",
+    },
+    {
+      href: dashboardUrl,
+      label: "Dashboard",
     },
     {
       href: installUrl,


### PR DESCRIPTION
Now that the dashboard is deployed at https://app.kodiakhq.com we should link to it!