### PR TITLE
fix(bot): disable Kodiak on GitHub API merge internal server error

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -124,7 +124,7 @@ class V1(BaseModel):
     merge: Merge = Merge()
     update: Update = Update()
     approve: Approve = Approve()
-    # label to apply to pull request to disable Kodiak from taking any action
+    # when added to a Pull Request Kodiak will be prevented from taking any action
     # (approvals, updates, merges, comments, labels). Kodiak will still set
     # status checks. A user should generally not need to change this label as it
     # should rarely be applied.

--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -83,10 +83,6 @@ class Merge(BaseModel):
     #
     # immediately update a PR whenever the target updates
     update_branch_immediately: bool = False
-    # label to apply to pull request when Kodiak encounters a 500 error merging
-    # a pull request. This is only used when merge.require_automerge_label is
-    # disabled.
-    merge_failure_label: str = "kodiak:merge-failed"
     # if a PR is passing all checks and is able to be merged, merge it without
     # placing it in the queue. This will introduce some unfairness where those
     # waiting in the queue the longest will not be served first.
@@ -128,6 +124,11 @@ class V1(BaseModel):
     merge: Merge = Merge()
     update: Update = Update()
     approve: Approve = Approve()
+    # label to apply to pull request to disable Kodiak from taking any action
+    # (approvals, updates, merges, comments, labels). Kodiak will still set
+    # status checks. A user should generally not need to change this label as it
+    # should rarely be applied.
+    disable_bot_label: str = "kodiak:disabled"
 
     @validator("version", pre=True, always=True)
     def correct_version(cls, v: int) -> int:

--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -83,6 +83,7 @@ class Merge(BaseModel):
     #
     # immediately update a PR whenever the target updates
     update_branch_immediately: bool = False
+    merge_failure_label: str = "kodiak:merge-failed"
     # if a PR is passing all checks and is able to be merged, merge it without
     # placing it in the queue. This will introduce some unfairness where those
     # waiting in the queue the longest will not be served first.

--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -83,6 +83,9 @@ class Merge(BaseModel):
     #
     # immediately update a PR whenever the target updates
     update_branch_immediately: bool = False
+    # label to apply to pull request when Kodiak encounters a 500 error merging
+    # a pull request. This is only used when merge.require_automerge_label is
+    # disabled.
     merge_failure_label: str = "kodiak:merge-failed"
     # if a PR is passing all checks and is able to be merged, merge it without
     # placing it in the queue. This will introduce some unfairness where those

--- a/bot/kodiak/errors.py
+++ b/bot/kodiak/errors.py
@@ -9,3 +9,7 @@ class PollForever(Exception):
 class ApiCallException(Exception):
     def __init__(self, method: str) -> None:
         self.method = method
