### PR TITLE
fix(web): show plan seat cost when modifying subscription

### DIFF
--- a/web_ui/src/components/UsageBillingPage.tsx
+++ b/web_ui/src/components/UsageBillingPage.tsx
@@ -470,7 +470,7 @@ function ManageSubscriptionModal({
     })
   }
 
-  const costCents = seats * settings.monthlyCost
+  const costCents = seats * cost.perSeatCents
   return (
     <Modal show={show} onHide={() => onClose()}>
       <Modal.Header closeButton>


### PR DESCRIPTION
We were using the $4.99 price even if the user had a different plan setup.