### PR TITLE
fix(web_ui): accounts layout to have even spacing

### DIFF
--- a/web_ui/src/components/AccountsPage.tsx
+++ b/web_ui/src/components/AccountsPage.tsx
@@ -72,7 +72,7 @@ function AccountsPageInner({
             <li className="d-flex align-items-center">
               <NavLink
                 to={`/t/${a.id}/`}
-                className="d-flex align-items-center px-4 py-2 border border-dark rounded text-decoration-none account-chooser-image">
+                className="d-flex align-items-center flex-grow-1 mb-2 px-4 py-2 border border-dark rounded text-decoration-none account-chooser-image">
                 <Image
                   url={a.profileImgUrl}
                   alt="org profile"


### PR DESCRIPTION
The accounts links now have spacing between items and have even width.

before
<img width="832" alt="image" src="https://user-images.githubusercontent.com/1929960/76173141-0a4a5b80-6173-11ea-895f-005f4b520f57.png">

after
<img width="832" alt="image" src="https://user-images.githubusercontent.com/1929960/76173130-f0a91400-6172-11ea-852b-0222cf796fd9.png">
