### PR TITLE
fix(web_ui): billing trial expiration timezone

### DIFF
--- a/web_ui/src/components/UsageBillingPage.tsx
+++ b/web_ui/src/components/UsageBillingPage.tsx
@@ -115,7 +115,7 @@ function formatFromNow(dateString: string): string {
 }
 
 function FormatDate({ date }: { date: string }) {
-  return <>{formatDate(parseISO(date), "y-MM-dd kk:mm") + " UTC"}</>
+  return <>{formatDate(parseISO(date), "y-MM-dd kk:mm O")}</>
 }
 
 const formattedMonthlyCost = formatCents(settings.monthlyCost)


### PR DESCRIPTION
Previously we had the date with UTC appended when the date was actually
formatted with the browser's timezone.

Now we format the date with the timezone info to avoid any ambiguities.

<img width="630" alt="image" src="https://user-images.githubusercontent.com/7340772/81353522-4b89b980-9097-11ea-9018-98b6f209ffe5.png">


rel: https://date-fns.org/v2.9.0/docs/format