### PR TITLE
add: merge.message.include_coauthors

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -41,6 +41,7 @@ class MergeMessage(BaseModel):
     body_type: BodyText = BodyText.markdown
     strip_html_comments: bool = False
     include_pull_request_author: bool = False
+    include_coauthors: bool = False
     include_pull_request_url: bool = False
 
 

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -79,8 +79,6 @@ class CommitAuthorName:
 def get_commit_author_info(
     *, login: str, databaseId: int, name: Optional[str], type_: str
 ) -> Optional[CommitAuthorName]:
-    if databaseId is None:
-        return None
     author_name = login
     author_login = login
     if type_ == "Bot":

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -180,6 +180,8 @@ def get_merge_body(
         MergeBodyStyle.empty,
         MergeBodyStyle.github_default,
     ):
+        # comment_message should never be None when using
+        # MergeBodyStyle.pull_request_body, but I'm not going to assert on that!
         commit_message = merge_body.commit_message or ""
         merge_body.commit_message = (
             commit_message + "\n\n" + "\n".join(co_author_trailers)

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -178,9 +178,9 @@ def get_merge_body(
                 )
             )
 
-    if coauthor_trailers and config.merge.message.body not in (
-        MergeBodyStyle.empty,
-        MergeBodyStyle.github_default,
+    if (
+        coauthor_trailers
+        and config.merge.message.body == MergeBodyStyle.pull_request_body
     ):
         # comment_message should never be None when using
         # MergeBodyStyle.pull_request_body, but I'm not going to assert on that!

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -137,7 +137,9 @@ def get_merge_body(
         else:
             merge_body.commit_message += "\n\n" + pull_request.url
 
-    co_author_trailers = []
+    # we share coauthor logic between include_pull_request_author and
+    # include_coauthors.
+    coauthor_trailers = []
     if config.merge.message.include_pull_request_author:
         author = get_commit_author_info(
             login=pull_request.author.login,
@@ -145,7 +147,7 @@ def get_merge_body(
             name=pull_request.author.name,
             type_=pull_request.author.type,
         )
-        co_author_trailers.append(
+        coauthor_trailers.append(
             get_coauthor_trailer(
                 user_id=pull_request.author.databaseId,
                 login=author.login,
@@ -168,7 +170,7 @@ def get_merge_body(
                 type_=commit_author.type,
             )
 
-            co_author_trailers.append(
+            coauthor_trailers.append(
                 get_coauthor_trailer(
                     user_id=commit_author.databaseId,
                     login=author.login,
@@ -176,7 +178,7 @@ def get_merge_body(
                 )
             )
 
-    if co_author_trailers and config.merge.message.body not in (
+    if coauthor_trailers and config.merge.message.body not in (
         MergeBodyStyle.empty,
         MergeBodyStyle.github_default,
     ):
@@ -184,7 +186,7 @@ def get_merge_body(
         # MergeBodyStyle.pull_request_body, but I'm not going to assert on that!
         commit_message = merge_body.commit_message or ""
         merge_body.commit_message = (
-            commit_message + "\n\n" + "\n".join(co_author_trailers)
+            commit_message + "\n\n" + "\n".join(coauthor_trailers)
         )
 
     return merge_body

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -151,8 +151,14 @@ def get_merge_body(
                 )
             )
 
-    if co_author_trailers and config.merge.message.body not in (MergeBodyStyle.empty, MergeBodyStyle.github_default):
-        merge_body.commit_message += "\n\n" + "\n".join(co_author_trailers)
+    if co_author_trailers and config.merge.message.body not in (
+        MergeBodyStyle.empty,
+        MergeBodyStyle.github_default,
+    ):
+        commit_message = merge_body.commit_message or ""
+        merge_body.commit_message = (
+            commit_message + "\n\n" + "\n".join(co_author_trailers)
+        )
 
     return merge_body
 

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -104,6 +104,7 @@ async def evaluate_pr(
                     reviews=pr.event.reviews,
                     contexts=pr.event.status_contexts,
                     check_runs=pr.event.check_runs,
+                    commit_authors=pr.event.commit_authors,
                     valid_signature=pr.event.valid_signature,
                     valid_merge_methods=pr.event.valid_merge_methods,
                     merging=merging,

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -451,6 +451,7 @@ class CommitAuthor(BaseModel):
     type: str
 
     def __hash__(self) -> int:
+        # defining a hash method allows us to deduplicate CommitAuthors easily.
         return hash(self.databaseId) + hash(self.login) + hash(self.name)
 
 
@@ -505,6 +506,9 @@ def get_sha(*, pr: dict) -> Optional[str]:
 
 
 def get_commit_authors(*, pr: dict) -> List[CommitAuthor]:
+    """
+    Extract the commit authors from the pull request commits.
+    """
     # we use a dict as an ordered set.
     commit_authors = {}
     try:

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -153,6 +153,7 @@ query GetEventInfo($owner: String!, $repo: String!, $rootConfigFileExpression: S
                 databaseId
                 name
                 login
+                type: __typename
               }
             }
           }
@@ -445,8 +446,9 @@ class TokenResponse(BaseModel):
 
 class CommitAuthor(BaseModel):
     databaseId: Optional[int]
-    login: Optional[str]
+    login: str
     name: Optional[str]
+    type: str
 
     def __hash__(self) -> int:
         return hash(self.databaseId) + hash(self.login) + hash(self.name)
@@ -512,9 +514,11 @@ def get_commit_authors(*, pr: dict) -> List[CommitAuthor]:
                     CommitAuthor.parse_obj(node["commit"]["author"]["user"])
                 ] = True
             except (pydantic.ValidationError, IndexError, KeyError, TypeError):
+                logger.warning("problem parsing commit author", exc_info=True)
                 continue
         return list(commit_authors.keys())
     except (IndexError, KeyError, TypeError):
+        logger.warning("problem parsing commit authors", exc_info=True)
         return []
 
 

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -504,7 +504,7 @@ def get_commit_authors(*, pr: dict) -> List[CommitAuthor]:
     commit_authors = set()
     try:
         for node in pr["commitHistory"]["nodes"]:
-            commit_author = node['commit']["author"]
+            commit_author = node["commit"]["author"]
             github_user = commit_author["user"]
             databaseId: Optional[int] = github_user["databaseId"]
             login: Optional[str] = github_user["login"]

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -29,6 +29,7 @@
           "body_type": "markdown",
           "strip_html_comments": false,
           "include_pull_request_author": false,
+          "include_coauthors": false,
           "include_pull_request_url": false
         },
         "dont_wait_on_status_checks": [],
@@ -122,6 +123,11 @@
           "default": false,
           "type": "boolean"
         },
+        "include_coauthors": {
+          "title": "Include Coauthors",
+          "default": false,
+          "type": "boolean"
+        },
         "include_pull_request_url": {
           "title": "Include Pull Request Url",
           "default": false,
@@ -195,6 +201,7 @@
             "body_type": "markdown",
             "strip_html_comments": false,
             "include_pull_request_author": false,
+            "include_coauthors": false,
             "include_pull_request_url": false
           },
           "allOf": [

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -3363,9 +3363,7 @@ def test_get_merge_body_include_coauthors(pull_request: PullRequest) -> None:
             CommitAuthor(
                 databaseId=590434, name="Maeve Millay", login="maeve-m", type="Bot"
             ),
-            CommitAuthor(
-                databaseId=771233, name=None, login="d-abernathy", type="Bot"
-            ),
+            CommitAuthor(databaseId=771233, name=None, login="d-abernathy", type="Bot"),
         ],
     )
     expected = MergeBody(

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1,5 +1,4 @@
 import logging
-import random
 from datetime import datetime, timedelta
 from typing import Any, List, Mapping, Optional, Tuple, Type, Union
 
@@ -272,15 +271,6 @@ def config_path() -> str:
 
 def create_config_path() -> str:
     return "master:.kodiak.toml"
-
-
-def create_commit_author() -> CommitAuthor:
-    database_id = random.randint(1, 10000)
-    return CommitAuthor(
-        databaseId=database_id,
-        login=f"j-doe-{database_id}",
-        name=f"J Doe {database_id}",
-    )
 
 
 @pytest.fixture
@@ -3367,13 +3357,17 @@ def test_get_merge_body_include_coauthors(pull_request: PullRequest) -> None:
         config=config,
         pull_request=pull_request,
         commit_authors=[
-            CommitAuthor(databaseId=9023904, name="b-lowe", login="Bernard Lowe"),
-            CommitAuthor(databaseId=590434, name="Maeve Millay", login="maeve-m"),
+            CommitAuthor(
+                databaseId=9023904, name="Bernard Lowe", login="b-lowe", type="User"
+            ),
+            CommitAuthor(
+                databaseId=590434, name="Maeve Millay", login="maeve-m", type="Bot"
+            ),
         ],
     )
     expected = MergeBody(
         merge_method="squash",
-        commit_message="hello world\n\nCo-authored-by: b-lowe <9023904+Bernard Lowe@users.noreply.github.com>\nCo-authored-by: Maeve Millay <590434+maeve-m@users.noreply.github.com>",
+        commit_message="hello world\n\nCo-authored-by: Bernard Lowe <9023904+b-lowe@users.noreply.github.com>\nCo-authored-by: Maeve Millay <590434+maeve-m[bot]@users.noreply.github.com>",
     )
     assert actual == expected
 
@@ -3394,8 +3388,10 @@ def test_get_merge_body_include_coauthors_invalid_body_style(
             config=config,
             pull_request=pull_request,
             commit_authors=[
-                CommitAuthor(databaseId=9023904, name="b-lowe", login="Bernard Lowe"),
-                CommitAuthor(databaseId=590434, name="Maeve Millay", login="maeve-m"),
+                CommitAuthor(databaseId=9023904, name="", login="b-lowe", type="User"),
+                CommitAuthor(
+                    databaseId=590434, name="Maeve Millay", login="maeve-m", type="Bot"
+                ),
             ],
         )
         expected = MergeBody(merge_method="squash", commit_message=commit_message)

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -3363,11 +3363,14 @@ def test_get_merge_body_include_coauthors(pull_request: PullRequest) -> None:
             CommitAuthor(
                 databaseId=590434, name="Maeve Millay", login="maeve-m", type="Bot"
             ),
+            CommitAuthor(
+                databaseId=771233, name=None, login="d-abernathy", type="Bot"
+            ),
         ],
     )
     expected = MergeBody(
         merge_method="squash",
-        commit_message="hello world\n\nCo-authored-by: Bernard Lowe <9023904+b-lowe@users.noreply.github.com>\nCo-authored-by: Maeve Millay <590434+maeve-m[bot]@users.noreply.github.com>",
+        commit_message="hello world\n\nCo-authored-by: Bernard Lowe <9023904+b-lowe@users.noreply.github.com>\nCo-authored-by: Maeve Millay <590434+maeve-m[bot]@users.noreply.github.com>\nCo-authored-by: d-abernathy[bot] <771233+d-abernathy[bot]@users.noreply.github.com>",
     )
     assert actual == expected
 

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -3332,6 +3332,10 @@ def test_get_merge_body_include_pull_request_author_mannequin(
 def test_get_merge_body_include_pull_request_author_invalid_body_style(
     pull_request: PullRequest
 ) -> None:
+    """
+    We only include trailers MergeBodyStyle.pull_request_body. Verify we don't
+    include trailers for MergeBodyStyle.github_default or MergeBodyStyle.empty.
+    """
     pull_request.body = "hello world"
     config = create_config()
     config.merge.message.include_pull_request_author = True
@@ -3349,6 +3353,9 @@ def test_get_merge_body_include_pull_request_author_invalid_body_style(
 
 
 def test_get_merge_body_include_coauthors(pull_request: PullRequest) -> None:
+    """
+    Verify we include coauthor trailers for MergeBodyStyle.pull_request_body.
+    """
     pull_request.body = "hello world"
     config = create_config()
     config.merge.message.body = MergeBodyStyle.pull_request_body
@@ -3380,6 +3387,11 @@ def test_get_merge_body_include_coauthors(pull_request: PullRequest) -> None:
 def test_get_merge_body_include_coauthors_invalid_body_style(
     pull_request: PullRequest
 ) -> None:
+    """
+    We only include trailers for MergeBodyStyle.pull_request_body. Verify we
+    don't add coauthor trailers for MergeBodyStyle.github_default or
+    MergeBodyStyle.empty.
+    """
     pull_request.body = "hello world"
     config = create_config()
     config.merge.message.include_coauthors = True


### PR DESCRIPTION
Add configuration option `merge.message.include_coauthors` to enable Kodiak to include coauthors in pull request body.
This option only applies to pull requests with `merge.message.body = "pull_request_body"`.

We add coauthors based on the last 100 commits on a pull request. We also only add coauthor information for commits that are linked to a GitHub user. We use the GitHub user's account information (login, id, name if available) to generate the coauthor trailers, not the commit author name or email.

resolves #277