### PR TITLE
fix(web_ui): start subscription form seat selection clarity

### DIFF
--- a/web_ui/src/components/UsageBillingPage.tsx
+++ b/web_ui/src/components/UsageBillingPage.tsx
@@ -221,7 +221,7 @@ function StartSubscriptionModal({
   onClose,
   seatUsage,
 }: IStartSubscriptionModalProps) {
-  const [seats, setSeats] = React.useState(1)
+  const [seats, setSeats] = React.useState(seatUsage)
   const [status, setStatus] = React.useState<
     { type: "initial" } | { type: "loading" } | { type: "error"; msg: string }
   >({ type: "initial" })
@@ -255,6 +255,7 @@ function StartSubscriptionModal({
   }
 
   const costCents = seats * settings.monthlyCost
+  const notEnoughSeats = seats < seatUsage && seatUsage > 0
   return (
     <Modal show={show} onHide={onClose}>
       <Modal.Header closeButton>
@@ -280,8 +281,10 @@ function StartSubscriptionModal({
             />
             {seatUsage > 0 && (
               <Form.Text className="text-muted">
-                You have <b>{seatUsage}</b> active seats this billing period.
-                Select at least <b>{seatUsage}</b> seats to continue service.
+                You have <b>{seatUsage}</b> active seats this billing period.{" "}
+                <span className={notEnoughSeats ? "text-danger" : ""}>
+                  Select at least <b>{seatUsage}</b> seats to continue service.
+                </span>
               </Form.Text>
             )}
           </Form.Group>
@@ -303,9 +306,14 @@ function StartSubscriptionModal({
             variant="primary"
             type="submit"
             block
-            disabled={status.type === "loading"}>
+            disabled={status.type === "loading" || notEnoughSeats}>
             {status.type === "loading" ? "Loading" : "Continue to Payment"}
           </Button>
+          {notEnoughSeats && (
+            <Form.Text className="text-danger">
+              Select at least <b>{seatUsage}</b> seats.
+            </Form.Text>
+          )}
           <Form.Text className="text-muted">
             Kodiak uses Stripe.com to securely handle payments.
           </Form.Text>


### PR DESCRIPTION
Previously the start subscription form defaulted to 1 seat. This is a bad default and has caused issues for some customers. We now default to the active user count.

We also change the "Select at least N seats to continue service." font color to red when the user has not selected enough seats.

**default state**
<img width="433" alt="Screen Shot 2020-05-08 at 11 44 35 PM" src="https://user-images.githubusercontent.com/1929960/81463707-984dbd00-9189-11ea-9831-f632fc489054.png">

**too few seats**
<img width="443" alt="Screen Shot 2020-05-09 at 12 09 03 AM" src="https://user-images.githubusercontent.com/1929960/81463720-a3a0e880-9189-11ea-9250-8aeb869a3b3e.png">
