### PR TITLE
update(deploy): dashboard playbook to install both versions of pip

### DIFF
--- a/infrastructure/playbooks/dashboard-deploy.yml
+++ b/infrastructure/playbooks/dashboard-deploy.yml
@@ -14,6 +14,12 @@
         name: python-pip
         state: present
 
+    - name: install pip3
+      become: true
+      apt:
+        name: python3-pip
+        state: present
+
     - name: install postgres
       become: true
       apt:


### PR DESCRIPTION
We're running different Ubuntu versions for different environments, some
are using pip3, others pip.

Now we install both so deploy will hopefully "just work".