### PR TITLE
fix(web_api): ordering of accounts endpoint

### DIFF
--- a/web_api/core/test_views.py
+++ b/web_api/core/test_views.py
@@ -667,17 +667,17 @@ def test_accounts_endpoint_ordering(authed_client: Client, user: User) -> None:
     res = authed_client.get("/v1/accounts")
     assert res.json() == [
         {
-            "id": acme.id,
+            "id": str(acme.id),
             "name": "acme-corp",
             "profileImgUrl": "https://avatars.githubusercontent.com/u/523412234",
         },
         {
-            "id": industries.id,
+            "id": str(industries.id),
             "name": "industries",
             "profileImgUrl": "https://avatars.githubusercontent.com/u/2234",
         },
         {
-            "id": market.id,
+            "id": str(market.id),
             "name": "market",
             "profileImgUrl": "https://avatars.githubusercontent.com/u/1020",
         },

--- a/web_api/core/views.py
+++ b/web_api/core/views.py
@@ -439,8 +439,10 @@ def stripe_webhook_handler(request: HttpRequest) -> HttpResponse:
 def accounts(request: HttpRequest) -> HttpResponse:
     return JsonResponse(
         [
-            dict(id=x.id, name=x.github_account_login, profileImgUrl=x.profile_image(),)
-            for x in Account.objects.filter(memberships__user=request.user)
+            dict(id=x.id, name=x.github_account_login, profileImgUrl=x.profile_image())
+            for x in Account.objects.filter(memberships__user=request.user).order_by(
+                "github_account_login"
+            )
         ],
         safe=False,
     )


### PR DESCRIPTION
We didn't provide an order by clause when fetching accounts for the
accounts switcher so the order is not great.