### PR TITLE
add(doc): merge errors documentation

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -34,8 +34,8 @@ If you use the "Restrict who can push to matching branches" branch protection se
 
 If you see Kodiak providing a status check of "Merging blocked by GitHub requirements", this likely means there is a branch protection setting that conflicts with Kodiak. If you see this issue persistently please contact us at support@kodiakhq.com.
 
-
 ### Merge Errors
+
 It is dangerous to retry merging a pull request when GitHub returns an internal server error (HTTP status code 500) because the merge can partially succeed in a way that will leave the pull request open, but the branch merged.
 
 This state where the branch has been merged but the pull request remains open would trigger Kodiak to erroneously merge in the pull request multiple times, as we've seen in [#397](https://github.com/chdsbd/kodiak/issues/397). To prevent this behavior Kodiak will disable itself on a pull request if it encounters an internal server error when merging a pull request.

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -33,3 +33,11 @@ If you use the "Restrict who can push to matching branches" branch protection se
 ### Kodiak "Merging blocked by GitHub requirements" status check
 
 If you see Kodiak providing a status check of "Merging blocked by GitHub requirements", this likely means there is a branch protection setting that conflicts with Kodiak. If you see this issue persistently please contact us at support@kodiakhq.com.
+
+
+### Merge Errors
+It is dangerous to retry merging a pull request when GitHub returns an internal server error (HTTP status code 500) because the merge can partially succeed in a way that will leave the pull request open, but the branch merged.
+
+This state where the branch has been merged but the pull request remains open would trigger Kodiak to erroneously merge in the pull request multiple times, as we've seen in [#397](https://github.com/chdsbd/kodiak/issues/397). To prevent this behavior Kodiak will disable itself on a pull request if it encounters an internal server error when merging a pull request.
+
+Related issues: [#398](https://github.com/chdsbd/kodiak/pull/398), [#397](https://github.com/chdsbd/kodiak/issues/397)

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -40,4 +40,6 @@ It is dangerous to retry merging a pull request when GitHub returns an internal 
 
 This state where the branch has been merged but the pull request remains open would trigger Kodiak to erroneously merge in the pull request multiple times, as we've seen in [#397](https://github.com/chdsbd/kodiak/issues/397). To prevent this behavior Kodiak will disable itself on a pull request if it encounters an internal server error when merging a pull request.
 
+If Kodiak set the `disable_bot_label` label (default "kodiak:disabled") on your pull request you can remove the label to re-enable Kodiak. GitHub API instability is usually brief.
+
 Related issues: [#398](https://github.com/chdsbd/kodiak/pull/398), [#397](https://github.com/chdsbd/kodiak/issues/397)


### PR DESCRIPTION
I neglected to add this documentation even though I linked to it in the pull request comment:

https://github.com/chdsbd/kodiak/blob/9d60ed69160fa16bec36a29d6aba1f150fb0961e/bot/kodiak/evaluation.py#L796-L798