### PR TITLE
add(bot): use valid repo merge method if not specified

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -64,7 +64,7 @@ class Merge(BaseModel):
     blocking_labels: List[str] = []
     # action to take when attempting to merge PR. An error will occur if method
     # is disabled for repository
-    method: MergeMethod = MergeMethod.merge
+    method: Optional[MergeMethod] = None
     # delete branch when PR is merged
     delete_branch_on_merge: bool = False
     # DEPRECATED

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -435,7 +435,13 @@ async def mergeable(
         )
         return
 
-    merge_method = config.merge.method
+    if config.merge.method is not None:
+        merge_method = config.merge.method
+    elif len(valid_merge_methods) == 1:
+        merge_method = valid_merge_methods[0]
+    else:
+        merge_method = MergeMethod.merge
+
     if (
         branch_protection.requiresCommitSignatures
         and merge_method == MergeMethod.rebase

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -19,7 +19,7 @@
         "blocking_title_regex": ":::|||kodiak|||internal|||reserved|||:::",
         "blacklist_labels": [],
         "blocking_labels": [],
-        "method": "merge",
+        "method": null,
         "delete_branch_on_merge": false,
         "block_on_reviews_requested": false,
         "notify_on_conflict": true,
@@ -180,7 +180,6 @@
         },
         "method": {
           "title": "Method",
-          "default": "merge",
           "enum": [
             "merge",
             "squash",

--- a/bot/kodiak/test/fixtures/config/v1-default.toml
+++ b/bot/kodiak/test/fixtures/config/v1-default.toml
@@ -8,7 +8,6 @@ require_automerge_label = true
 # `WIP:.*` default regex in evaluation.py
 blacklist_title_regex = ":::|||kodiak|||internal|||reserved|||:::"
 blacklist_labels = []
-method = "merge"
 delete_branch_on_merge = false
 block_on_reviews_requested = false
 notify_on_conflict = true

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1132,6 +1132,61 @@ async def test_mergeable_single_merge_method() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mergeable_two_merge_methods() -> None:
+    """
+    If we have two options available, choose the first one, based on our ordered
+    list of "merge", "squash", "rebase".
+    """
+    api = create_api()
+    mergeable = create_mergeable()
+    config = create_config()
+
+    assert config.merge.method is None, "we must not specify a default for this to work"
+
+    await mergeable(
+        api=api,
+        config=config,
+        valid_merge_methods=[
+            # Kodiak should select the first valid merge method if `merge.method`
+            # is not configured.
+            MergeMethod.squash,
+            MergeMethod.rebase,
+        ],
+        merging=True,
+    )
+    assert api.merge.call_count == 1
+    assert api.merge.calls[0]["merge_method"] == "squash"
+
+    assert api.dequeue.called is False
+    assert api.update_branch.called is False
+    assert api.queue_for_merge.called is False
+
+
+@pytest.mark.asyncio
+async def test_mergeable_no_valid_methods() -> None:
+    """
+    We should always have at least one valid_merge_method in production, but
+    this is just a test to make sure we handle this case anyway.
+    """
+    api = create_api()
+    mergeable = create_mergeable()
+    config = create_config()
+
+    assert config.merge.method is None, "we must not specify a default for this to work"
+
+    await mergeable(api=api, config=config, valid_merge_methods=[])
+    assert api.dequeue.call_count == 1
+    assert api.set_status.call_count == 1
+    assert (
+        "configured merge.method 'merge' is invalid." in api.set_status.calls[0]["msg"]
+    )
+
+    assert api.merge.called is False
+    assert api.update_branch.called is False
+    assert api.queue_for_merge.called is False
+
+
+@pytest.mark.asyncio
 async def test_mergeable_block_on_reviews_requested() -> None:
     """
     block merge if reviews are requested and merge.block_on_reviews_requested is

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1088,6 +1088,10 @@ async def test_mergeable_default_merge_method() -> None:
     mergeable = create_mergeable()
     config = create_config()
 
+    assert (
+        config.merge.method is None
+    ), "we shouldn't have specified a value for the merge method. We want to allow the default."
+
     await mergeable(api=api, config=config, merging=True)
     assert api.merge.call_count == 1
     assert api.merge.calls[0]["merge_method"] == MergeMethod.merge
@@ -1095,6 +1099,36 @@ async def test_mergeable_default_merge_method() -> None:
     assert api.dequeue.called is False
     assert api.queue_for_merge.called is False
     assert api.update_branch.called is False
+
+
+@pytest.mark.asyncio
+async def test_mergeable_single_merge_method() -> None:
+    """
+    If an account only has one merge method configured, use that if they haven't
+    specified an option.
+    """
+    api = create_api()
+    mergeable = create_mergeable()
+    config = create_config()
+
+    assert config.merge.method is None, "we must not specify a default for this to work"
+
+    await mergeable(
+        api=api,
+        config=config,
+        valid_merge_methods=[
+            # Kodiak should select the only valid merge method if `merge.method`
+            # is not configured.
+            MergeMethod.rebase
+        ],
+        merging=True,
+    )
+    assert api.merge.call_count == 1
+    assert api.merge.calls[0]["merge_method"] == "rebase"
+
+    assert api.dequeue.called is False
+    assert api.update_branch.called is False
+    assert api.queue_for_merge.called is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
If `merge.method` is not configured, use the first valid merge method in the repository based on the list "merge", "squash", "rebase".

For example, if a repository only allows "rebase" commits and `merge.method` is not provided, Kodiak will now use the "rebase" merge method. Previously it would have used the default "merge" method.

If a repository only allowed "squash" and "rebase", and `merge.method` was not configured, "squash" would be chosen because it is the first valid option in the list "merge", "squash", "rebase".

This change is backwards compatible for the most part. Kodiak now works instead of raising a configuration error if a user only allowed "squash" merge methods and didn't specify `merge.method`. If a user was relying on `"merge"` being the default, they will be okay since `"merge"` is the first option in the list of valid merge methods to try.

Fixes https://github.com/chdsbd/kodiak/issues/387

Docs will be updated in https://github.com/chdsbd/kodiak/pull/466.