### PR TITLE
fix(bot): error handling to be less noisy

### DIFF
--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -514,8 +514,11 @@ def get_commit_authors(*, pr: dict) -> List[CommitAuthor]:
     try:
         for node in pr["commitHistory"]["nodes"]:
             try:
+                user = node["commit"]["author"]["user"]
+                if user is None:
+                    continue
                 commit_authors[
-                    CommitAuthor.parse_obj(node["commit"]["author"]["user"])
+                    CommitAuthor.parse_obj(user)
                 ] = True
             except (pydantic.ValidationError, IndexError, KeyError, TypeError):
                 logger.warning("problem parsing commit author", exc_info=True)

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -517,9 +517,7 @@ def get_commit_authors(*, pr: dict) -> List[CommitAuthor]:
                 user = node["commit"]["author"]["user"]
                 if user is None:
                     continue
-                commit_authors[
-                    CommitAuthor.parse_obj(user)
-                ] = True
+                commit_authors[CommitAuthor.parse_obj(user)] = True
             except (pydantic.ValidationError, IndexError, KeyError, TypeError):
                 logger.warning("problem parsing commit author", exc_info=True)
                 continue

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -614,13 +614,7 @@ def test_get_commit_authors() -> None:
                         }
                     }
                 },
-                {
-                    "commit": {
-                        "author": {
-                            "user": None
-                        }
-                    }
-                },
+                {"commit": {"author": {"user": None}}},
                 {
                     "commit": {
                         "author": {

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -617,6 +617,13 @@ def test_get_commit_authors() -> None:
                 {
                     "commit": {
                         "author": {
+                            "user": None
+                        }
+                    }
+                },
+                {
+                    "commit": {
+                        "author": {
                             "user": {
                                 "name": "Christopher Dignam",
                                 "databaseId": 1929960,


### PR DESCRIPTION
It appears that "user" can frequently be null. This is fine because we handle the errors, but we also log a warning which is noisy in Sentry.

We explicitly handle the null case so we don't log a warning about it.

This test doesn't really do much but I manually verified that we don't log a warning with this case.