### PR TITLE
update(docs): split recipe and clarify merge.optimistic_updates

### DIFF
--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -142,6 +142,8 @@ If Kodiak is merging an out-of-date pull request that has running status checks,
 
 This setting can speed up merges by not waiting for status checks to finish on out-of-date pull requests.
 
+Assuming your status checks pass most of the time, it's useful to leave `merge.optimistic_updates` enabled.
+
 > **Note:** The "Require branches to be up to date before merging" GitHub Branch Protection setting must be enabled for Kodiak to update branches.
 
 ### `merge.dont_wait_on_status_checks`

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -140,7 +140,7 @@ This option only applies when `merge.require_automerge_label` is enabled.
 
 _Assuming your status checks pass most of the time, it's useful to leave `merge.optimistic_updates` enabled._
 
-If Kodiak is merging an out-of-date pull request that has running status checks, update the pull request branch without waiting for the running status checks to finish.
+If Kodiak is merging an out-of-date pull request that has running status checks, update the pull request's branch without waiting for the running status checks to finish.
 
 This setting can speed up merges by not waiting for status checks to finish on out-of-date pull requests.
 

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -144,7 +144,6 @@ If Kodiak is merging an out-of-date pull request that has running status checks,
 
 This setting can speed up merges by not waiting for status checks to finish on out-of-date pull requests.
 
-
 > **Note:** The "Require branches to be up to date before merging" GitHub Branch Protection setting must be enabled for Kodiak to update branches.
 
 ### `merge.dont_wait_on_status_checks`

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -138,11 +138,12 @@ This option only applies when `merge.require_automerge_label` is enabled.
 - **type:** `boolean`
 - **default:** `true`
 
+_Assuming your status checks pass most of the time, it's useful to leave `merge.optimistic_updates` enabled._
+
 If Kodiak is merging an out-of-date pull request that has running status checks, update the pull request branch without waiting for the running status checks to finish.
 
 This setting can speed up merges by not waiting for status checks to finish on out-of-date pull requests.
 
-Assuming your status checks pass most of the time, it's useful to leave `merge.optimistic_updates` enabled.
 
 > **Note:** The "Require branches to be up to date before merging" GitHub Branch Protection setting must be enabled for Kodiak to update branches.
 

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -138,7 +138,7 @@ This option only applies when `merge.require_automerge_label` is enabled.
 - **type:** `boolean`
 - **default:** `true`
 
-If an out-of-date pull request has running status checks, update the pull request branch without waiting for the running status checks to finish.
+If Kodiak is merging an out-of-date pull request that has running status checks, update the pull request branch without waiting for the running status checks to finish.
 
 This setting can speed up merges by not waiting for status checks to finish on out-of-date pull requests.
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -89,6 +89,8 @@ title = "pull_request_title" # default: "github_default"
 body = "pull_request_body" # default: "github_default"
 ```
 
+<span id="efficiency-and-speed"/> <!-- handle old links -->
+
 ## Efficient Merges
 
 By default, Kodiak will efficiently merge pull requests.
@@ -103,7 +105,7 @@ If we had multiple PRs waiting to be merged, each PR would only be updated (if r
 version = 1
 ```
 
