### PR TITLE
add(dashboard): cache control header to disable caching for index.html

### DIFF
--- a/web_ui/nginx.conf
+++ b/web_ui/nginx.conf
@@ -73,6 +73,11 @@ server {
 
 
     location / {
+        # Ensure the browser doesn't cache the index.html.
+        # Without cache-control headers, browsers use
+        # heuristic caching.
+        add_header Cache-Control "no-store";
+
         # First attempt to serve request as file, then serve our index.html
         try_files $uri /index.html;
     }


### PR DESCRIPTION
Without the proper header, browsers will use their heuristic caching
which means users might not get the latest version for a bit (depends on
how long the bowser decides to cache it).

rel: https://github.com/recipeyak/recipeyak/pull/561