### PR TITLE
fix(bot): pushAllowance parsing for non-app actors

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -212,6 +212,9 @@ async def block_merge(api: PRAPI, pull_request: PullRequest, msg: str) -> None:
 
 def missing_push_allowance(push_allowances: List[PushAllowance]) -> bool:
     for push_allowance in push_allowances:
+        # a null databaseId indicates this is not a GitHub App.
+        if push_allowance.actor.databaseId is None:
+            continue
         if str(push_allowance.actor.databaseId) == str(app_config.GITHUB_APP_ID):
             return False
     return True

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -294,12 +294,13 @@ mutation merge($PRId: ID!, $SHA: GitObjectID!, $title: String, $body: String) {
 """
 
 
-class PushAllowanceActorApp(BaseModel):
+class PushAllowanceActor(BaseModel):
     """
     https://developer.github.com/v4/object/app/
     """
 
-    databaseId: int
+    # databaseId will be None for non github apps (users, organizations, teams).
+    databaseId: Optional[int]
 
 
 class PushAllowance(BaseModel):
@@ -307,7 +308,7 @@ class PushAllowance(BaseModel):
     https://developer.github.com/v4/object/pushallowance/
     """
 
-    actor: PushAllowanceActorApp
+    actor: PushAllowanceActor
 
 
 class NodeListPushAllowance(BaseModel):

--- a/bot/kodiak/test/fixtures/api/get_event/behind.json
+++ b/bot/kodiak/test/fixtures/api/get_event/behind.json
@@ -27,6 +27,9 @@
             "pushAllowances": {
               "nodes": [
                 {
+                  "actor": {}
+                },
+                {
                   "actor": {
                     "databaseId": 53453
                   }

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -34,7 +34,7 @@ from kodiak.queries import (
     PullRequestAuthor,
     PullRequestState,
     PushAllowance,
-    PushAllowanceActorApp,
+    PushAllowanceActor,
     RepoInfo,
     StatusContext,
     StatusState,
@@ -653,7 +653,7 @@ async def test_mergeable_missing_push_allowance_correct() -> None:
     branch_protection = create_branch_protection()
     branch_protection.restrictsPushes = True
     branch_protection.pushAllowances = NodeListPushAllowance(
-        nodes=[PushAllowance(actor=PushAllowanceActorApp(databaseId=534524))]
+        nodes=[PushAllowance(actor=PushAllowanceActor(databaseId=534524))]
     )
     await mergeable(api=api, branch_protection=branch_protection)
     assert api.queue_for_merge.called is True

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -29,7 +29,7 @@ from kodiak.queries import (
     PullRequestAuthor,
     PullRequestState,
     PushAllowance,
-    PushAllowanceActorApp,
+    PushAllowanceActor,
     RepoInfo,
     StatusContext,
     StatusState,
@@ -133,7 +133,10 @@ def block_event() -> EventInfoResponse:
         requiresCommitSignatures=False,
         restrictsPushes=True,
         pushAllowances=NodeListPushAllowance(
-            nodes=[PushAllowance(actor=PushAllowanceActorApp(databaseId=53453))]
+            nodes=[
+                PushAllowance(actor=PushAllowanceActor(databaseId=None)),
+                PushAllowance(actor=PushAllowanceActor(databaseId=53453)),
+            ]
         ),
     )
 


### PR DESCRIPTION
If a push allowance was for a non-app actor we'd get:

```
{
  "actor": {}
}
```

Instead of:

```
{
  "actor": {
    "databaseId": 29196
  }
}
```

This would fail to parse, which would cause the BranchProtectionRule to return None and Kodiak to not run.