### PR TITLE
add: channel for triggering bot to reevaluate PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,12 +306,7 @@ workflows:
     jobs:
       - bot_test
       - bot_lint
-      - bot_build_container:
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /^v.*/
+      - bot_build_container
   docs:
     jobs:
       - docs_typecheck

--- a/bot/kodiak/cli.py
+++ b/bot/kodiak/cli.py
@@ -78,7 +78,9 @@ def validate_config(config_path: str) -> None:
     assert isinstance(cfg_file, V1)
     click.echo(cfg_file.json(indent=2))
 
+
 @cli.command()
 def refresh_pull_requests() -> None:
     from kodiak.refresh_pull_requests import main
+
     main()

--- a/bot/kodiak/cli.py
+++ b/bot/kodiak/cli.py
@@ -79,8 +79,11 @@ def validate_config(config_path: str) -> None:
     click.echo(cfg_file.json(indent=2))
 
 
-@cli.command()
+@cli.command(help="listen for messages and trigger pull request refreshes")
 def refresh_pull_requests() -> None:
+    """
+    Listen on a Redis list for messages triggering pull request reevaluations.
+    """
     from kodiak.refresh_pull_requests import main
 
     main()

--- a/bot/kodiak/cli.py
+++ b/bot/kodiak/cli.py
@@ -77,3 +77,8 @@ def validate_config(config_path: str) -> None:
     cfg_file = V1.parse_toml(cfg_text)
     assert isinstance(cfg_file, V1)
     click.echo(cfg_file.json(indent=2))
+
+@cli.command()
+def refresh_pull_requests() -> None:
+    from kodiak.refresh_pull_requests import main
+    main()

--- a/bot/kodiak/queue.py
+++ b/bot/kodiak/queue.py
@@ -38,6 +38,9 @@ class WebhookEvent(BaseModel):
     def get_merge_target_queue_name(self) -> str:
         return self.get_merge_queue_name() + ":target"
 
