### PR TITLE
add: better messaging for api call failures

### DIFF
--- a/bot/kodiak/errors.py
+++ b/bot/kodiak/errors.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+
 class RetryForSkippableChecks(Exception):
     pass
 
@@ -7,5 +10,6 @@ class PollForever(Exception):
 
 
 class ApiCallException(Exception):
-    def __init__(self, method: str) -> None:
+    def __init__(self, method: str, description: Optional[str] = None) -> None:
         self.method = method
+        self.description = description

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -259,12 +259,12 @@ async def mergeable(
     if api_call_retry_timeout == 0:
         log.warning("timeout reached for api calls to GitHub")
         if api_call_retry_message is not None:
-            msg = f"⚠️ problem contacting GitHub API: {api_call_retry_message.message!r}"
+            msg = (
+                f"⚠️ problem contacting GitHub API: {api_call_retry_message.message!r}"
+            )
             if api_call_retry_message.description:
                 msg += f" ({api_call_retry_message.description})"
-            await set_status(
-                msg
-            )
+            await set_status(msg)
         else:
             await set_status("⚠️ problem contacting GitHub API")
         return

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Awaitable, Callable, Optional
+from json import JSONDecodeError
+from typing import Awaitable, Callable, Optional, Type
 
 import structlog
-from requests_async import HTTPError
+from requests_async import HTTPError, Response
 
 import kodiak.app_config as conf
 from kodiak.errors import ApiCallException, PollForever, RetryForSkippableChecks
-from kodiak.evaluation import mergeable
+from kodiak.evaluation import ApiErrorMessage, mergeable
 from kodiak.queries import Client, EventInfoResponse
 
 logger = structlog.get_logger()
@@ -61,7 +62,7 @@ async def evaluate_pr(
 ) -> None:
     skippable_check_timeout = 4
     api_call_retry_timeout = 5
-    api_call_retry_method_name: Optional[str] = None
+    api_call_retry_message: Optional[ApiErrorMessage] = None
     log = logger.bind(install=install, owner=owner, repo=repo, number=number)
     while True:
         log.info("get_pr")
@@ -95,7 +96,7 @@ async def evaluate_pr(
                 is_active_merge=is_active_merging,
                 skippable_check_timeout=skippable_check_timeout,
                 api_call_retry_timeout=api_call_retry_timeout,
-                api_call_retry_method_name=api_call_retry_method_name,
+                api_call_retry_message=api_call_retry_message,
             )
             log.info("evaluate_pr successful")
         except RetryForSkippableChecks:
@@ -112,12 +113,25 @@ async def evaluate_pr(
             # if we have some api exception, it's likely a temporary error that
             # can be resolved by calling GitHub again.
             if api_call_retry_timeout:
-                api_call_retry_method_name = e.method
+                api_call_retry_message = ApiErrorMessage(
+                    message=e.method, description=e.description
+                )
                 api_call_retry_timeout -= 1
                 log.info("problem contacting remote api. retrying")
                 continue
             log.exception("api_call_retry_timeout")
         return
+
+
+def get_key_from_response(response: Response, key: str) -> Optional[str]:
+    try:
+        res_dict = response.json()
+    except JSONDecodeError:
+        return None
+    val = res_dict.get(key)
+    if val is None:
+        return None
+    return str(val)
 
 
 class PRV2:
@@ -138,6 +152,7 @@ class PRV2:
         number: int,
         dequeue_callback: Callable[[], Awaitable],
         queue_for_merge_callback: Callable[[], Awaitable[Optional[int]]],
+        client: Optional[Type[Client]] = None,
     ):
         self.install = install
         self.owner = owner
@@ -147,6 +162,7 @@ class PRV2:
         self.dequeue_callback = dequeue_callback
         self.queue_for_merge_callback = queue_for_merge_callback
         self.log = logger.bind(install=install, owner=owner, repo=repo, number=number)
+        self.client = client or Client
 
     async def dequeue(self) -> None:
         self.log.info("dequeue")
@@ -167,7 +183,7 @@ class PRV2:
         alongside the summary/detail content.
         """
         self.log.info("set_status", message=msg, markdown_content=markdown_content)
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             res = await api_client.create_notification(
@@ -183,7 +199,7 @@ class PRV2:
     async def pull_requests_for_ref(self, ref: str) -> Optional[int]:
         log = self.log.bind(ref=ref)
         log.info("pull_requests_for_ref", ref=ref)
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             prs = await api_client.get_open_pull_requests(base=ref)
@@ -195,7 +211,7 @@ class PRV2:
 
     async def delete_branch(self, branch_name: str) -> None:
         self.log.info("delete_branch", branch_name=branch_name)
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             res = await api_client.delete_branch(branch=branch_name)
@@ -209,7 +225,7 @@ class PRV2:
 
     async def update_branch(self) -> None:
         self.log.info("update_branch")
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             res = await api_client.update_branch(pull_number=self.number)
@@ -218,11 +234,11 @@ class PRV2:
             except HTTPError:
                 self.log.exception("failed to update branch", res=res)
                 # we raise an exception to retry this request.
-                raise ApiCallException("update branch")
+                raise ApiCallException("update branch failed")
 
     async def approve_pull_request(self) -> None:
         self.log.info("approve_pull_request")
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             res = await api_client.approve_pull_request(pull_number=self.number)
@@ -233,7 +249,7 @@ class PRV2:
 
     async def trigger_test_commit(self) -> None:
         self.log.info("trigger_test_commit")
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             res = await api_client.get_pull_request(number=self.number)
@@ -251,7 +267,7 @@ class PRV2:
         commit_message: Optional[str],
     ) -> None:
         self.log.info("merge", method=merge_method)
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             res = await api_client.merge_pull_request(
@@ -263,6 +279,10 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError as e:
+                if e.response is not None:
+                    description = get_key_from_response(e.response, key="message")
+                else:
+                    description = None
                 if e.response is not None and e.response.status_code == 405:
                     self.log.info(
                         "branch is not mergeable. PR likely already merged.", res=res
@@ -270,7 +290,9 @@ class PRV2:
                 else:
                     self.log.exception("failed to merge pull request", res=res)
                 # we raise an exception to retry this request.
-                raise ApiCallException("merge")
+                raise ApiCallException(
+                    "merge pull request failed", description=description
+                )
 
     async def queue_for_merge(self) -> Optional[int]:
         self.log.info("queue_for_merge")
@@ -281,7 +303,7 @@ class PRV2:
         remove the PR label specified by `label_id` for a given `pr_number`
         """
         self.log.info("remove_label", label=label)
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             res = await api_client.delete_label(label, pull_number=self.number)
@@ -290,14 +312,14 @@ class PRV2:
             except HTTPError:
                 self.log.exception("failed to delete label", label=label, res=res)
                 # we raise an exception to retry this request.
-                raise ApiCallException("delete label")
+                raise ApiCallException("delete label failed")
 
     async def create_comment(self, body: str) -> None:
         """
        create a comment on the specified `pr_number` with the given `body` as text.
         """
         self.log.info("create_comment", body=body)
-        async with Client(
+        async with self.client(
             installation_id=self.install, owner=self.owner, repo=self.repo
         ) as api_client:
             res = await api_client.create_comment(body=body, pull_number=self.number)

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -14,7 +14,13 @@ from kodiak.config import (
     MergeTitleStyle,
 )
 from kodiak.errors import PollForever, RetryForSkippableChecks
-from kodiak.evaluation import PRAPI, MergeBody, get_merge_body, mergeable
+from kodiak.evaluation import (
+    PRAPI,
+    ApiErrorMessage,
+    MergeBody,
+    get_merge_body,
+    mergeable,
+)
 from kodiak.queries import (
     BranchProtectionRule,
     CheckConclusionState,
@@ -324,7 +330,7 @@ async def test_mergeable_abort_is_active_merge(
         merging=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         is_active_merge=True,
     )
@@ -368,7 +374,7 @@ async def test_mergeable_config_error_sets_warning(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         config=broken_config,
         config_str=broken_config_str,
@@ -417,7 +423,7 @@ async def test_mergeable_different_app_id(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         app_id=our_fake_app_id,
     )
@@ -460,7 +466,7 @@ async def test_mergeable_missing_branch_protection(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         branch_protection=None,
     )
@@ -510,7 +516,7 @@ async def test_mergeable_requires_commit_signatures(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             valid_merge_methods=[method],
         )
@@ -563,7 +569,7 @@ async def test_mergeable_requires_commit_signatures_with_merge_commits(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         valid_merge_methods=[MergeMethod.merge],
     )
@@ -611,7 +617,7 @@ async def test_mergeable_missing_automerge_label(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -657,7 +663,7 @@ async def test_mergeable_missing_automerge_label_require_automerge_label(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 0
@@ -703,7 +709,7 @@ async def test_mergeable_has_blacklist_labels(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -750,7 +756,7 @@ async def test_mergeable_blacklist_title_regex(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -802,7 +808,7 @@ async def test_mergeable_blacklist_title_match_with_exp_regex(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     # we don't really care about the result for this so long as this test
     # doesn't hang the entire suite.
@@ -842,7 +848,7 @@ async def test_mergeable_draft_pull_request(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -888,7 +894,7 @@ async def test_mergeable_invalid_merge_method(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         valid_merge_methods=[MergeMethod.merge],
     )
@@ -941,7 +947,7 @@ async def test_mergeable_block_on_reviews_requested(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -992,7 +998,7 @@ async def test_mergeable_pull_request_merged_no_delete_branch(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 1
@@ -1042,7 +1048,7 @@ async def test_mergeable_pull_request_merged_delete_branch(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 1
@@ -1094,7 +1100,7 @@ async def test_mergeable_pull_request_merged_delete_branch_with_branch_dependenc
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 1
@@ -1147,7 +1153,7 @@ async def test_mergeable_pull_request_merged_delete_branch_cross_repo_pr(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 1
@@ -1193,7 +1199,7 @@ async def test_mergeable_pull_request_closed(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 1
@@ -1241,7 +1247,7 @@ async def test_mergeable_pull_request_merge_conflict(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -1294,7 +1300,7 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -1348,7 +1354,7 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_missing_
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.create_comment.call_count == 0
 
@@ -1395,7 +1401,7 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_no_requi
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -1446,7 +1452,7 @@ async def test_mergeable_pull_request_need_test_commit(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 0
     assert api.dequeue.call_count == 0
@@ -1495,7 +1501,7 @@ async def test_mergeable_missing_required_approving_reviews(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -1545,7 +1551,7 @@ async def test_mergeable_missing_required_approving_reviews_has_review_with_miss
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -1595,7 +1601,7 @@ async def test_mergeable_missing_required_approving_reviews_changes_requested(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -1645,7 +1651,7 @@ async def test_mergeable_missing_required_approving_reviews_missing_approving_re
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 1
@@ -1694,7 +1700,7 @@ async def test_mergeable_missing_requires_status_checks_failing_status_context(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         check_runs=[],
     )
@@ -1748,7 +1754,7 @@ async def test_mergeable_missing_requires_status_checks_failing_check_run(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         contexts=[],
     )
@@ -1802,7 +1808,7 @@ async def test_mergeable_travis_ci_checks(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         check_runs=[],
     )
@@ -1859,7 +1865,7 @@ async def test_mergeable_travis_ci_checks_success(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             merging=True,
             check_runs=[],
@@ -1918,7 +1924,7 @@ async def test_mergeable_skippable_contexts_with_status_check(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 0
@@ -1974,7 +1980,7 @@ async def test_mergeable_skippable_contexts_with_check_run(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 0
@@ -2031,7 +2037,7 @@ async def test_mergeable_skippable_contexts_passing(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 0
@@ -2084,7 +2090,7 @@ async def test_mergeable_skippable_contexts_merging_pull_request(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             merging=True,
         )
@@ -2137,7 +2143,7 @@ async def test_mergeable_update_branch_immediately(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert api.dequeue.call_count == 0
@@ -2190,7 +2196,7 @@ async def test_mergeable_optimistic_update_need_branch_update(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             merging=True,
         )
@@ -2244,7 +2250,7 @@ async def test_mergeable_need_branch_update(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             merging=True,
         )
@@ -2302,7 +2308,7 @@ async def test_mergeable_queue_in_progress(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "enqueued for merge" in api.set_status.calls[0]["msg"]
@@ -2362,7 +2368,7 @@ async def test_mergeable_queue_in_progress_with_ready_to_merge(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "enqueued for merge" in api.set_status.calls[0]["msg"]
@@ -2414,7 +2420,7 @@ async def test_mergeable_optimistic_update_wait_for_checks(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             merging=True,
         )
@@ -2467,7 +2473,7 @@ async def test_mergeable_wait_for_checks(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             merging=True,
         )
@@ -2515,7 +2521,7 @@ async def test_mergeable_unknown_merge_blockage(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
 
     assert api.set_status.call_count == 1
@@ -2561,7 +2567,7 @@ async def test_mergeable_prioritize_ready_to_merge(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
 
     assert api.set_status.call_count == 1
@@ -2606,7 +2612,7 @@ async def test_mergeable_merge(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         merging=True,
     )
@@ -2652,7 +2658,7 @@ async def test_mergeable_queue_for_merge_no_position(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
 
     assert api.set_status.call_count == 0
@@ -2695,7 +2701,7 @@ async def test_mergeable_passing(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "enqueued for merge (position=4th)" in api.set_status.calls[0]["msg"]
@@ -2737,7 +2743,7 @@ async def test_mergeable_need_update(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "enqueued for merge (position=4th)" in api.set_status.calls[0]["msg"]
@@ -2802,7 +2808,7 @@ async def test_regression_mishandling_multiple_reviews_failing_reviews(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "changes requested" in api.set_status.calls[0]["msg"]
@@ -2873,7 +2879,7 @@ async def test_regression_mishandling_multiple_reviews_okay_reviews(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "enqueued for merge (position=" in api.set_status.calls[0]["msg"]
@@ -2938,7 +2944,7 @@ async def test_regression_mishandling_multiple_reviews_okay_dismissed_reviews(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "enqueued for merge (position=" in api.set_status.calls[0]["msg"]
@@ -2998,7 +3004,7 @@ async def test_regression_mishandling_multiple_reviews_okay_non_member_reviews(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "enqueued for merge (position=" in api.set_status.calls[0]["msg"]
@@ -3043,7 +3049,7 @@ async def test_mergeable_do_not_merge(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.called is True
     assert "okay to merge" in api.set_status.calls[0]["msg"]
@@ -3091,7 +3097,7 @@ async def test_mergeable_do_not_merge_behind_no_update_immediately(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.called is True
     assert (
@@ -3141,7 +3147,7 @@ async def test_mergeable_do_not_merge_with_update_branch_immediately_no_update(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.called is True
     assert "okay to merge" in api.set_status.calls[0]["msg"]
@@ -3193,7 +3199,7 @@ async def test_mergeable_do_not_merge_with_update_branch_immediately_waiting_for
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.called is True
     assert (
@@ -3243,7 +3249,7 @@ async def test_mergeable_do_not_merge_with_update_branch_immediately_need_update
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
 
     assert api.update_branch.called is True
@@ -3286,12 +3292,12 @@ async def test_mergeable_api_call_retry_timeout(
         skippable_check_timeout=5,
         #
         api_call_retry_timeout=0,
-        api_call_retry_method_name="update branch",
+        api_call_retry_message=ApiErrorMessage("failed to update branch"),
     )
 
     assert api.set_status.called is True
     assert (
-        "problem contacting GitHub API with method 'update branch'"
+        "problem contacting GitHub API: 'failed to update branch'"
         in api.set_status.calls[0]["msg"]
     )
     assert api.update_branch.called is False
@@ -3335,7 +3341,7 @@ async def test_mergeable_api_call_retry_timeout_missing_method(
         skippable_check_timeout=5,
         #
         api_call_retry_timeout=0,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
 
     assert api.set_status.called is True
@@ -3385,7 +3391,7 @@ async def test_mergeable_skippable_check_timeout(
         valid_merge_methods=[MergeMethod.squash],
         is_active_merge=False,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         merging=True,
         skippable_check_timeout=0,
@@ -3649,7 +3655,7 @@ async def test_mergeable_update_username_blacklist(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.update_branch.call_count == 0
     assert api.set_status.call_count == 1
@@ -3706,7 +3712,7 @@ async def test_mergeable_update_username_blacklist_merging(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             merging=True,
         )
@@ -3760,7 +3766,7 @@ async def test_mergeable_update_always(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.update_branch.call_count == 1
     assert api.set_status.call_count == 1
@@ -3815,7 +3821,7 @@ async def test_mergeable_update_always_require_automerge_label_missing_label(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.update_branch.call_count == 0
 
@@ -3870,7 +3876,7 @@ async def test_mergeable_update_always_no_require_automerge_label_missing_label(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.update_branch.call_count == 1
     assert api.set_status.call_count == 1
@@ -3917,7 +3923,7 @@ async def test_mergeable_passing_update_always_enabled(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.set_status.call_count == 1
     assert "enqueued for merge (position=4th)" in api.set_status.calls[0]["msg"]
@@ -3965,7 +3971,7 @@ async def test_mergeable_update_always_enabled_merging_behind_pull_request(
             is_active_merge=False,
             skippable_check_timeout=5,
             api_call_retry_timeout=5,
-            api_call_retry_method_name=None,
+            api_call_retry_message=None,
             #
             merging=True,
         )
@@ -4011,7 +4017,7 @@ async def test_mergeable_auto_approve(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         reviews=[],
     )
@@ -4063,7 +4069,7 @@ async def test_mergeable_auto_approve_existing_approval(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.approve_pull_request.call_count == 0
     assert api.set_status.call_count == 1
@@ -4113,7 +4119,7 @@ async def test_mergeable_auto_approve_old_approval(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
     )
     assert api.approve_pull_request.call_count == 1
     assert api.set_status.call_count == 1
@@ -4164,7 +4170,7 @@ async def test_mergeable_auto_approve_ignore_closed_merged_prs(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         reviews=[],
     )
@@ -4214,7 +4220,7 @@ async def test_mergeable_auto_approve_ignore_draft_pr(
         is_active_merge=False,
         skippable_check_timeout=5,
         api_call_retry_timeout=5,
-        api_call_retry_method_name=None,
+        api_call_retry_message=None,
         #
         reviews=[],
     )

--- a/bot/kodiak/test_pull_request.py
+++ b/bot/kodiak/test_pull_request.py
@@ -1,0 +1,238 @@
+from typing import Any, Type, cast
+
+import pytest
+import requests
+
+from kodiak.config import V1, Merge, MergeMethod
+from kodiak.errors import ApiCallException
+from kodiak.pull_request import PRV2, EventInfoResponse
+from kodiak.queries import (
+    BranchProtectionRule,
+    Client,
+    MergeableState,
+    MergeStateStatus,
+    PullRequest,
+    PullRequestAuthor,
+    PullRequestState,
+    RepoInfo,
+)
+
+
+def create_event() -> EventInfoResponse:
+    config = V1(
+        version=1, merge=Merge(automerge_label="automerge", method=MergeMethod.squash)
+    )
+    pr = PullRequest(
+        id="e14ff7599399478fb9dbc2dacb87da72",
+        number=100,
+        author=PullRequestAuthor(login="arnold", databaseId=49118, type="Bot"),
+        mergeStateStatus=MergeStateStatus.BEHIND,
+        state=PullRequestState.OPEN,
+        mergeable=MergeableState.MERGEABLE,
+        isCrossRepository=False,
+        labels=["automerge"],
+        latest_sha="8d728d017cac4f5ba37533debe65730abe65730a",
+        baseRefName="master",
+        headRefName="df825f90-9825-424c-a97e-733522027e4c",
+        title="Update README.md",
+        body="",
+        bodyText="",
+        bodyHTML="",
+        url="https://github.com/delos-corp/hive-mind/pull/324",
+    )
+    rep_info = RepoInfo(
+        merge_commit_allowed=False,
+        rebase_merge_allowed=False,
+        squash_merge_allowed=True,
+    )
+    branch_protection = BranchProtectionRule(
+        requiresApprovingReviews=True,
+        requiredApprovingReviewCount=2,
+        requiresStatusChecks=True,
+        requiredStatusCheckContexts=[
+            "ci/circleci: frontend_lint",
+            "ci/circleci: frontend_test",
+        ],
+        requiresStrictStatusChecks=True,
+        requiresCommitSignatures=False,
+    )
+
+    return EventInfoResponse(
+        config=config,
+        config_str="""\
+version = 1
+[merge]
+method = "squash"
+""",
+        config_file_expression="master:.kodiak.toml",
+        head_exists=True,
+        pull_request=pr,
+        repo=rep_info,
+        branch_protection=branch_protection,
+        review_requests=[],
+        reviews=[],
+        status_contexts=[],
+        check_runs=[],
+        valid_signature=True,
+        valid_merge_methods=[MergeMethod.squash],
+    )
+
+
+@pytest.fixture
+async def pr_v2() -> PRV2:
+    async def dequeue() -> None:
+        return None
+
+    async def queue_for_merge() -> None:
+        return None
+
+    return PRV2(
+        event=create_event(),
+        install="88443234",
+        owner="delos",
+        repo="incite",
+        number=8534,
+        dequeue_callback=dequeue,
+        queue_for_merge_callback=queue_for_merge,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pr_v2_merge() -> None:
+    async def dequeue() -> None:
+        return None
+
+    async def queue_for_merge() -> None:
+        return None
+
+    class FakeClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(
+            self, exc_type: object, exc_value: object, traceback: object
+        ) -> None:
+            pass
+
+        async def merge_pull_request(
+            self, number: int, merge_method: str, commit_title: str, commit_message: str
+        ) -> requests.Response:
+            res = requests.Response()
+            cast(
+                Any, res
+            )._content = b"""{
+  "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "merged": true,
+  "message": "Pull Request successfully merged"
+}"""
+            res.status_code = 200
+            return res
+
+    pr_v2 = PRV2(
+        event=create_event(),
+        install="88443234",
+        owner="delos",
+        repo="incite",
+        number=8534,
+        dequeue_callback=dequeue,
+        queue_for_merge_callback=queue_for_merge,
+        client=cast(Type[Client], FakeClient),
+    )
+    await pr_v2.merge("squash", commit_title="", commit_message="")
+
+
+@pytest.mark.asyncio
+async def test_pr_v2_merge_rebase_error() -> None:
+    async def dequeue() -> None:
+        return None
+
+    async def queue_for_merge() -> None:
+        return None
+
+    class FakeClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(
+            self, exc_type: object, exc_value: object, traceback: object
+        ) -> None:
+            pass
+
+        async def merge_pull_request(
+            self, number: int, merge_method: str, commit_title: str, commit_message: str
+        ) -> requests.Response:
+            res = requests.Response()
+            cast(
+                Any, res
+            )._content = b"""{"message":"This branch can't be rebased","documentation_url":"https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button"}"""
+            res.status_code = 405
+            return res
+
+    pr_v2 = PRV2(
+        event=create_event(),
+        install="88443234",
+        owner="delos",
+        repo="incite",
+        number=8534,
+        dequeue_callback=dequeue,
+        queue_for_merge_callback=queue_for_merge,
+        client=cast(Type[Client], FakeClient),
+    )
+    with pytest.raises(ApiCallException) as e:
+        await pr_v2.merge("squash", commit_title="", commit_message="")
+    assert e.value.method == "merge pull request failed"
+    assert e.value.description == "This branch can't be rebased"
+
+
+@pytest.mark.asyncio
+async def test_pr_v2_merge_service_unavailable() -> None:
+    async def dequeue() -> None:
+        return None
+
+    async def queue_for_merge() -> None:
+        return None
+
+    class FakeClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(
+            self, exc_type: object, exc_value: object, traceback: object
+        ) -> None:
+            pass
+
+        async def merge_pull_request(
+            self,
+            number: int,
+            merge_method: object,
+            commit_title: object,
+            commit_message: object,
+        ) -> requests.Response:
+            res = requests.Response()
+            cast(Any, res)._content = b"""<html>Service Unavailable</html>"""
+            res.status_code = 503
+            return res
+
+    pr_v2 = PRV2(
+        event=create_event(),
+        install="88443234",
+        owner="delos",
+        repo="incite",
+        number=8534,
+        dequeue_callback=dequeue,
+        queue_for_merge_callback=queue_for_merge,
+        client=cast(Type[Client], FakeClient),
+    )
+    with pytest.raises(ApiCallException) as e:
+        await pr_v2.merge("squash", commit_title="", commit_message="")
+    assert e.value.method == "merge pull request failed"
+    assert e.value.description is None


### PR DESCRIPTION
The error messages we display for failed API calls to GitHub aren't very useful.

Example:

```
problem contacting GitHub API with method 'merge'

problem contacting GitHub API: 'merge pull request failed' ('This branch can't be rebased')
```

related: https://github.com/chdsbd/kodiak/issues/295

Our test coverage for a lot of this logic is nonexistent, so this PR adds some boilerplate for that.