### PR TITLE
fix(docs): broken links to code

### DIFF
--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -522,4 +522,4 @@ require_automerge_label = true # default: true
 
 ## other resources
 
-See [`kodiak/test/fixtures/config`](https://github.com/chdsbd/kodiak/tree/master/kodiak/test/fixtures/config) for more examples and [`kodiak/config.py`](https://github.com/chdsbd/kodiak/blob/master/kodiak/config.py) for the Python models that codify this configuration.
+See [`bot/kodiak/test/fixtures/config`](https://github.com/chdsbd/kodiak/tree/master/bot/kodiak/test/fixtures/config) for more examples and [`bot/kodiak/config.py`](https://github.com/chdsbd/kodiak/blob/master/bot/kodiak/config.py) for the Python models that codify this configuration.


### PR DESCRIPTION
These links were broken ages ago when we created the web api and web ui.