+    def get_webhook_queue_name(self) -> str:
+        return get_webhook_queue_name(self)
+
     def __hash__(self) -> int:
         return (
             hash(self.repo_owner)

--- a/bot/kodiak/refresh_pull_requests.py
+++ b/bot/kodiak/refresh_pull_requests.py
@@ -1,3 +1,13 @@
+"""
+A process for triggering reevaluation of pull requests for a given installation.
+This is useful for triggering the bot to remove the paywall status check message
+after a user has started a trial or subscription.
+
+We listen for events on a Redis list. When we receive an event we look up all
+the private PRs associated with that installation. We queue webhook events like
+a GitHub webhook would for each pull request to trigger the bot to reevaluate
+the mergeability.
+"""
 from __future__ import annotations
 
 import asyncio
@@ -184,14 +194,14 @@ async def main_async() -> None:
             continue
         pr_refresh_message = RefreshPullRequestsMessage.parse_raw(res.value)
         installation_id = pr_refresh_message.installation_id
-        start = time.time()
+        start = time.monotonic()
         await refresh_pull_requests_for_installation(
             installation_id=installation_id, redis=redis
         )
         logger.info(
             "pull_request_refresh",
             installation_id=installation_id,
-            duration=time.time() - start,
+            duration=time.monotonic() - start,
         )
 
 

--- a/bot/kodiak/refresh_pull_requests.py
+++ b/bot/kodiak/refresh_pull_requests.py
@@ -7,7 +7,7 @@ from typing import cast
 import asyncio_redis
 import requests_async as http
 import sentry_sdk
-from asyncio_redis.replies import BlockingZPopReply
+from asyncio_redis.replies import BlockingPopReply
 from pydantic import BaseModel
 
 from kodiak import app_config as conf
@@ -120,7 +120,7 @@ async def main_async() -> None:
     while True:
         logger.info("block for new events")
         try:
-            res: BlockingZPopReply = await redis.bzpopmin(
+            res: BlockingPopReply = await redis.blpop(
                 ["kodiak:refresh_pull_requests_for_installation"], timeout=5
             )
         except asyncio_redis.exceptions.TimeoutError:

--- a/bot/kodiak/refresh_pull_requests.py
+++ b/bot/kodiak/refresh_pull_requests.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import structlog
+from typing import cast
+
+import asyncio_redis
+import requests_async as http
+import sentry_sdk
+from asyncio_redis.replies import BlockingZPopReply
+from pydantic import BaseModel
+
+from kodiak import app_config as conf
+from kodiak.queries import generate_jwt, get_token_for_install
+from kodiak.queue import WebhookEvent, redis_webhook_queue
+
+sentry_sdk.init()
+
+
+logger = structlog.get_logger()
+
+QUERY = """
+query ($login: String!) {
+  userdata: user(login: $login) {
+    repositories(first: 5) {
+      nodes {
+        name
+        pullRequests(first: 50, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            number
+          }
+        }
+      }
+    }
+  }
+  organizationdata: organization(login: $login) {
+    repositories(first: 5) {
+      nodes {
+        name
+        pullRequests(first: 50, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            number
+          }
+        }
+      }
+    }
+  }
+}
+
+"""
+
+
+async def get_login_for_install(*, installation_id: str) -> str:
+    app_token = generate_jwt(
+        private_key=conf.PRIVATE_KEY, app_identifier=conf.GITHUB_APP_ID
+    )
+    res = await http.get(
+        f"https://api.github.com/app/installations/{installation_id}",
+        headers=dict(
+            Accept="application/vnd.github.machine-man-preview+json",
+            Authorization=f"Bearer {app_token}",
+        ),
+    )
+    res.raise_for_status()
+    return cast(str, res.json()["account"]["login"])
+
+
+async def refresh_pull_requests_for_installation(*, installation_id: str) -> None:
+    login = await get_login_for_install(installation_id=installation_id)
+    token = get_token_for_install(installation_id=installation_id)
+    res = await http.post(
+        "https://api.github.com/graphql",
+        json=dict(query=QUERY, variables=dict(login=login)),
+        headers=dict(Authorization=f"Bearer {token}"),
+    )
+    res.raise_for_status()
+
+    organizationdata = res.json()["data"]["organizationdata"]
+    userdata = res.json()["data"]["userdata"]
+    if organizationdata is not None:
+        data = organizationdata
+    elif userdata is not None:
+        data = userdata
+    else:
+        raise ValueError("missing data for user/organization")
+
+    events = []
+    for repository in data["repositories"]["nodes"]:
+        repo_name = repository["name"]
+        for pull_request in repository["pullRequests"]["nodes"]:
+            events.append(
+                WebhookEvent(
+                    repo_owner=login,
+                    repo_name=repo_name,
+                    pull_request_number=pull_request["number"],
+                    installation_id=installation_id,
+                )
+            )
+    logger.info("queuing %s events", len(events))
+    for event in events:
+        await redis_webhook_queue.enqueue(event=event)
+
+
+class RefreshPullRequestsMessage(BaseModel):
+    installation_id: str
+
+
+async def main_async() -> None:
+    redis_db = 0
+    try:
+        redis_db = int(conf.REDIS_URL.database)
+    except ValueError:
+        pass
+    redis = await asyncio_redis.Connection.create(
+        host=conf.REDIS_URL.hostname or "localhost",
+        port=conf.REDIS_URL.port or 6379,
+        password=conf.REDIS_URL.password or None,
+        db=redis_db,
+    )
+    while True:
+        logger.info("block for new events")
+        try:
+            res: BlockingZPopReply = await redis.bzpopmin(
+                ["kodiak:refresh_pull_requests_for_installation"], timeout=5
+            )
+        except asyncio_redis.exceptions.TimeoutError:
+            continue
+        pr_refresh_message = RefreshPullRequestsMessage.parse_raw(res.value)
+        installation_id = pr_refresh_message.installation_id
+        logger.info("refreshing pull requests for", installation_id=installation_id)
+        await refresh_pull_requests_for_installation(installation_id=installation_id)
+
+
+def main() -> None:
+    asyncio.run(main_async())

--- a/bot/kodiak/refresh_pull_requests.py
+++ b/bot/kodiak/refresh_pull_requests.py
@@ -153,7 +153,11 @@ async def main_async() -> None:
         await refresh_pull_requests_for_installation(
             installation_id=installation_id, redis=redis
         )
-        logger.info("pull_request_refresh", installation_id=installation_id, duration=time.time() -start)
+        logger.info(
+            "pull_request_refresh",
+            installation_id=installation_id,
+            duration=time.time() - start,
+        )
 
 
 def main() -> None:

--- a/web_api/core/models.py
+++ b/web_api/core/models.py
@@ -7,6 +7,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Callable, List, Optional, cast
 
+import pydantic
 import redis
 import requests
 import stripe
@@ -347,7 +348,7 @@ class Account(BaseModel):
         # Trigger bot to reevaluate pull request mergeability.
         # We can use this to trigger the bot to remove the paywall status message on upgrades.
 
-        class RefreshPullRequestsMessage(BaseModel):
+        class RefreshPullRequestsMessage(pydantic.BaseModel):
             installation_id: str
 
         r.rpush(

--- a/web_api/core/models.py
+++ b/web_api/core/models.py
@@ -344,6 +344,19 @@ class Account(BaseModel):
         subscription_blocker = self.get_subscription_blocker() or ""
         r.hset(key, b"subscription_blocker", subscription_blocker.encode())  # type: ignore
 
+        # Trigger bot to reevaluate pull request mergeability.
+        # We can use this to trigger the bot to remove the paywall status message on upgrades.
+
+        class RefreshPullRequestsMessage(BaseModel):
+            installation_id: str
+
+        r.rpush(
+            "kodiak:refresh_pull_requests_for_installation",
+            RefreshPullRequestsMessage(
+                installation_id=self.github_installation_id
+            ).json(),
+        )
+
 
 class AccountRole(models.TextChoices):
     admin = "admin"

--- a/web_api/core/test_account.py
+++ b/web_api/core/test_account.py
@@ -23,11 +23,16 @@ def test_update_bot() -> None:
         github_account_type="Organization",
     )
     assert r.hgetall(f"kodiak:subscription:{account.github_installation_id}") == {}  # type: ignore
+    assert r.exists("kodiak:refresh_pull_requests_for_installation") == 0
     account.update_bot()
     assert r.hgetall(f"kodiak:subscription:{account.github_installation_id}") == {  # type: ignore
         b"account_id": str(account.id).encode(),
         b"subscription_blocker": b"",
     }
+    assert r.exists("kodiak:refresh_pull_requests_for_installation") == 1
+    assert r.lrange("kodiak:refresh_pull_requests_for_installation", 0, -1) == [  # type: ignore
+        ('{"installation_id": "%s"}' % account.github_installation_id).encode()
+    ]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
When a user hits the paywall, they will need to start a trial or subscription to remove it. However, Kodiak only evaluates a PR when it gets a new related GitHub webhook. So after starting a trial or subscription the user would still see paywalls on their PRs unless they trigger a refresh by updating the PR.

This change adds a method for triggering the bot to reevaluate PRs outside of GitHub webhook triggers. This change adds a process that will listen for events in Redis and trigger updates in the bot.

On trial or subscription upgrades the web api will send a refresh message via Redis to the listening process. The listening process will enqueue webhook events for all open PRs into the webhook event queue, like a normal GitHub webhook event, triggering reevaluation of PRs.

I've done manual testing to verify this works.