### PR TITLE
fix(web_api): oauth flow not handling api error in membership check

### DIFF
--- a/web_api/core/models.py
+++ b/web_api/core/models.py
@@ -147,8 +147,9 @@ class User(BaseModel):
                 try:
                     account_membership_res.raise_for_status()
                 except requests.HTTPError:
-                    # TODO(chdsbd): Confirm that this gets a 403 when the user
-                    # is a collaborator instead of a member or admin.
+                    # If the user is a collaborator instead of a member or admin
+                    # of the organization, they won't have access and will get a
+                    # 403 error.
                     logger.warning(
                         "problem fetching account membership response=%s, installation_account_login=%s user_github_login=%s",
                         account_membership_res,

--- a/web_api/core/models.py
+++ b/web_api/core/models.py
@@ -144,7 +144,18 @@ class User(BaseModel):
                     headers=dict(authorization=f"Bearer {self.github_access_token}"),
                     timeout=5,
                 )
-                account_membership_res.raise_for_status()
+                try:
+                    account_membership_res.raise_for_status()
+                except requests.HTTPError:
+                    # TODO(chdsbd): Confirm that this gets a 403 when the user
+                    # is a collaborator instead of a member or admin.
+                    logger.warning(
+                        "problem fetching account membership response=%s, installation_account_login=%s user_github_login=%s",
+                        account_membership_res,
+                        installation_account_login,
+                        self.github_login,
+                    )
+                    continue
                 role = account_membership_res.json()["role"]
             elif (
                 installation_account_type == "User"

--- a/web_api/core/test_user.py
+++ b/web_api/core/test_user.py
@@ -250,12 +250,306 @@ def successful_installation_response(mocked_responses: Any) -> None:
     )
 
 
