### PR TITLE
ref(bot): make paywall message less ominous

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -314,7 +314,7 @@ async def mergeable(
                     subscription.subscription_blocker,
                 )
         await set_status(
-            f"💳 payment required: {message}",
+            f"💳 subscription: {message}",
             markdown_content=get_markdown_for_paywall(),
         )
         return

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -314,8 +314,7 @@ async def mergeable(
                     subscription.subscription_blocker,
                 )
         await set_status(
-            f"💳 subscription: {message}",
-            markdown_content=get_markdown_for_paywall(),
+            f"💳 subscription: {message}", markdown_content=get_markdown_for_paywall()
         )
         return
 

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -4352,9 +4352,9 @@ async def test_mergeable_paywall(
             subscription=subscription,
         )
         assert api.set_status.call_count == index + 1
-    assert "💳 payment required: subscription missing" in api.set_status.calls[0]["msg"]
+    assert "💳 subscription: subscription missing" in api.set_status.calls[0]["msg"]
     assert (
-        "💳 payment required: usage has exceeded licensed seats"
+        "💳 subscription: usage has exceeded licensed seats"
         in api.set_status.calls[1]["msg"]
     )
 


### PR DESCRIPTION
"💳 payment required: ..." => "💳 subscription: ..."

I think this is more accurate because payment isn't necessarily required for trials and complimentary access.