+
+
+class GitHubApiInternalServerError(Exception):
+    pass

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -350,6 +350,14 @@ async def mergeable(
     # we keep the configuration errors before the rest of the application logic
     # so configuration issues are surfaced as early as possible.
 
+    if config.merge.merge_failure_label in pull_request.labels:
+        await api.dequeue()
+        await api.set_status(
+            f"🚨 kodiak disabled by merge.merge_failure_label ({config.merge.merge_failure_label}). Remove label to re-enable Kodiak.",
+            latest_commit_sha=pull_request.latest_sha,
+        )
+        return
+
     if (
         app_config.SUBSCRIPTIONS_ENABLED
         and repository.is_private

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -12,7 +12,11 @@ from typing_extensions import Protocol
 
 from kodiak import app_config, config, messages
 from kodiak.config import V1, BodyText, MergeBodyStyle, MergeMethod, MergeTitleStyle
-from kodiak.errors import PollForever, RetryForSkippableChecks
+from kodiak.errors import (
+    GitHubApiInternalServerError,
+    PollForever,
+    RetryForSkippableChecks,
+)
 from kodiak.messages import (
     get_markdown_for_config,
     get_markdown_for_paywall,
@@ -776,7 +780,7 @@ branch protection requirements.
                 await api.add_label(config.merge.merge_failure_label)
 
             await block_merge(
-                api, pull_request, f"Cannot merge due to GitHub API failure."
+                api, pull_request, "Cannot merge due to GitHub API failure."
             )
             body = messages.format(
                 textwrap.dedent(

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -775,6 +775,10 @@ branch protection requirements.
         # _not_ safe to retry. Instead we mark the pull request as unmergable
         # and require a user to re-enable Kodiak on the pull request.
         except GitHubApiInternalServerError:
+            logger.warning(
+                "kodiak encountered GitHub API error merging pull request",
+                exc_info=True,
+            )
             # We add the disable_bot_label to disable Kodiak from taking any
             # action to update, approve, comment, label, or merge.
             disable_bot_label = config.disable_bot_label

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -350,10 +350,10 @@ async def mergeable(
     # we keep the configuration errors before the rest of the application logic
     # so configuration issues are surfaced as early as possible.
 
-    if config.merge.merge_failure_label in pull_request.labels:
+    if config.disable_bot_label in pull_request.labels:
         await api.dequeue()
         await api.set_status(
-            f"🚨 kodiak disabled by merge.merge_failure_label ({config.merge.merge_failure_label}). Remove label to re-enable Kodiak.",
+            f"🚨 kodiak disabled by disable_bot_label ({config.disable_bot_label}). Remove label to re-enable Kodiak.",
             latest_commit_sha=pull_request.latest_sha,
         )
         return
@@ -777,15 +777,15 @@ branch protection requirements.
         except GitHubApiInternalServerError:
             # if require_automerge_label is enabled, we'll remove that to
             # disable Kodiak for the pull request. If disabled, we'll add a new
-            # label (merge.merge_failure_label) to disable Kodiak.
+            # label (disable_bot_label) to disable Kodiak.
             if config.merge.require_automerge_label:
                 automerge_label = config.merge.automerge_label
                 error_message = f"please re-add the `{automerge_label}` label"
                 await api.remove_label(automerge_label)
             else:
-                merge_failure_label = config.merge.merge_failure_label
+                merge_failure_label = config.disable_bot_label
                 error_message = f"please remove the `{merge_failure_label}` label"
-                await api.add_label(config.merge.merge_failure_label)
+                await api.add_label(config.disable_bot_label)
 
             await block_merge(
                 api, pull_request, "Cannot merge due to GitHub API failure."

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -775,17 +775,10 @@ branch protection requirements.
         # _not_ safe to retry. Instead we mark the pull request as unmergable
         # and require a user to re-enable Kodiak on the pull request.
         except GitHubApiInternalServerError:
-            # if require_automerge_label is enabled, we'll remove that to
-            # disable Kodiak for the pull request. If disabled, we'll add a new
-            # label (disable_bot_label) to disable Kodiak.
-            if config.merge.require_automerge_label:
-                automerge_label = config.merge.automerge_label
-                error_message = f"please re-add the `{automerge_label}` label"
-                await api.remove_label(automerge_label)
-            else:
-                merge_failure_label = config.disable_bot_label
-                error_message = f"please remove the `{merge_failure_label}` label"
-                await api.add_label(config.disable_bot_label)
+            # We add the disable_bot_label to disable Kodiak from taking any
+            # action to update, approve, comment, label, or merge.
+            disable_bot_label = config.disable_bot_label
+            await api.add_label(disable_bot_label)
 
             await block_merge(
                 api, pull_request, "Cannot merge due to GitHub API failure."
@@ -793,7 +786,7 @@ branch protection requirements.
             body = messages.format(
                 textwrap.dedent(
                     f"""
-            This PR could not be merged because the GitHub API returned an internal server error. To enable Kodiak on this pull request {error_message}.
+            This PR could not be merged because the GitHub API returned an internal server error. To enable Kodiak on this pull request please remove the `{disable_bot_label}` label.
 
             When the GitHub API returns an internal server error (HTTP status code 500), it is not safe for Kodiak to retry merging.
 

--- a/bot/kodiak/messages.py
+++ b/bot/kodiak/messages.py
@@ -8,11 +8,12 @@ FOOTER = """
 If you need help, you can open a GitHub issue, check the docs, or reach us privately at support@kodiakhq.com.
 
 [docs](https://kodiakhq.com/docs/troubleshooting) | [dashboard](https://app.kodiakhq.com) | [support](https://kodiakhq.com/help)
+
 """
 
 
 def format(msg: str) -> str:
-    return msg + "\n\n" + FOOTER
+    return msg + "\n" + FOOTER
 
 
 def get_markdown_for_config(

--- a/bot/kodiak/messages.py
+++ b/bot/kodiak/messages.py
@@ -11,6 +11,10 @@ If you need help, you can open a GitHub issue, check the docs, or reach us priva
 """
 
 
+def format(msg: str) -> str:
+    return msg + "\n\n" + FOOTER
+
+
 def get_markdown_for_config(
     error: Union[pydantic.ValidationError, toml.TomlDecodeError],
     config_str: str,
@@ -22,7 +26,8 @@ def get_markdown_for_config(
     else:
         error_escaped = markupsafe.escape(repr(error))
     line_count = config_str.count("\n") + 1
-    return f"""\
+    return format(
+        f"""\
 You have an invalid Kodiak configuration file.
 
 ## configuration file
@@ -42,29 +47,27 @@ You have an invalid Kodiak configuration file.
 - Check the Kodiak docs for setup information at https://kodiakhq.com/docs/quickstart.
 - A configuration reference is available at https://kodiakhq.com/docs/config-reference.
 - Full examples are available at https://kodiakhq.com/docs/recipes
-
-{FOOTER}
 """
+    )
 
 
 def get_markdown_for_paywall() -> str:
-    return f"""\
+    return format(
+        f"""\
 You can start a 30 day trial or update your subscription on the Kodiak dashboard at https://app.kodiakhq.com.
 
 Kodiak is free to use on public repositories, but requires a subscription to use with private repositories.
 
 See the [Kodiak docs](https://kodiakhq.com/docs/billing) for more information about free trials and subscriptions.
-
-{FOOTER}
 """
+    )
 
 
 def get_markdown_for_push_allowance_error(*, branch_name: str) -> str:
-    return f"""\
+    return format(
+        f"""\
 Your branch protection setting for `{branch_name}` has "Restrict who can push to matching branches" enabled. You must allow Kodiak to push to this branch for Kodiak to merge pull requests.
 
 See the Kodiak troubleshooting docs for more information: https://kodiakhq.com/docs/troubleshooting#restricting-pushes
-
-
-{FOOTER}
 """
+    )

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -283,6 +283,8 @@ class PRV2:
                     )
                 else:
                     self.log.exception("failed to merge pull request", res=res)
+                if e.response is not None and e.response.status_code == 500:
+                    raise GitHubApiInternalServerError
                 # we raise an exception to retry this request.
                 raise ApiCallException("merge")
 

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -309,7 +309,7 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.exception("failed to delete label", label=label, res=res)
+                self.log.exception("failed to add label", label=label, res=res)
                 raise ApiCallException("add label")
 
     async def remove_label(self, label: str) -> None:

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -988,6 +988,15 @@ class Client:
         async with self.throttler:
             return await self.session.post(url, headers=headers, json=body)
 
+    async def add_label(self, label: str, pull_number: int) -> http.Response:
+        headers = await get_headers(installation_id=self.installation_id)
+        async with self.throttler:
+            return await self.session.post(
+                f"https://api.github.com/repos/{self.owner}/{self.repo}/issues/{pull_number}/labels/",
+                json=dict(labels=[label]),
+                headers=headers,
+            )
+
     async def delete_label(self, label: str, pull_number: int) -> http.Response:
         headers = await get_headers(installation_id=self.installation_id)
         async with self.throttler:

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -992,7 +992,7 @@ class Client:
         headers = await get_headers(installation_id=self.installation_id)
         async with self.throttler:
             return await self.session.post(
-                f"https://api.github.com/repos/{self.owner}/{self.repo}/issues/{pull_number}/labels/",
+                f"https://api.github.com/repos/{self.owner}/{self.repo}/issues/{pull_number}/labels",
                 json=dict(labels=[label]),
                 headers=headers,
             )

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -33,6 +33,7 @@
         },
         "dont_wait_on_status_checks": [],
         "update_branch_immediately": false,
+        "merge_failure_label": "kodiak:merge-failed",
         "prioritize_ready_to_merge": false,
         "do_not_merge": false
       },
@@ -210,6 +211,11 @@
           "title": "Update Branch Immediately",
           "default": false,
           "type": "boolean"
+        },
+        "merge_failure_label": {
+          "title": "Merge Failure Label",
+          "default": "kodiak:merge-failed",
+          "type": "string"
         },
         "prioritize_ready_to_merge": {
           "title": "Prioritize Ready To Merge",

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -33,7 +33,6 @@
         },
         "dont_wait_on_status_checks": [],
         "update_branch_immediately": false,
-        "merge_failure_label": "kodiak:merge-failed",
         "prioritize_ready_to_merge": false,
         "do_not_merge": false
       },
@@ -66,6 +65,11 @@
           "$ref": "#/definitions/Approve"
         }
       ]
+    },
+    "disable_bot_label": {
+      "title": "Disable Bot Label",
+      "default": "kodiak:disabled",
+      "type": "string"
     }
   },
   "required": [
@@ -211,11 +215,6 @@
           "title": "Update Branch Immediately",
           "default": false,
           "type": "boolean"
-        },
-        "merge_failure_label": {
-          "title": "Merge Failure Label",
-          "default": "kodiak:merge-failed",
-          "type": "string"
         },
         "prioritize_ready_to_merge": {
           "title": "Prioritize Ready To Merge",

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -4195,7 +4195,7 @@ async def test_mergeable_merge_pull_request_api_exception() -> None:
 @pytest.mark.asyncio
 async def test_mergeable_merge_pull_request_api_exception_require_automerge_label_disabled() -> None:
     """
-    When merge.require_automerge_label is disabled we cannot use the merge.automerge_label to disable merging. Instead we add merge.merge_failure_label and leave a similar comment.
+    When merge.require_automerge_label is disabled we cannot use the merge.automerge_label to disable merging. Instead we add disable_bot_label and leave a similar comment.
     """
     api = create_api()
     mergeable = create_mergeable()
@@ -4212,14 +4212,14 @@ async def test_mergeable_merge_pull_request_api_exception_require_automerge_labe
     assert api.dequeue.call_count == 1
     assert api.remove_label.call_count == 0
     assert api.add_label.call_count == 1
-    assert api.add_label.calls[0]["label"] == config.merge.merge_failure_label
+    assert api.add_label.calls[0]["label"] == config.disable_bot_label
     assert api.create_comment.call_count == 1
     assert (
         "This PR could not be merged because the GitHub API returned an internal server"
         in api.create_comment.calls[0]["body"]
     )
     assert (
-        f"remove the `{config.merge.merge_failure_label}` label"
+        f"remove the `{config.disable_bot_label}` label"
         in api.create_comment.calls[0]["body"]
     )
 
@@ -4231,7 +4231,7 @@ async def test_mergeable_merge_pull_request_api_exception_require_automerge_labe
 async def test_mergeable_merge_failure_label() -> None:
     """
     Kodiak should take no action on a pull request when
-    merge.merge_failure_label is applied. This is similar to missing an
+    disable_bot_label is applied. This is similar to missing an
     automerge label when require_automerge_label is enabled.
     """
     api = create_api()
@@ -4240,13 +4240,11 @@ async def test_mergeable_merge_failure_label() -> None:
     pull_request = create_pull_request()
 
     config.merge.require_automerge_label = False
-    pull_request.labels = [config.merge.merge_failure_label]
+    pull_request.labels = [config.disable_bot_label]
 
     await mergeable(api=api, config=config, pull_request=pull_request, merging=True)
     assert api.set_status.call_count == 1
-    assert (
-        "kodiak disabled by merge.merge_failure_label" in api.set_status.calls[0]["msg"]
-    )
+    assert "kodiak disabled by disable_bot_label" in api.set_status.calls[0]["msg"]
     assert api.dequeue.call_count == 1
 
     assert api.update_branch.call_count == 0

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -108,6 +108,11 @@ class MockRemoveLabel(BaseMockFunc):
         self.log_call(dict(label=label))
 
 
+class MockAddLabel(BaseMockFunc):
+    async def __call__(self, label: str) -> None:
+        self.log_call(dict(label=label))
+
+
 class MockCreateComment(BaseMockFunc):
     async def __call__(self, body: str) -> None:
         self.log_call(dict(body=body))
@@ -165,6 +170,7 @@ class MockPrApi:
         self.pull_requests_for_ref = MockPullRequestsForRef()
         self.delete_branch = MockDeleteBranch()
         self.remove_label = MockRemoveLabel()
+        self.add_label = MockAddLabel()
         self.create_comment = MockCreateComment()
         self.trigger_test_commit = MockTriggerTestCommit()
         self.merge = MockMerge()

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Any, List, Mapping, Optional, Tuple, Union
+from typing import Any, List, Mapping, Optional, Tuple, Type, Union
 
 import pydantic
 import pytest
@@ -16,9 +16,9 @@ from kodiak.config import (
     MergeTitleStyle,
 )
 from kodiak.errors import (
+    GitHubApiInternalServerError,
     PollForever,
     RetryForSkippableChecks,
-    GitHubApiInternalServerError,
 )
 from kodiak.evaluation import PRAPI, MergeBody, get_merge_body
 from kodiak.evaluation import mergeable as mergeable_func
@@ -128,7 +128,7 @@ class MockTriggerTestCommit(BaseMockFunc):
 
 
 class MockMerge(BaseMockFunc):
-    raises: Optional[Exception] = None
+    raises: Optional[Union[Type[Exception], Exception]] = None
 
     async def __call__(
         self,


### PR DESCRIPTION
This change disables Kodiak merging a pull request when it encounters an internal server error from the GitHub merge api. In this event, Kodiak adds a label `disable_kodiak_label` and leaves a comment describing the issue. Kodiak will not update, approve, comment on, label, or merge a pull request with the `disable_kodiak_label`. It will still update status checks. The user must remove this label to re-enable Kodiak merging the pull request.

fixes #397

## background
It is dangerous to retry merging when GitHub returns an internal server error (HTTP status code 500) because the merge can partially succeed in a way that will allow Kodiak to erroneously merge in a pull request multiple times, as we've seen in #397.

The GitHub pull request merge API is _not always_ idempotent (https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button). Normally if you try to merge an already merged pull request using this API you'll get a `405 Method not allowed` error, as documented in the GitHub API docs. However in an error state, when the GitHub API returns a 500 HTTP error, the pull request can be partially merged, as shown in #397.

It appears the git operations of merging the pull request branch into master can succeed but not affect the pull request state itself. In this failure scenario the pull request will still be in an OPEN state even though the underlying branch was merged successfully into the target branch.


## further discussion
I realized implementing this change that GitHub API calls to add pull request labels could also fail. In this case Kodiak would still erroneously merge a pull request.

I think the most robust solution to this GitHub API reliability problem would be to store some information in Redis to disable Kodiak. But then there's the problem of how to surface that data in the GitHub UI. If we can't trust the GitHub API, how can we notify a user that Kodiak is disabled on their pull request? 🙍‍♂️ 

## screenshots
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1929960/82390717-7831bf80-9a0d-11ea-86ff-ab3b288ef370.png">
