### PR TITLE
add(bot): merge message option to include pull request URL

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -41,6 +41,7 @@ class MergeMessage(BaseModel):
     body_type: BodyText = BodyText.markdown
     strip_html_comments: bool = False
     include_pull_request_author: bool = False
+    include_pr_url: bool = False
 
 
 class Merge(BaseModel):

--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -41,7 +41,7 @@ class MergeMessage(BaseModel):
     body_type: BodyText = BodyText.markdown
     strip_html_comments: bool = False
     include_pull_request_author: bool = False
-    include_pr_url: bool = False
+    include_pull_request_url: bool = False
 
 
 class Merge(BaseModel):

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -78,6 +78,11 @@ def get_merge_body(config: V1, pull_request: PullRequest) -> MergeBody:
         merge_body.commit_title = pull_request.title
     if config.merge.message.include_pr_number and merge_body.commit_title is not None:
         merge_body.commit_title += f" (#{pull_request.number})"
+    if config.merge.message.include_pr_url:
+        if merge_body.commit_message is None:
+            merge_body.commit_message = pull_request.url
+        else:
+            merge_body.commit_message += "\n" + pull_request.url
     if config.merge.message.include_pull_request_author:
         commit_message = (
             merge_body.commit_message if merge_body.commit_message is not None else ""

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -78,11 +78,11 @@ def get_merge_body(config: V1, pull_request: PullRequest) -> MergeBody:
         merge_body.commit_title = pull_request.title
     if config.merge.message.include_pr_number and merge_body.commit_title is not None:
         merge_body.commit_title += f" (#{pull_request.number})"
-    if config.merge.message.include_pr_url:
+    if config.merge.message.include_pull_request_url:
         if merge_body.commit_message is None:
             merge_body.commit_message = pull_request.url
         else:
-            merge_body.commit_message += "\n" + pull_request.url
+            merge_body.commit_message += "\n\n" + pull_request.url
     if config.merge.message.include_pull_request_author:
         commit_message = (
             merge_body.commit_message if merge_body.commit_message is not None else ""

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -114,6 +114,7 @@ query GetEventInfo($owner: String!, $repo: String!, $rootConfigFileExpression: S
       body
       bodyText
       bodyHTML
+      url
       reviews(first: 100) {
         nodes {
           createdAt
@@ -242,6 +243,7 @@ class PullRequest(BaseModel):
     latest_sha: str
     baseRefName: str
     headRefName: str
+    url: str
 
 
 @dataclass

--- a/bot/kodiak/test/fixtures/api/get_event/behind.json
+++ b/bot/kodiak/test/fixtures/api/get_event/behind.json
@@ -64,6 +64,7 @@
         "body": "",
         "bodyText": "",
         "bodyHTML": "",
+        "url": "",
         "reviews": {
           "nodes": [
             {

--- a/bot/kodiak/test/fixtures/api/get_event/behind.json
+++ b/bot/kodiak/test/fixtures/api/get_event/behind.json
@@ -64,7 +64,7 @@
         "body": "",
         "bodyText": "",
         "bodyHTML": "",
-        "url": "",
+        "url": "https://github.com/delos-corp/hive-mind/pull/324",
         "reviews": {
           "nodes": [
             {

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -28,7 +28,8 @@
           "include_pr_number": true,
           "body_type": "markdown",
           "strip_html_comments": false,
-          "include_pull_request_author": false
+          "include_pull_request_author": false,
+          "include_pr_url": false
         },
         "dont_wait_on_status_checks": [],
         "update_branch_immediately": false,
@@ -114,6 +115,11 @@
           "title": "Include Pull Request Author",
           "default": false,
           "type": "boolean"
+        },
+        "include_pr_url": {
+          "title": "Include Pr Url",
+          "default": false,
+          "type": "boolean"
         }
       }
     },
@@ -182,7 +188,8 @@
             "include_pr_number": true,
             "body_type": "markdown",
             "strip_html_comments": false,
-            "include_pull_request_author": false
+            "include_pull_request_author": false,
+            "include_pr_url": false
           },
           "allOf": [
             {

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -29,7 +29,7 @@
           "body_type": "markdown",
           "strip_html_comments": false,
           "include_pull_request_author": false,
-          "include_pr_url": false
+          "include_pull_request_url": false
         },
         "dont_wait_on_status_checks": [],
         "update_branch_immediately": false,
@@ -116,8 +116,8 @@
           "default": false,
           "type": "boolean"
         },
-        "include_pr_url": {
-          "title": "Include Pr Url",
+        "include_pull_request_url": {
+          "title": "Include Pull Request Url",
           "default": false,
           "type": "boolean"
         }
@@ -189,7 +189,7 @@
             "body_type": "markdown",
             "strip_html_comments": false,
             "include_pull_request_author": false,
-            "include_pr_url": false
+            "include_pull_request_url": false
           },
           "allOf": [
             {

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -3478,7 +3478,7 @@ def test_get_merge_body_includes_pull_request_url(pull_request: PullRequest) -> 
             merge=Merge(
                 method=MergeMethod.squash,
                 message=MergeMessage(
-                    body=MergeBodyStyle.pull_request_body, include_pr_url=True
+                    body=MergeBodyStyle.pull_request_body, include_pull_request_url=True
                 ),
             ),
         ),
@@ -3486,7 +3486,42 @@ def test_get_merge_body_includes_pull_request_url(pull_request: PullRequest) -> 
     )
     expected = MergeBody(
         merge_method="squash",
-        commit_message="# some description\nhttps://github.com/example_org/example_repo/pull/65",
+        commit_message="""\
+# some description
+
+https://github.com/example_org/example_repo/pull/65""",
+    )
+    assert actual == expected
+
+
+def test_get_merge_body_includes_pull_request_url_with_coauthor(
+    pull_request: PullRequest
+) -> None:
+    """
+    Coauthor should appear after the pull request url
+    """
+    actual = get_merge_body(
+        V1(
+            version=1,
+            merge=Merge(
+                method=MergeMethod.squash,
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body,
+                    include_pull_request_url=True,
+                    include_pull_request_author=True,
+                ),
+            ),
+        ),
+        pull_request,
+    )
+    expected = MergeBody(
+        merge_method="squash",
+        commit_message="""\
+# some description
+
+https://github.com/example_org/example_repo/pull/65
+
+Co-authored-by: Barry Berkman <828352+barry@users.noreply.github.com>""",
     )
     assert actual == expected
 

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -246,6 +246,7 @@ def pull_request() -> PullRequest:
         body="# some description",
         bodyText="some description",
         bodyHTML="<h1>some description</h1>",
+        url="https://github.com/example_org/example_repo/pull/65",
     )
 
 
@@ -3463,6 +3464,30 @@ def test_get_merge_body_empty(pull_request: PullRequest) -> None:
         pull_request,
     )
     expected = MergeBody(merge_method="squash", commit_message="")
+    assert actual == expected
+
+
+def test_get_merge_body_includes_pull_request_url(pull_request: PullRequest) -> None:
+    """
+    Ensure that when the appropriate config option is set, we include the
+    pull request url in the commit message.
+    """
+    actual = get_merge_body(
+        V1(
+            version=1,
+            merge=Merge(
+                method=MergeMethod.squash,
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body, include_pr_url=True
+                ),
+            ),
+        ),
+        pull_request,
+    )
+    expected = MergeBody(
+        merge_method="squash",
+        commit_message="# some description\nhttps://github.com/example_org/example_repo/pull/65",
+    )
     assert actual == expected
 
 

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -98,6 +98,7 @@ def block_event() -> EventInfoResponse:
         body="",
         bodyText="",
         bodyHTML="",
+        url="",
     )
     rep_info = RepoInfo(
         merge_commit_allowed=False,

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -98,7 +98,7 @@ def block_event() -> EventInfoResponse:
         body="",
         bodyText="",
         bodyHTML="",
-        url="",
+        url="https://github.com/delos-corp/hive-mind/pull/324",
     )
     rep_info = RepoInfo(
         merge_commit_allowed=False,


### PR DESCRIPTION
When enabled, should make it easier to click back to the pull request
the commit came from.