### PR TITLE
add(web): make Kodiak free for personal accounts

### DIFF
--- a/web_api/core/models.py
+++ b/web_api/core/models.py
@@ -314,6 +314,9 @@ class Account(BaseModel):
         """
         If there is a valid trial or subscription, we should return None. Otherwise we should return the reason for the block.
         """
+        if self.github_account_type == AccountType.user:
+            return None
+
         if self.active_trial():
             return None
 

--- a/web_api/core/test_account.py
+++ b/web_api/core/test_account.py
@@ -6,7 +6,7 @@ import redis
 from django.conf import settings
 from django.utils.timezone import make_aware
 
-from core.models import Account, StripeCustomerInformation
+from core.models import Account, AccountType, StripeCustomerInformation
 
 
 @pytest.mark.django_db
@@ -149,10 +149,15 @@ def test_get_subscription_blocker_seats_exceeded_no_sub_or_trial(mocker: Any) ->
         github_account_type="Organization",
         stripe_customer_id="cus_H2pvQ2kt7nk0JY",
     )
+    assert account.github_account_type == AccountType.organization
     assert get_active_users_in_last_30_days.call_count == 0
     assert account.get_subscription_blocker() == "seats_exceeded"
     assert get_active_users_in_last_30_days.call_count == 1
     assert account.get_active_user_count() == 5
+
+    account.github_account_type = AccountType.user
+    account.save()
+    assert account.get_subscription_blocker() is None
 
 
 @pytest.mark.django_db

--- a/web_api/core/views.py
+++ b/web_api/core/views.py
@@ -23,6 +23,7 @@ from core import auth
 from core.exceptions import BadRequest, PermissionDenied, UnprocessableEntity
 from core.models import (
     Account,
+    AccountType,
     AnonymousUser,
     PullRequestActivity,
     StripeCustomerInformation,
@@ -76,6 +77,7 @@ def usage_billing(request: HttpRequest, team_id: str) -> HttpResponse:
         )
     return JsonResponse(
         dict(
+            canSubscribe=account.github_account_type != AccountType.user,
             subscription=subscription,
             trial=trial,
             activeUsers=[

--- a/web_ui/src/api.ts
+++ b/web_ui/src/api.ts
@@ -33,6 +33,7 @@ export interface IUsageBillingPageArgs {
   readonly teamId: string
 }
 export interface IUsageBillingPageApiResponse {
+  readonly canSubscribe: boolean
   readonly subscription: {
     readonly seats: number
     readonly nextBillingDate: string

--- a/web_ui/src/components/UsageBillingPage.tsx
+++ b/web_ui/src/components/UsageBillingPage.tsx
@@ -48,6 +48,7 @@ export function UsageBillingPage() {
 }
 
 interface IUsageBillingData {
+  readonly canSubscribe: boolean
   readonly subscription: {
     readonly seats: number
     readonly nextBillingDate: string
@@ -913,14 +914,27 @@ function UsageBillingPageInner(props: IUsageBillingPageInnerProps) {
             }}
           />
         ) : null}
-        <Subscription
-          startSubscription={handleStartSubscription}
-          startTrial={handleStartTrial}
-          modifySubscription={modifySubscription}
-          subscription={data.subscription}
-          trial={data.trial}
-          teamId={teamId}
-        />
+        {data.canSubscribe ? (
+          <Subscription
+            startSubscription={handleStartSubscription}
+            startTrial={handleStartTrial}
+            modifySubscription={modifySubscription}
+            subscription={data.subscription}
+            trial={data.trial}
+            teamId={teamId}
+          />
+        ) : (
+          <Row>
+            <Col>
+              <p className="text-center">
+                Kodiak is free for personal GitHub accounts.
+                <br />
+                Organizations can subscribe to use Kodiak on private
+                repositories.
+              </p>
+            </Col>
+          </Row>
+        )}
 
         <h3 className="h5">Usage</h3>
         <div className="border border-primary rounded p-2">


### PR DESCRIPTION
This change makes Kodiak free for personal GitHub accounts. Kodiak now only requires a subscription for private GitHub organization repositories.

The subscription section is replaced with some copy saying Kodiak is free for personal accounts.
<img width="752" alt="image" src="https://user-images.githubusercontent.com/1929960/81477633-c2819800-91e6-11ea-9fcb-bf7f8bcd8862.png">