+@pytest.fixture
+def failing_installation_response_membership_check(mocked_responses: Any) -> None:
+    mocked_responses.add(
+        responses.GET,
+        "https://api.github.com/user/installations",
+        json={
+            "total_count": 1,
+            "installations": [
+                {
+                    "id": 1066615,
+                    "account": {
+                        "login": "ghost",
+                        "id": 10137,
+                        "node_id": "MDQ6VXNlcjE5Mjk5NjA=",
+                        "avatar_url": "https://avatars2.githubusercontent.com/u/10137?v=4",
+                        "gravatar_id": "",
+                        "url": "https://api.github.com/users/ghost",
+                        "html_url": "https://github.com/ghost",
+                        "followers_url": "https://api.github.com/users/ghost/followers",
+                        "following_url": "https://api.github.com/users/ghost/following{/other_user}",
+                        "gists_url": "https://api.github.com/users/ghost/gists{/gist_id}",
+                        "starred_url": "https://api.github.com/users/ghost/starred{/owner}{/repo}",
+                        "subscriptions_url": "https://api.github.com/users/ghost/subscriptions",
+                        "organizations_url": "https://api.github.com/users/ghost/orgs",
+                        "repos_url": "https://api.github.com/users/ghost/repos",
+                        "events_url": "https://api.github.com/users/ghost/events{/privacy}",
+                        "received_events_url": "https://api.github.com/users/ghost/received_events",
+                        "type": "User",
+                        "site_admin": False,
+                    },
+                    "repository_selection": "selected",
+                    "access_tokens_url": "https://api.github.com/app/installations/136746/access_tokens",
+                    "repositories_url": "https://api.github.com/installation/repositories",
+                    "html_url": "https://github.com/settings/installations/136746",
+                    "app_id": 31500,
+                    "app_slug": "kodiak-local-dev",
+                    "target_id": 10137,
+                    "target_type": "User",
+                    "permissions": {
+                        "administration": "read",
+                        "checks": "write",
+                        "contents": "write",
+                        "issues": "read",
+                        "metadata": "read",
+                        "pull_requests": "write",
+                        "statuses": "read",
+                    },
+                    "events": [
+                        "check_run",
+                        "issue_comment",
+                        "pull_request",
+                        "pull_request_review",
+                        "pull_request_review_comment",
+                        "push",
+                        "status",
+                    ],
+                    "created_at": "2019-05-26T23:47:57.000-04:00",
+                    "updated_at": "2020-02-09T18:39:43.000-05:00",
+                    "single_file_name": None,
+                },
+                {
+                    "id": 136746,
+                    "account": {
+                        "login": "chdsbd",
+                        "id": 1929960,
+                        "node_id": "MDQ6VXNlcjE5Mjk5NjA=",
+                        "avatar_url": "https://avatars2.githubusercontent.com/u/1929960?v=4",
+                        "gravatar_id": "",
+                        "url": "https://api.github.com/users/chdsbd",
+                        "html_url": "https://github.com/chdsbd",
+                        "followers_url": "https://api.github.com/users/chdsbd/followers",
+                        "following_url": "https://api.github.com/users/chdsbd/following{/other_user}",
+                        "gists_url": "https://api.github.com/users/chdsbd/gists{/gist_id}",
+                        "starred_url": "https://api.github.com/users/chdsbd/starred{/owner}{/repo}",
+                        "subscriptions_url": "https://api.github.com/users/chdsbd/subscriptions",
+                        "organizations_url": "https://api.github.com/users/chdsbd/orgs",
+                        "repos_url": "https://api.github.com/users/chdsbd/repos",
+                        "events_url": "https://api.github.com/users/chdsbd/events{/privacy}",
+                        "received_events_url": "https://api.github.com/users/chdsbd/received_events",
+                        "type": "User",
+                        "site_admin": False,
+                    },
+                    "repository_selection": "selected",
+                    "access_tokens_url": "https://api.github.com/app/installations/1066615/access_tokens",
+                    "repositories_url": "https://api.github.com/installation/repositories",
+                    "html_url": "https://github.com/settings/installations/1066615",
+                    "app_id": 31500,
+                    "app_slug": "kodiak-local-dev",
+                    "target_id": 1929960,
+                    "target_type": "User",
+                    "permissions": {
+                        "administration": "read",
+                        "checks": "write",
+                        "contents": "write",
+                        "issues": "read",
+                        "metadata": "read",
+                        "pull_requests": "write",
+                        "statuses": "read",
+                    },
+                    "events": [
+                        "check_run",
+                        "issue_comment",
+                        "pull_request",
+                        "pull_request_review",
+                        "pull_request_review_comment",
+                        "push",
+                        "status",
+                    ],
+                    "created_at": "2019-05-26T23:47:57.000-04:00",
+                    "updated_at": "2020-02-09T18:39:43.000-05:00",
+                    "single_file_name": None,
+                },
+                {
+                    "id": 81843,
+                    "account": {
+                        "login": "recipeyak",
+                        "id": 57954,
+                        "node_id": "MDQ6T3JnYW5pemF0aW9uNTc5NTQ=",
+                        "avatar_url": "https://avatars2.githubusercontent.com/u/57954?v=4",
+                        "gravatar_id": "",
+                        "url": "https://api.github.com/users/recipeyak",
+                        "html_url": "https://github.com/recipeyak",
+                        "followers_url": "https://api.github.com/users/recipeyak/followers",
+                        "following_url": "https://api.github.com/users/recipeyak/following{/other_user}",
+                        "gists_url": "https://api.github.com/users/recipeyak/gists{/gist_id}",
+                        "starred_url": "https://api.github.com/users/recipeyak/starred{/owner}{/repo}",
+                        "subscriptions_url": "https://api.github.com/users/recipeyak/subscriptions",
+                        "organizations_url": "https://api.github.com/users/recipeyak/orgs",
+                        "repos_url": "https://api.github.com/users/recipeyak/repos",
+                        "events_url": "https://api.github.com/users/recipeyak/events{/privacy}",
+                        "received_events_url": "https://api.github.com/users/recipeyak/received_events",
+                        "type": "Organization",
+                        "site_admin": False,
+                    },
+                    "repository_selection": "selected",
+                    "access_tokens_url": "https://api.github.com/app/installations/81843/access_tokens",
+                    "repositories_url": "https://api.github.com/installation/repositories",
+                    "html_url": "https://github.com/settings/installations/81843",
+                    "app_id": 31500,
+                    "app_slug": "kodiak-local-dev",
+                    "target_id": 1929960,
+                    "target_type": "User",
+                    "permissions": {
+                        "administration": "read",
+                        "checks": "write",
+                        "contents": "write",
+                        "issues": "read",
+                        "metadata": "read",
+                        "pull_requests": "write",
+                        "statuses": "read",
+                    },
+                    "events": [
+                        "check_run",
+                        "issue_comment",
+                        "pull_request",
+                        "pull_request_review",
+                        "pull_request_review_comment",
+                        "push",
+                        "status",
+                    ],
+                    "created_at": "2019-06-12T16:21:22.000-04:00",
+                    "updated_at": "2020-03-11T13:11:25.000-05:00",
+                    "single_file_name": None,
+                },
+                {
+                    "id": 65490234,
+                    "account": {
+                        "login": "acme-corp",
+                        "id": 23452345,
+                        "node_id": "MDQ6T3JnYW5pemF0aW9uNjU0OTAyMzQK",
+                        "avatar_url": "https://avatars2.githubusercontent.com/u/57954?v=4",
+                        "gravatar_id": "",
+                        "url": "https://api.github.com/users/acme-corp",
+                        "html_url": "https://github.com/acme-corp",
+                        "followers_url": "https://api.github.com/users/acme-corp/followers",
+                        "following_url": "https://api.github.com/users/acme-corp/following{/other_user}",
+                        "gists_url": "https://api.github.com/users/acme-corp/gists{/gist_id}",
+                        "starred_url": "https://api.github.com/users/acme-corp/starred{/owner}{/repo}",
+                        "subscriptions_url": "https://api.github.com/users/acme-corp/subscriptions",
+                        "organizations_url": "https://api.github.com/users/acme-corp/orgs",
+                        "repos_url": "https://api.github.com/users/acme-corp/repos",
+                        "events_url": "https://api.github.com/users/acme-corp/events{/privacy}",
+                        "received_events_url": "https://api.github.com/users/acme-corp/received_events",
+                        "type": "Organization",
+                        "site_admin": False,
+                    },
+                    "repository_selection": "selected",
+                    "access_tokens_url": "https://api.github.com/app/installations/65490234/access_tokens",
+                    "repositories_url": "https://api.github.com/installation/repositories",
+                    "html_url": "https://github.com/settings/installations/65490234",
+                    "app_id": 31500,
+                    "app_slug": "kodiak-local-dev",
+                    "target_id": 1929960,
+                    "target_type": "User",
+                    "permissions": {
+                        "administration": "read",
+                        "checks": "write",
+                        "contents": "write",
+                        "issues": "read",
+                        "metadata": "read",
+                        "pull_requests": "write",
+                        "statuses": "read",
+                    },
+                    "events": [
+                        "check_run",
+                        "issue_comment",
+                        "pull_request",
+                        "pull_request_review",
+                        "pull_request_review_comment",
+                        "push",
+                        "status",
+                    ],
+                    "created_at": "2019-06-12T16:21:22.000-04:00",
+                    "updated_at": "2020-03-11T13:11:25.000-05:00",
+                    "single_file_name": None,
+                },
+            ],
+        },
+    )
+    mocked_responses.add(
+        responses.GET,
+        "https://api.github.com/orgs/recipeyak/memberships/ghost",
+        json={
+            "organization": {
+                "avatar_url": "https://avatars2.githubusercontent.com/u/57954?v=4",
+                "description": None,
+                "events_url": "https://api.github.com/orgs/recipeyak/events",
+                "hooks_url": "https://api.github.com/orgs/recipeyak/hooks",
+                "id": 57954,
+                "issues_url": "https://api.github.com/orgs/recipeyak/issues",
+                "login": "recipeyak",
+                "members_url": "https://api.github.com/orgs/recipeyak/members{/member}",
+                "node_id": "MDQ6T3JnYW5pemF0aW9uNTc5NTQ=",
+                "public_members_url": "https://api.github.com/orgs/recipeyak/public_members{/member}",
+                "repos_url": "https://api.github.com/orgs/recipeyak/repos",
+                "url": "https://api.github.com/orgs/recipeyak",
+            },
+            "organization_url": "https://api.github.com/orgs/recipeyak",
+            "role": "admin",
+            "state": "active",
+            "url": "https://api.github.com/orgs/recipeyak/memberships/ghost",
+            "user": {
+                "avatar_url": "https://avatars2.githubusercontent.com/u/1929960?v=4",
+                "events_url": "https://api.github.com/users/ghost/events{/privacy}",
+                "followers_url": "https://api.github.com/users/ghost/followers",
+                "following_url": "https://api.github.com/users/ghost/following{/other_user}",
+                "gists_url": "https://api.github.com/users/ghost/gists{/gist_id}",
+                "gravatar_id": "",
+                "html_url": "https://github.com/ghost",
+                "id": 10137,
+                "login": "ghost",
+                "node_id": "MDQ6VXNlcjEwMTM3Cg=",
+                "organizations_url": "https://api.github.com/users/ghost/orgs",
+                "received_events_url": "https://api.github.com/users/ghost/received_events",
+                "repos_url": "https://api.github.com/users/ghost/repos",
+                "site_admin": False,
+                "starred_url": "https://api.github.com/users/ghost/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/ghost/subscriptions",
+                "type": "User",
+                "url": "https://api.github.com/users/ghost",
+            },
+        },
+    )
+    mocked_responses.add(
+        responses.GET,
+        "https://api.github.com/orgs/acme-corp/memberships/ghost",
+        status=403,
+        json={
+            "message": "You must be a member of acme-corp to see membership information for ghost.",
+            "documentation_url": "https://developer.github.com/v3/orgs/members/#get-organization-membership",
+        },
+    )
+
+
 @pytest.mark.django_db
 def test_sync_accounts_failing_api_request(
     user: User, failing_installation_response: object
 ) -> None:
     with pytest.raises(SyncAccountsError):
         user.sync_accounts()
