### PR TITLE
add(bot): setting success status on merge complete

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -928,6 +928,8 @@ branch protection requirements.
                 )
             )
             await api.create_comment(body)
+        else:
+            await set_status("merge complete 🎉")
 
     else:
         position_in_queue = await api.queue_for_merge()

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -2384,8 +2384,9 @@ async def test_mergeable_prioritize_ready_to_merge(
         api_call_retry_method_name=None,
     )
 
-    assert api.set_status.call_count == 1
+    assert api.set_status.call_count == 2
     assert "attempting to merge PR (merging)" in api.set_status.calls[0]["msg"]
+    assert api.set_status.calls[1]["msg"] == "merge complete 🎉"
     assert api.dequeue.call_count == 0
     assert api.update_branch.call_count == 0
     assert api.merge.call_count == 1
@@ -2431,8 +2432,9 @@ async def test_mergeable_merge(
         merging=True,
     )
 
-    assert api.set_status.call_count == 1
+    assert api.set_status.call_count == 2
     assert "attempting to merge PR (merging)" in api.set_status.calls[0]["msg"]
+    assert api.set_status.calls[1]["msg"] == "merge complete 🎉"
     assert api.dequeue.call_count == 0
     assert api.update_branch.call_count == 0
     assert api.merge.call_count == 1
@@ -3546,8 +3548,9 @@ async def test_mergeable_include_coauthors() -> None:
         ],
         merging=True,
     )
-    assert api.set_status.call_count == 1
+    assert api.set_status.call_count == 2
     assert "attempting to merge PR" in api.set_status.calls[0]["msg"]
+    assert api.set_status.calls[1]["msg"] == "merge complete 🎉"
 
     assert api.merge.call_count == 1
     assert (


### PR DESCRIPTION
Previously we never update the status after merging a PR which means
the status stays at `status ⛴ attempting to merge PR (merging)`.

Now we show `merge complete 🎉`, but I'm open to other messages / emojis.

example of previous behavior: https://github.com/chdsbd/kodiak/runs/691144867

fixes: https://github.com/chdsbd/kodiak/issues/401