### PR TITLE
fix(bot): handling of rare check run statuses

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -544,6 +544,8 @@ async def mergeable(
                     CheckConclusionState.FAILURE,
                     CheckConclusionState.TIMED_OUT,
                     CheckConclusionState.CANCELLED,
+                    CheckConclusionState.SKIPPED,
+                    CheckConclusionState.STALE,
                 ):
                     failing_contexts.append(check_run.name)
             passing = set(passing_contexts)

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -543,6 +543,7 @@ async def mergeable(
                     CheckConclusionState.ACTION_REQUIRED,
                     CheckConclusionState.FAILURE,
                     CheckConclusionState.TIMED_OUT,
+                    CheckConclusionState.CANCELLED,
                 ):
                     failing_contexts.append(check_run.name)
             passing = set(passing_contexts)

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -358,6 +358,8 @@ class CheckConclusionState(Enum):
     CANCELLED = "CANCELLED"
     FAILURE = "FAILURE"
     NEUTRAL = "NEUTRAL"
+    SKIPPED = "SKIPPED"
+    STALE = "STALE"
     SUCCESS = "SUCCESS"
     TIMED_OUT = "TIMED_OUT"
 

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1797,6 +1797,8 @@ async def test_mergeable_missing_requires_status_checks_failing_check_run(
             CheckConclusionState.FAILURE,
             CheckConclusionState.TIMED_OUT,
             CheckConclusionState.CANCELLED,
+            CheckConclusionState.SKIPPED,
+            CheckConclusionState.STALE,
         )
     ):
         check_run.conclusion = check_run_conclusion


### PR DESCRIPTION
We were missing some check run states like `STALE` and `SKIPPED`. We also weren't marking `CANCELLED` check runs as failures, so Kodiak was erroneously waiting for them to succeed. This change makes Kodiak's behavior match GitHub.