### PR TITLE
tools(squawk): fix setup for circle ci

### DIFF
--- a/web_api/s/squawk.py
+++ b/web_api/s/squawk.py
@@ -45,7 +45,7 @@ def main() -> None:
     # circle's built in git checkout code clobbers the `master` ref so we do the
     # following to make it not point to the current ref.
     # https://discuss.circleci.com/t/git-checkout-of-a-branch-destroys-local-reference-to-master/23781/7
-    if os.getenv("CIRCLECI"):
+    if os.getenv("CIRCLECI") and os.getenv("CIRCLE_BRANCH") != "master":
         subprocess.run(["git", "branch", "-f", "master", "origin/master"], check=True)
 
     diff_cmd = [


### PR DESCRIPTION
When merging to master CI runs again and the git command to fix Circle's
clobbering of the master ref fails.

Now we'll only run that when we aren't on master.

rel: https://github.com/recipeyak/recipeyak/pull/576