### PR TITLE
update(tools): vscode cfg to sort imports & use project specific tools

### DIFF
--- a/bot/.isort.cfg
+++ b/bot/.isort.cfg
@@ -4,3 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+known_third_party=redis

--- a/bot/.vscode/settings.json
+++ b/bot/.vscode/settings.json
@@ -1,15 +1,15 @@
 {
-    "python.pythonPath": ".venv/bin/python",
-    "python.formatting.provider": "black",
-    "editor.formatOnSave": true,
-    "python.linting.mypyEnabled": true,
-    "python.testing.pytestArgs": [
-        "kodiak"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "python.linting.flake8Enabled": true,
-    "python.linting.pylintEnabled": true,
-    "typescript.preferences.importModuleSpecifier": "relative"
+  "python.pythonPath": ".venv/bin/python",
+  "python.formatting.provider": "black",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
+  "python.linting.mypyEnabled": true,
+  "python.testing.pytestArgs": ["kodiak"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.nosetestsEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "python.linting.flake8Enabled": true,
+  "python.linting.pylintEnabled": true
 }

--- a/kodiak.code-workspace
+++ b/kodiak.code-workspace
@@ -1,0 +1,17 @@
+{
+  "folders": [
+    {
+      "path": "web_ui"
+    },
+    {
+      "path": "bot"
+    },
+    {
+      "path": "web_api"
+    },
+    {
+      "path": "infrastructure"
+    }
+  ],
+  "settings": {}
+}

--- a/web_api/.isort.cfg
+++ b/web_api/.isort.cfg
@@ -4,3 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+known_third_party=redis

--- a/web_api/.vscode/settings.json
+++ b/web_api/.vscode/settings.json
@@ -1,14 +1,15 @@
 {
-    "python.pythonPath": ".venv/bin/python",
-    "python.formatting.provider": "black",
-    "editor.formatOnSave": true,
-    "python.linting.mypyEnabled": true,
-    "python.testing.pytestArgs": [
-        "kodiak"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "python.linting.flake8Enabled": true,
-    "python.linting.pylintEnabled": true
+  "python.pythonPath": ".venv/bin/python",
+  "python.formatting.provider": "black",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
+  "python.linting.mypyEnabled": true,
+  "python.testing.pytestArgs": ["kodiak"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.nosetestsEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "python.linting.flake8Enabled": true,
+  "python.linting.pylintEnabled": true
 }


### PR DESCRIPTION
Previously opening the project in the root wouldn't work well with vscode.
Each subproject needed to be opened separately to get lints & friends to
work.

Workspace allows each subfolder config to work as expected.

Opening the project in vscode is now done via:

```
code kodiak.code-workspace
```

in the root of the project.

Also updated the isort config because redis was being treated as a first party module.

rel: https://code.visualstudio.com/docs/editor/multi-root-workspaces