+
+
+@pytest.mark.django_db
+def test_sync_accounts_failing_api_requestv2(
+    user: User, failing_installation_response_membership_check: object
+) -> None:
+    assert Account.objects.count() == 0
+    assert AccountMembership.objects.count() == 0
+    assert User.objects.count() == 1
+    user.sync_accounts()
+
+    assert (
+        Account.objects.filter(
+            github_account_login__in=["ghost", "chdsbd", "recipeyak"]
+        ).count()
+        == Account.objects.count()
+        == 3
+    )
+    assert AccountMembership.objects.count() == 3
+    assert User.objects.count() == 1
 
 
 @pytest.mark.django_db

--- a/web_api/core/test_user.py
+++ b/web_api/core/test_user.py
@@ -533,9 +533,13 @@ def test_sync_accounts_failing_api_request(
 
 
 @pytest.mark.django_db
-def test_sync_accounts_failing_api_requestv2(
+def test_sync_accounts_failing_api_request_collaborator(
     user: User, failing_installation_response_membership_check: object
 ) -> None:
+    """
+    If the user is a collaborator of an organization they will get an API error
+    when testing membership. We should ignore the error and not add them to that organization.
+    """
     assert Account.objects.count() == 0
     assert AccountMembership.objects.count() == 0
     assert User.objects.count() == 1

--- a/web_api/core/test_views.py
+++ b/web_api/core/test_views.py
@@ -719,20 +719,6 @@ def test_sync_accounts_failure(
 
 
 @pytest.mark.django_db
-def test_sync_accounts_failure_account_membership(
-    authed_client: Client, failing_sync_accounts_response: object
-) -> None:
-    """
-    Verify that when a request to account membership fails we continue on without erring.
-    """
-    assert Account.objects.count() == 0
-    res = authed_client.post("/v1/sync_accounts")
-    assert res.status_code == 200
-    assert res.json()["ok"] is True
-    assert Account.objects.count() == 0
-
-
-@pytest.mark.django_db
 def test_current_account(authed_client: Client, user: User) -> None:
     user_account = Account.objects.create(
         github_installation_id=377930,

--- a/web_api/core/test_views.py
+++ b/web_api/core/test_views.py
@@ -719,6 +719,20 @@ def test_sync_accounts_failure(
 
 
 @pytest.mark.django_db
+def test_sync_accounts_failure_account_membership(
+    authed_client: Client, failing_sync_accounts_response: object
+) -> None:
+    """
+    Verify that when a request to account membership fails we continue on without erring.
+    """
+    assert Account.objects.count() == 0
+    res = authed_client.post("/v1/sync_accounts")
+    assert res.status_code == 200
+    assert res.json()["ok"] is True
+    assert Account.objects.count() == 0
+
+
+@pytest.mark.django_db
 def test_current_account(authed_client: Client, user: User) -> None:
     user_account = Account.objects.create(
         github_installation_id=377930,


### PR DESCRIPTION
If the user is a collaborator of an organization instead of a member or admin, calling GET https://api.github.com/orgs/:org/memberships/:user will fail with a permission error. This change handles that case.