### PR TITLE
add(bot): prioritize merge conflict notifications

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -382,7 +382,6 @@ async def mergeable(
         )
         return
 
-
     # We want users to get notified a merge conflict even if the PR matches a
     # WIP title via merge.blacklist_title_regex.
     if (
@@ -401,7 +400,6 @@ async def mergeable(
             )
             await api.create_comment(body)
         return
-
 
     blacklist_labels = set(config.merge.blacklist_labels) & set(pull_request.labels)
     if blacklist_labels:

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1367,6 +1367,61 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict(
     assert api.merge.called is False
     assert api.queue_for_merge.called is False
 
+@pytest.mark.asyncio
+async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_blacklist_title_regex(
+    api: MockPrApi,
+    config: V1,
+    config_path: str,
+    config_str: str,
+    pull_request: PullRequest,
+    branch_protection: BranchProtectionRule,
+    review: PRReview,
+    context: StatusContext,
+    check_run: CheckRun,
+) -> None:
+    """
+    if a PR has a merge conflict we can't merge. If the title matches the
+    blacklist_title_regex we should still leave a comment and remove the
+    automerge label.
+    """
+    pull_request.mergeStateStatus = MergeStateStatus.DIRTY
+    pull_request.mergeable = MergeableState.CONFLICTING
+    config.merge.notify_on_conflict = True
+    config.merge.require_automerge_label = True
+    config.merge.blacklist_title_regex = "WIP.*"
+    pull_request.title = "WIP: add csv download to reports view"
+
+    await mergeable(
+        api=api,
+        config=config,
+        config_str=config_str,
+        config_path=config_path,
+        pull_request=pull_request,
+        branch_protection=branch_protection,
+        review_requests=[],
+        reviews=[review],
+        contexts=[context],
+        check_runs=[check_run],
+        valid_signature=False,
+        valid_merge_methods=[MergeMethod.squash],
+        merging=False,
+        is_active_merge=False,
+        skippable_check_timeout=5,
+        api_call_retry_timeout=5,
+        api_call_retry_method_name=None,
+    )
+    assert api.set_status.call_count == 1
+    assert api.dequeue.call_count == 1
+    assert "cannot merge" in api.set_status.calls[0]["msg"]
+    assert "merge conflict" in api.set_status.calls[0]["msg"]
+    assert api.remove_label.call_count == 1
+    assert api.create_comment.call_count == 1
+
+    # verify we haven't tried to update/merge the PR
+    assert api.update_branch.called is False
+    assert api.merge.called is False
+    assert api.queue_for_merge.called is False
+
 
 @pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_missing_label(

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1367,6 +1367,7 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict(
     assert api.merge.called is False
     assert api.queue_for_merge.called is False
 
+
 @pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_blacklist_title_regex(
     api: MockPrApi,


### PR DESCRIPTION
fixes https://github.com/chdsbd/kodiak/issues/276

This problem is #276 is that the `merge.blacklist_title_regex` was taking priority over `merge.notify_on_conflict`. This is not as desirable because I think merge conflict notifications are higher priority.

I was going to make a more general change in #364, but I think this is a simple solution that addresses the immediate problem. I plan to circle back to #364 later.