### PR TITLE
cut(docs): invalid nav link to #quickstart

### DIFF
--- a/docs/siteConfig.js
+++ b/docs/siteConfig.js
@@ -49,7 +49,6 @@ const siteConfig = {
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
     { doc: "quickstart", label: "Docs" },
-    { href: "#quickstart", label: "Quick Start" },
     { page: "help", label: "Help" },
     { href: changeLogUrl, label: "Changelog" },
     {


### PR DESCRIPTION
This nav link worked on the homepage, but it didn't work anywhere else.

I don't think we should bother making this a link to quickstart since "Docs" links to that already.