### PR TITLE
fix(web_ui): scrolling to allow scrolling at margin of page

### DIFF
--- a/web_ui/src/components/Page.tsx
+++ b/web_ui/src/components/Page.tsx
@@ -15,10 +15,12 @@ export function Page({ children }: IPageProps) {
           <SideBarNav />
         </div>
         <ErrorBoundary>
-          <Container className="p-4 w-100 overflow-sm-auto">
-            <SubscriptionAlert />
-            {children}
-          </Container>
+          <div className="w-100 overflow-sm-auto">
+            <Container className="p-4">
+              <SubscriptionAlert />
+              {children}
+            </Container>
+          </div>
         </ErrorBoundary>
       </div>
     </div>


### PR DESCRIPTION
Previously you could only scroll on the center content and would get no feedback when scrolling in the margin.