### PR TITLE
fix(dashboard): nginx config to include missing headers

### DIFF
--- a/web_ui/Dockerfile
+++ b/web_ui/Dockerfile
@@ -16,6 +16,7 @@ RUN node /var/app/scripts/build.js
 FROM nginx:1.13.8-alpine@sha256:c8ff0187cc75e1f5002c7ca9841cb191d33c4080f38140b9d6f07902ababbe66
 RUN mkdir -p /var/app/build
 COPY --from=builder /var/app/build /var/app/build
+COPY general_headers.conf /etc/nginx/headers.d/
 COPY nginx.conf /etc/nginx/conf.d/
 RUN rm /etc/nginx/conf.d/default.conf
 WORKDIR /var/app

--- a/web_ui/general_headers.conf
+++ b/web_ui/general_headers.conf
@@ -1,0 +1,12 @@
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Directives
+add_header Content-Security-Policy "default-src 'self' https://sentry.io; connect-src https://*.kodiakhq.com; img-src *; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri https://sentry.io/api/3352104/security/?sentry_key=0012ad6693d042d1b57ac5f00918b3bd";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+add_header Referrer-Policy "strict-origin-when-cross-origin";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+add_header X-Content-Type-Options "nosniff";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+add_header X-Frame-Options "SAMEORIGIN";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+add_header X-XSS-Protection "1; mode=block";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";

--- a/web_ui/nginx.conf
+++ b/web_ui/nginx.conf
@@ -55,24 +55,13 @@ server {
     access_log /var/log/nginx/access.log logfmt;
     error_log /var/log/nginx/error.log;
 
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Directives
-    # https://sentry.io/magnus-montis/recipeyak/settings/csp/
-    add_header Content-Security-Policy "default-src 'self' https://sentry.io; connect-src https://*.kodiakhq.com; img-src *; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri https://sentry.io/api/3352104/security/?sentry_key=0012ad6693d042d1b57ac5f00918b3bd";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
-    add_header Referrer-Policy "strict-origin-when-cross-origin";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
-    add_header X-Content-Type-Options "nosniff";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-    add_header X-Frame-Options "SAMEORIGIN";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
-    add_header X-XSS-Protection "1; mode=block";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+    include headers.d/general_headers.conf;
 
     root /var/app/build;
 
 
     location / {
+        include headers.d/general_headers.conf;
         # Ensure the browser doesn't cache the index.html.
         # Without cache-control headers, browsers use
         # heuristic caching.


### PR DESCRIPTION
`add_header` clears headers added in the parent so when we add the cache
specific header, we clear all the security headers

rel: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
rel: https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx
rel: https://github.com/recipeyak/recipeyak/pull/562