### PR TITLE
fix(web_ui): only fetch proration information when modal is visible

### DIFF
--- a/web_ui/src/components/UsageBillingPage.tsx
+++ b/web_ui/src/components/UsageBillingPage.tsx
@@ -434,8 +434,10 @@ function ManageSubscriptionModal({
   )
 
   React.useEffect(() => {
-    fetchProrationDebounced()
-  }, [fetchProrationDebounced, seats])
+    if (show) {
+      fetchProrationDebounced()
+    }
+  }, [show, fetchProrationDebounced, seats])
 
   function formatProration(x: IProrationAmount) {
     if (x.kind === "loading" || x.kind === "failed") {


### PR DESCRIPTION
Previously we would fetch whenever the page loaded because the Modal component would load but remain hidden.