### PR TITLE
fix(bot): escaping in delete branch and delete label api calls

### DIFF
--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import urllib
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -917,7 +918,7 @@ class Client:
         delete a branch by name
         """
         headers = await get_headers(installation_id=self.installation_id)
-        ref = f"heads/{branch}"
+        ref = urllib.parse.quote(f"heads/{branch}")
         async with self.throttler:
             return await self.session.delete(
                 f"https://api.github.com/repos/{self.owner}/{self.repo}/git/refs/{ref}",
@@ -999,9 +1000,10 @@ class Client:
 
     async def delete_label(self, label: str, pull_number: int) -> http.Response:
         headers = await get_headers(installation_id=self.installation_id)
+        escaped_label = urllib.parse.quote(label)
         async with self.throttler:
             return await self.session.delete(
-                f"https://api.github.com/repos/{self.owner}/{self.repo}/issues/{pull_number}/labels/{label}",
+                f"https://api.github.com/repos/{self.owner}/{self.repo}/issues/{pull_number}/labels/{escaped_label}",
                 headers=headers,
             )
 


### PR DESCRIPTION
If a branch had a name that was not url safe, like `#123`, the resulting url we would call out to GitHub with would return 404 because `#` would leave the URL cut off.

The fix is to url encode the branch name. I've checked other queries and found one suspicious one and a false alarm.

If we pass url-unsafe parameters via `params` requests will escape them properly:

https://github.com/chdsbd/kodiak/blob/071ece2258de3eaa7dd34ec2db661d3c8ab3fc0b/bot/kodiak/queries.py#L902-L907

I think if a label was unsafely named we would fail to delete it. So I fixed this api call:

https://github.com/chdsbd/kodiak/blob/071ece2258de3eaa7dd34ec2db661d3c8ab3fc0b/bot/kodiak/queries.py#L1002-L1006

Fixes #407