### PR TITLE
update(bot): config schema test failure message to be helpful

### DIFF
--- a/bot/kodiak/test_config.py
+++ b/bot/kodiak/test_config.py
@@ -112,10 +112,18 @@ def test_config_parsing_opposite(config_fixture_name: str, expected_config: V1) 
 
 
 def test_config_schema() -> None:
+    """
+    Although we don't use the config schema anywhere, it provides a form of
+    documentation for the bot config.
+    """
     schema_path = load_config_fixture("config-schema.json")
     assert json.loads(V1.schema_json()) == json.loads(
         schema_path.read_text()
-    ), "schema shouldn't change unexpectedly."
+    ), (
+        "schema shouldn't change unexpectedly.\n"
+        "Did you remember to run `poetry run kodiak gen-conf-json-schema > kodiak/test/fixtures/config/config-schema.json` in the `bot` directory?"
+    )
+
 
 
 def test_bad_file() -> None:

--- a/bot/kodiak/test_config.py
+++ b/bot/kodiak/test_config.py
@@ -117,13 +117,10 @@ def test_config_schema() -> None:
     documentation for the bot config.
     """
     schema_path = load_config_fixture("config-schema.json")
-    assert json.loads(V1.schema_json()) == json.loads(
-        schema_path.read_text()
-    ), (
+    assert json.loads(V1.schema_json()) == json.loads(schema_path.read_text()), (
         "schema shouldn't change unexpectedly.\n"
         "Did you remember to run `poetry run kodiak gen-conf-json-schema > kodiak/test/fixtures/config/config-schema.json` in the `bot` directory?"
     )
-
 
 
 def test_bad_file() -> None:


### PR DESCRIPTION
Previously we didn't offer any tips to update the schema. Ideally we'd
have some sort of snapshot setup, but what we have works for the most
part.

Before we just said the schema shouldn't change on error, now we provide
the command to update the schema.

The error:

```
============================================== FAILURES ===============================================
_________________________________________ test_config_schema __________________________________________

    def test_config_schema() -> None:
        """
        Although we don't use the config schema anywhere, it provides a form of
        documentation for the bot config.
        """
        schema_path = load_config_fixture("config-schema.json")
>       assert json.loads(V1.schema_json()) == json.loads(
            schema_path.read_text()
        ), (
            "schema shouldn't change unexpectedly.\n"
            "Did you remember to run `poetry run kodiak gen-conf-json-schema > kodiak/test/fixtures/config/config-schema.json` in the `bot` directory?"
        )
E       AssertionError: schema shouldn't change unexpectedly.
E         Did you remember to run `poetry run kodiak gen-conf-json-schema > kodiak/test/fixtures/config/config-schema.json` in the `bot` directory?
E       assert {'definitions...e': 'V1', ...} == {'definitions'...e': 'V1', ...}
E         Omitting 4 identical items, use -vv to show
E         Differing items:
E         {'properties': {'app_id': {'title': 'App Id', 'type': 'string'}, 'approve': {'allOf': [{'$ref': '#/definitions/Approve...st_labels': [], 'blacklist_title_regex': '^WIP:.*', 'block_on_reviews_requested': False, ...}, 'title': 'Merge'}, ...}} != {'properties': {'app_id': {'title': 'App Id', 'type': 'string'}, 'approve': {'allOf': [{'$ref': '#/definitions/Approve...ef': '#/definitions/Update'}], 'default': {'always': False, 'require_automerge_label': True}, 'title': 'Update'}, ...}}
E         Use -v to get the full diff

kodiak/test_config.py:120: AssertionError
================================ 1 failed, 130 passed in 2.22 seconds =================================
```

rel: https://github.com/chdsbd/kodiak/pull/327