### PR TITLE
fix(bot): ignore conflicts when the PR is closed or merged

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -425,7 +425,7 @@ async def mergeable(
     if (
         pull_request.mergeStateStatus == MergeStateStatus.DIRTY
         or pull_request.mergeable == MergeableState.CONFLICTING
-    ):
+    ) and pull_request.state == PullRequestState.OPEN:
         await block_merge(api, pull_request, "merge conflict")
         # remove label if configured and send message
         if config.merge.notify_on_conflict and config.merge.require_automerge_label:


### PR DESCRIPTION
Post merge Kodiak said their was a merge conflict. This problem was introduced in #371, because prior to that we would return early if the PR was merged or closed, avoiding the merge conflict logic.

When a pull request is merged we will get `MergeStateStatus.DIRTY` and `MergeableState.CONFLICTING `, which would normally trigger a merge conflict error. However it's not helpful to leave a comment when the pull request is merged, so now we check and only comment if the pull request is open.