### PR TITLE
fix(web_ui): page loading states having scroll bars

### DIFF
--- a/web_ui/src/components/ActivityPage.tsx
+++ b/web_ui/src/components/ActivityPage.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { Container } from "react-bootstrap"
 import { WebData } from "../webdata"
 import { Spinner } from "./Spinner"
 import { PullRequestActivityChart, KodiakActivityChart } from "./ActivityChart"

--- a/web_ui/src/components/ActivityPage.tsx
+++ b/web_ui/src/components/ActivityPage.tsx
@@ -38,7 +38,7 @@ interface IActivityPageInnerProps {
 function ActivityPageInner({ data }: IActivityPageInnerProps) {
   if (data.status === "loading") {
     return (
-      <ActivityPageContainer className="h-100">
+      <ActivityPageContainer>
         <Spinner />
       </ActivityPageContainer>
     )
@@ -63,16 +63,12 @@ function ActivityPageInner({ data }: IActivityPageInnerProps) {
 
 interface IActivityPageContainer {
   readonly children: React.ReactNode
-  readonly className?: string
 }
-function ActivityPageContainer({
-  children,
-  className,
-}: IActivityPageContainer) {
+function ActivityPageContainer({ children }: IActivityPageContainer) {
   return (
-    <Container className={className}>
+    <div className="flex-grow-1 d-flex flex-column">
       <h2>Activity</h2>
       {children}
-    </Container>
+    </div>
   )
 }

--- a/web_ui/src/components/Page.tsx
+++ b/web_ui/src/components/Page.tsx
@@ -14,7 +14,9 @@ export function Page({ children }: IPageProps) {
           <SideBarNav />
         </div>
         <ErrorBoundary>
-          <Container className="p-4 w-100 overflow-auto">{children}</Container>
+          <Container className="p-4 w-100 overflow-auto d-flex">
+            {children}
+          </Container>
         </ErrorBoundary>
       </div>
     </div>

--- a/web_ui/src/components/UsageBillingPage.tsx
+++ b/web_ui/src/components/UsageBillingPage.tsx
@@ -47,7 +47,7 @@ interface IUsageBillingPageInnerProps {
 
 function Loading() {
   return (
-    <UsageAndBillingContainer className="h-100">
+    <UsageAndBillingContainer>
       <Spinner />
     </UsageAndBillingContainer>
   )
@@ -61,15 +61,9 @@ function Failure() {
   )
 }
 
-function UsageAndBillingContainer({
-  children,
-  className,
-}: {
-  children: React.ReactNode
-  className?: string
-}) {
+function UsageAndBillingContainer({ children }: { children: React.ReactNode }) {
   return (
-    <div className={className}>
+    <div className="d-flex flex-column flex-grow-1">
       <h2>Usage & Billing</h2>
       {children}
     </div>


### PR DESCRIPTION
Our mix of `h-100` on the containers and their parents results in scroll
bars on the loading states for the pages.

Some css changes to remove the scroll bars and center the loading spinner
in the center of the page.