### PR TITLE
tools(web_ui): add lints around restricted globals

### DIFF
--- a/web_ui/.eslintrc.js
+++ b/web_ui/.eslintrc.js
@@ -21,6 +21,16 @@ module.exports = {
   rules: {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
+    "no-restricted-globals": [
+      "error",
+      "close",
+      "closed",
+      "status",
+      "name",
+      "length",
+      "origin",
+      "event",
+    ],
     "react/self-closing-comp": [
       "error",
       {


### PR DESCRIPTION
Probably not super necessary to add but might as avoid them if we can.

rel: https://steve.dignam.xyz/2020/07/24/pesky-globals/