### PR TITLE
update(tools): remove `include_pull_request_author` flag from kodiak cfg

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -7,4 +7,3 @@ delete_branch_on_merge = true
 [merge.message]
 title = "pull_request_title"
 body = "pull_request_body"
-include_pull_request_author = true


### PR DESCRIPTION
GitHub fixed the issue with PR attribution a few days after releasing
the change so we no longer need this.