### PR TITLE
minor(web_ui): update jsonToFormData type to be more strict

### DIFF
--- a/web_ui/src/api.ts
+++ b/web_ui/src/api.ts
@@ -1,4 +1,4 @@
-export interface ILoginUserArgs {
+export type ILoginUserArgs = {
   code: string
   serverState: string
   clientState: string
@@ -120,7 +120,7 @@ export interface IStartTrialArgs {
   readonly teamId: string
   readonly billingEmail: string
 }
-export interface IUpdateSubscriptionArgs {
+export type IUpdateSubscriptionArgs = {
   readonly teamId: string
   readonly seats: number
   readonly prorationTimestamp: number

--- a/web_ui/src/world.ts
+++ b/web_ui/src/world.ts
@@ -33,11 +33,10 @@ authRoute.interceptors.response.use(
  * Our Django app only accepts multi-part and url encoded form data. JSON is not
  * supported.
  */
-function jsonToFormData(data: object) {
+function jsonToFormData(data: { readonly [_: string]: string | number }) {
   const form = new FormData()
   Object.entries(data).forEach(([k, v]) => {
-    // tslint:disable-next-line no-unsafe-any
-    form.set(k, v)
+    form.set(k, String(v))
   })
   return form
 }
@@ -140,7 +139,9 @@ export const Current: World = {
       (
         await authRoute.post<api.IFetchProrationResponse>(
           `/v1/t/${args.teamId}/fetch_proration`,
-          jsonToFormData({ subscriptionQuantity: args.subscriptionQuantity }),
+          jsonToFormData({
+            subscriptionQuantity: args.subscriptionQuantity,
+          }),
         )
       ).data,
   },


### PR DESCRIPTION
Currently using `object` which results in `any` and is too lenient for
what [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData#append()) supports.

We accept both string and number even though form data only allows
string and blob as values. Easier to convert the number than update
all the call sites.

We also have to convert some `interface`s to `type`s since `interfaces` don't have implicit index signatures: https://github.com/Microsoft/TypeScript/issues/15300