### PR TITLE
fix(bot): merge blockers conflicting with test commits

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -527,10 +527,10 @@ async def mergeable(
             return
 
     # we should trigger mergeability checks whenever we encounter UNKNOWN.
-    # 
+    #
     # I don't foresee conflicts with checking configuration errors,
     # `config.disable_bot_label`, and the paywall before this code.
-    # 
+    #
     # Previously we had an issue where this code wasn't being entered because
     # `merge.blocking_title_regex` was checked first. Which caused
     # `update.always` to not operate.


### PR DESCRIPTION
When mergeStateStatus is `UNKNOWN` we need to trigger a test commit so GitHub will evaluate the PR mergeability. This change fixes a conflict where the `merge.blocking_title_regex` was conflicting with the trigger_test_commit logic.

Now if a pull request state is `UNKOWN` we should always trigger a test commit.

Related https://github.com/chdsbd/kodiak/issues/261#issuecomment-671096403