-See ["Efficient Merging"](features.md#efficient-merging) for more information.
+See ["Efficient Merging"](features.md#efficient-merging) for more information about efficiency.
 
 ## Speedy Merges
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -91,15 +91,13 @@ body = "pull_request_body" # default: "github_default"
 
 ## Efficient Merges
 
-By default Kodiak will efficiently merge pull requests. 
-
+By default Kodiak will efficiently merge pull requests.
 
 When "Require branches to be up to date before merging" is enabled via GitHub Branch Protection settings, a pull request's branch must be up-to-date with the target branch before merge.
 
 By default Kodiak will efficiently update pull requests and only update a pull request just before merge.
 
 If we had multiple PRs waiting to be merged, each PR would only be updated prior to merge.
-
 
 ```toml
 # .kodiak.toml

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -91,11 +91,11 @@ body = "pull_request_body" # default: "github_default"
 
 ## Efficient Merges
 
-By default Kodiak will efficiently merge pull requests.
+By default, Kodiak will efficiently merge pull requests.
 
 When "Require branches to be up to date before merging" is enabled via GitHub Branch Protection settings, a pull request's branch must be up-to-date with the target branch before merge.
 
-By default Kodiak will only update a pull request just before merge.
+By default, Kodiak will only update a pull request just before merge.
 
 If we had multiple PRs waiting to be merged, each PR would only be updated prior to merge.
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -93,11 +93,9 @@ body = "pull_request_body" # default: "github_default"
 
 By default, Kodiak will efficiently merge pull requests.
 
-When "Require branches to be up to date before merging" is enabled via GitHub Branch Protection settings, a pull request's branch must be up-to-date with the target branch before merge.
+When ["Require branches to be up to date before merging"](features.md#updating-pull-requests) is enabled via GitHub Branch Protection settings, a pull request's branch must be up-to-date with the target branch before merge. In this case Kodiak will update a pull request just before merge.
 
-By default, Kodiak will only update a pull request just before merge.
-
-If we had multiple PRs waiting to be merged, each PR would only be updated prior to merge.
+If we had multiple PRs waiting to be merged, each PR would only be updated (if required) just before to merge.
 
 ```toml
 # .kodiak.toml
@@ -105,11 +103,13 @@ If we had multiple PRs waiting to be merged, each PR would only be updated prior
 version = 1
 ```
 
+See ["Efficient Merging"](features.md#efficient-merging) for more information.
+
 ## Speedy Merges
 
 By default, pull requests are merged on a first-come-first-served policy for the merge queue. Enabling [`merge.prioritize_ready_to_merge`](config-reference.md#mergeprioritize_ready_to_merge) bypasses the queue for any PR that can be merged without updates.
 
-Assuming "Require branches to be up to date before merging" is enabled via GitHub Branch Protection settings, when [`update.always`](config-reference.md#updatealways) is enabled, a pull request's branch will be updated when the target branch updates. This option may improve merge speeds but wastes resources.
+Assuming ["Require branches to be up to date before merging"](features.md#updating-pull-requests) is enabled via GitHub Branch Protection settings, when [`update.always`](config-reference.md#updatealways) is enabled, a pull request's branch will be updated when the target branch updates. This option may improve merge speeds but wastes resources.
 
 ```toml
 # .kodiak.toml

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -95,7 +95,7 @@ By default Kodiak will efficiently merge pull requests.
 
 When "Require branches to be up to date before merging" is enabled via GitHub Branch Protection settings, a pull request's branch must be up-to-date with the target branch before merge.
 
-By default Kodiak will efficiently update pull requests and only update a pull request just before merge.
+By default Kodiak will only update a pull request just before merge.
 
 If we had multiple PRs waiting to be merged, each PR would only be updated prior to merge.
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -89,20 +89,33 @@ title = "pull_request_title" # default: "github_default"
 body = "pull_request_body" # default: "github_default"
 ```
 
-## Efficiency and Speed
+## Efficient Merges
 
-This config prioritizes resource conservation by only updating a PR when it is ready to merge and favors speed by immediately merging any PR that is ready to merge.
+By default Kodiak will efficiently merge pull requests. 
 
-Disabling `merge.prioritize_ready_to_merge` would improve fairness by ensuring a first-come-first-served policy for the merge queue.
+
+When "Require branches to be up to date before merging" is enabled via GitHub Branch Protection settings, a pull request's branch must be up-to-date with the target branch before merge.
+
+By default Kodiak will efficiently update pull requests and only update a pull request just before merge.
+
+If we had multiple PRs waiting to be merged, each PR would only be updated prior to merge.
+
+
+```toml
+# .kodiak.toml
+# Kodiak is efficient by default
+version = 1
+```
+
+## Speedy Merges
+
+By default, pull requests are merged on a first-come-first-served policy for the merge queue. Enabling `merge.prioritize_ready_to_merge` bypasses the queue for any PR that can be merged without updates.
 
 ```toml
 # .kodiak.toml
 version = 1
 
 [merge]
-# don't wait for running status checks when a PR needs update.
-optimistic_updates = true # default: true
-
 # if a PR is ready, merge it, don't place it in the merge queue.
 prioritize_ready_to_merge = true # default: false
 ```

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -107,7 +107,9 @@ version = 1
 
 ## Speedy Merges
 
-By default, pull requests are merged on a first-come-first-served policy for the merge queue. Enabling `merge.prioritize_ready_to_merge` bypasses the queue for any PR that can be merged without updates.
+By default, pull requests are merged on a first-come-first-served policy for the merge queue. Enabling [`merge.prioritize_ready_to_merge`](config-reference.md#mergeprioritize_ready_to_merge) bypasses the queue for any PR that can be merged without updates.
+
+Assuming "Require branches to be up to date before merging" is enabled via GitHub Branch Protection settings, when [`update.always`](config-reference.md#updatealways) is enabled, a pull request's branch will be updated when the target branch updates. This option may improve merge speeds but wastes resources.
 
 ```toml
 # .kodiak.toml
@@ -116,6 +118,10 @@ version = 1
 [merge]
 # if a PR is ready, merge it, don't place it in the merge queue.
 prioritize_ready_to_merge = true # default: false
+
+[update]
+# immediately update a pull request's branch when outdated.
+always = true # default: false
 ```
 
 ## Better Merge Messages


### PR DESCRIPTION
Speed and efficiency are kind of contradictory choices. This change breaks this recipe into two distinct options.

This change also adds slightly more detail to `merge.optimistic_updates`.

fixes #475