### PR TITLE
update(docs): include_pull_request_author w/ github revert info

### DIFF
--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -232,8 +232,8 @@ Add the pull request author as a coauthor of the merge commit using `Co-authored
 This setting will override `merge.message.body = "github_default"` and `merge.message.body = "empty"`. In both cases, the commit message will only contain coauthor information.
 
 This setting was added to mitigate the fallout of GitHub's change to the
-squash method on March 4th, 2020. This change was reverted around March 6th,
-2020, making this option no longer necessary.
+squash method on March 4th, 2020. GitHub reverted their change around
+March 6th, 2020, making this option no longer necessary.
 
 ### `update.always`
 
@@ -402,8 +402,8 @@ title = "github_default" # default: "github_default", options: "github_default",
 body = "github_default" # default: "github_default", options: "github_default", "pull_request_body", "empty"
 
 # Option to mitigate the fallout of GitHub's change to the
-# squash method on March 4th, 2020. This change was reverted around March 6th,
-# 2020, making this option no longer necessary.
+# squash method on March 4th, 2020. GitHub reverted their change around
+# March 6th, 2020, making this option no longer necessary.
 include_pull_request_author = false # default: false
 
 # Add the PR number to the merge commit title. This setting replicates GitHub's

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -231,7 +231,9 @@ Add the pull request author as a coauthor of the merge commit using `Co-authored
 
 This setting will override `merge.message.body = "github_default"` and `merge.message.body = "empty"`. In both cases, the commit message will only contain coauthor information.
 
-This setting is useful when GitHub strips authorship information for squashes.
+This setting was added to mitigate the fallout of GitHub's change to the
+squash method on March 4th, 2020. This change was reverted around March 6th,
+2020, making this option no longer necessary.
 
 ### `update.always`
 
@@ -398,6 +400,10 @@ title = "github_default" # default: "github_default", options: "github_default",
 # content of the PR to generate the body content while `"empty"` sets an empty
 # body.
 body = "github_default" # default: "github_default", options: "github_default", "pull_request_body", "empty"
+
+# Option to mitigate the fallout of GitHub's change to the
+# squash method on March 4th, 2020. This change was reverted around March 6th,
+# 2020, making this option no longer necessary.
 include_pull_request_author = false # default: false
 
 # Add the PR number to the merge commit title. This setting replicates GitHub's

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -52,7 +52,6 @@ delete_branch_on_merge = true # default: false
 [merge.message]
 title = "pull_request_title" # default: "github_default"
 body = "pull_request_body" # default: "github_default"
-include_pull_request_author = true # default: false
 ```
 
 ## Efficiency and Speed


### PR DESCRIPTION
`include_pull_request_author` was added to mitigate the fallout of GitHub's
change to how they process squashing of PRs. GitHub reverted that change
a couple days later so updating the docs to note how this option isn't
necessary anymore.