### PR TITLE
fix(web_ui): chart label date offsets

### DIFF
--- a/web_ui/src/components/ActivityChart.tsx
+++ b/web_ui/src/components/ActivityChart.tsx
@@ -3,6 +3,7 @@ import { Bar } from "react-chartjs-2"
 import { ChartOptions } from "chart.js"
 import format from "date-fns/format"
 import sub from "date-fns/sub"
+import parseISO from 'date-fns/parseISO'
 
 const TODAY = new Date()
 const ONE_MONTH_AGO = sub(new Date(), { months: 1 })
@@ -41,7 +42,7 @@ const chartOptions: ChartOptions = {
         if (label == null) {
           return "unknown"
         }
-        const date = new Date(label)
+        const date = parseISO(label)
         return format(date, "MMM do")
       },
     },
@@ -169,7 +170,7 @@ const chartOptionsTotal: ChartOptions = {
         if (label == null) {
           return "unknown"
         }
-        const date = new Date(label)
+        const date = parseISO(label)
         return format(date, "MMM do")
       },
     },


### PR DESCRIPTION
Our chart labels were being offset by one day because of how we were parsing the date strings. Parsing "2020-03-07" via `new Date()` gives us a date with an offset from UTC, effectively showing "2020-03-06". Using `parseISO` gives the correct behavior of giving the same "2020-03-07" in the current user's timezone.