### PR TITLE
add: notify_on_conflict to notify on any merge conflict

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -124,6 +124,8 @@ class V1(BaseModel):
     merge: Merge = Merge()
     update: Update = Update()
     approve: Approve = Approve()
+    notify_on_conflict: bool = False
+    notify_on_conflict_label: str = "kodiak:merge_conflict"
 
     @validator("version", pre=True, always=True)
     def correct_version(cls, v: int) -> int:

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -467,8 +467,12 @@ async def mergeable(
         or pull_request.mergeable == MergeableState.CONFLICTING
     ):
         await block_merge(api, pull_request, "merge conflict")
-        # remove label if configured and send message
-        if config.merge.notify_on_conflict and config.merge.require_automerge_label:
+        # remove label if configured and send message. config.notify_on_conflict overrides this option.
+        if (
+            config.merge.notify_on_conflict
+            and config.merge.require_automerge_label
+            and not config.notify_on_conflict
+        ):
             automerge_label = config.merge.automerge_label
             await api.remove_label(automerge_label)
             body = textwrap.dedent(

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -373,7 +373,6 @@ async def mergeable(
             await api.create_comment(
                 "This PR has a merge conflict. Please resolve this to allow the PR to be updated and/or merged."
             )
-        return
 
     need_branch_update = (
         branch_protection.requiresStrictStatusChecks

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -294,6 +294,19 @@ class PRV2:
                 # we raise an exception to retry this request.
                 raise ApiCallException("delete label")
 
+    async def add_label(self, label: str) -> bool:
+        self.log.info("add_label", label=label)
+        async with Client(
+            installation_id=self.install, owner=self.owner, repo=self.repo
+        ) as api_client:
+            res = await api_client.add_labels(labels=[label], pull_number=self.number)
+            try:
+                res.raise_for_status()
+                return True
+            except HTTPError:
+                self.log.exception("failed to create label", res=res)
+        return False
+
     async def create_comment(self, body: str) -> None:
         """
        create a comment on the specified `pr_number` with the given `body` as text.

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -956,6 +956,16 @@ class Client:
                 headers=headers,
             )
 
+    async def add_labels(self, labels: List[str], pull_number: int) -> http.Response:
+        headers = await get_headers(installation_id=self.installation_id)
+        # POST /repos/:owner/:repo/issues/:issue_number/labels
+        async with self.throttler:
+            return await self.session.post(
+                f"https://api.github.com/repos/{self.owner}/{self.repo}/issues/{pull_number}/labels",
+                json=dict(labels=labels),
+                headers=headers,
+            )
+
     async def create_comment(self, body: str, pull_number: int) -> http.Response:
         headers = await get_headers(installation_id=self.installation_id)
         async with self.throttler:

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -65,6 +65,16 @@
           "$ref": "#/definitions/Approve"
         }
       ]
+    },
+    "notify_on_conflict": {
+      "title": "Notify On Conflict",
+      "default": false,
+      "type": "boolean"
+    },
+    "notify_on_conflict_label": {
+      "title": "Notify On Conflict Label",
+      "default": "kodiak:merge_conflict",
+      "type": "string"
     }
   },
   "required": [


### PR DESCRIPTION
This change adds two configuration options: `notify_on_conflict` and `notify_on_conflict_label`. If a PR encounters a merge conflict, Kodiak will add a label (configurable via `notify_on_conflict_label`) and leave a comment, even if the PR isn't set for merging. When the merge conflict is resolved, Kodiak will remove the label.

We have an existing `merge.notify_on_conflict` option, but Kodiak will only notify when the automerge label is configured. `notify_on_conflict` also supersedes `merge.notify_on_conflict` (the code is earlier in evaluation.py).

Here's an example config that enables `notify_on_conflict` and sets a custom `notify_on_conflict_label`.

```toml
# .kodiak.toml
version = 1

notify_on_conflict = true
notify_on_conflict_label = "merge conflict!?"

[merge]
method = "squash"
```

While I think `notify_on_conflict` would be a good default option, I think we should leave it opt-in to preserve existing behavior for users. (edit: I'm not sure about this)

I'll document this feature in another PR after it's been deployed.

fixes #276