### PR TITLE
fix(CI): squawk python wrapper

### DIFF
--- a/web_api/s/squawk.py
+++ b/web_api/s/squawk.py
@@ -22,7 +22,7 @@ def is_installed(name: str) -> bool:
 
 
 def get_migration_id(filename: str) -> str:
-    return Path(filename).stem.split("_")[0]
+    return Path(filename).stem
 
 
 @dataclass(frozen=True)
@@ -53,7 +53,7 @@ def main() -> None:
         "--no-pager",
         "diff",
         "--name-only",
-        "master..",
+        "master...",
         MIGRATIONS_DIRECTORY,
     ]
 
@@ -107,7 +107,7 @@ def main() -> None:
     if not is_installed("squawk"):
         subprocess.run(["npm", "config", "set", "unsafe-perm", "true"], check=True)
         log.info("squawk not found, installing")
-        subprocess.run(["npm", "install", "-g", "squawk-cli@0.2.2"], check=True)
+        subprocess.run(["npm", "install", "-g", "squawk-cli@0.3.0"], check=True)
 
     pr_info = get_pr_info(os.environ)
     assert pr_info is not None


### PR DESCRIPTION
Getting the migrations was bugged by using `..` instead of `...`.

Also there can be multiple migrations with the same id so we use the
full filename instead.

bump version as well

rel: https://github.com/recipeyak/recipeyak/pull/583