### PR TITLE
fix: docker CMD to handle signals

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -21,4 +21,4 @@ RUN rm -rf /var/app/pip-wheel-metadata/
 # install cli
 RUN poetry install
 
-CMD poetry run uvicorn kodiak.main:app --host 0.0.0.0 --port $PORT
+CMD /var/app/.venv/bin/uvicorn kodiak.main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
Using `poetry run` means signals don't get sent correctly so stopping a container is slow. Calling uvicorn directly ensures signals are properly handled.

This is similar to what we do on the web api container.