### PR TITLE
ref(bot): skip branch deletion if branch deletion is enabled on repo

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -470,7 +470,11 @@ async def mergeable(
             config.merge.delete_branch_on_merge,
         )
         await api.dequeue()
-        if not config.merge.delete_branch_on_merge or pull_request.isCrossRepository:
+        if (
+            not config.merge.delete_branch_on_merge
+            or pull_request.isCrossRepository
+            or repository.delete_branch_on_merge
+        ):
             return
         pr_count = await api.pull_requests_for_ref(ref=pull_request.headRefName)
         # if we couldn't access the dependent PR count or we have dependent PRs

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -87,6 +87,7 @@ query GetEventInfo($owner: String!, $repo: String!, $rootConfigFileExpression: S
     mergeCommitAllowed
     rebaseMergeAllowed
     squashMergeAllowed
+    deleteBranchOnMerge
     isPrivate
     pullRequest(number: $PRNumber) {
       id
@@ -261,6 +262,7 @@ class RepoInfo(BaseModel):
     merge_commit_allowed: bool
     rebase_merge_allowed: bool
     squash_merge_allowed: bool
+    delete_branch_on_merge: bool
     is_private: bool
 
 
@@ -869,6 +871,7 @@ class Client:
                 merge_commit_allowed=repository.get("mergeCommitAllowed", False),
                 rebase_merge_allowed=repository.get("rebaseMergeAllowed", False),
                 squash_merge_allowed=repository.get("squashMergeAllowed", False),
+                delete_branch_on_merge=repository.get("deleteBranchOnMerge") is True,
                 is_private=repository.get("isPrivate") is True,
             ),
             subscription=subscription,

--- a/bot/kodiak/test/fixtures/api/get_event/behind.json
+++ b/bot/kodiak/test/fixtures/api/get_event/behind.json
@@ -39,6 +39,7 @@
       "mergeCommitAllowed": false,
       "rebaseMergeAllowed": false,
       "squashMergeAllowed": true,
+      "deleteBranchOnMerge": true,
       "isPrivate": true,
       "pullRequest": {
         "id": "e14ff7599399478fb9dbc2dacb87da72",

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -115,6 +115,7 @@ def block_event() -> EventInfoResponse:
         merge_commit_allowed=False,
         rebase_merge_allowed=False,
         squash_merge_allowed=True,
+        delete_branch_on_merge=True,
         is_private=True,
     )
     branch_protection = BranchProtectionRule(

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -94,6 +94,8 @@ Once a PR is merged, delete the branch.
 
 This option behaves like the GitHub repository setting "Automatically delete head branches", which automatically deletes head branches after pull requests are merged.
 
+If "Automatically delete head branches" is enabled on the repository via the GitHub UI, Kodiak will _not_ attempt branch deletion.
+
 ### `merge.block_on_reviews_requested`
 
 - **type:** `boolean`


### PR DESCRIPTION
We shouldn't bother doing this work if we don't need to.

I think when automatic branch deletion was first introduced by GitHub it didn't work for bots, but now it does, so making the requests to github is a waste of time.