### PR TITLE
fix(bot): trigger test commit loop

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -534,7 +534,10 @@ async def mergeable(
     # Previously we had an issue where this code wasn't being entered because
     # `merge.blocking_title_regex` was checked first. Which caused
     # `update.always` to not operate.
-    if pull_request.mergeable == MergeableState.UNKNOWN:
+    if (
+        pull_request.mergeable == MergeableState.UNKNOWN
+        and pull_request.state == PullRequestState.OPEN
+    ):
         # we need to trigger a test commit to fix this. We do that by calling
         # GET on the pull request endpoint.
         await api.trigger_test_commit()

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1646,6 +1646,9 @@ async def test_mergeable_pull_request_need_test_commit_need_update_pr_not_open()
     """
     If a pull request mergeable status is UNKNOWN _and_ it is OPEN we should
     trigger a test commit and queue it for evaluation.
+
+    Regression test to prevent infinite loop calling trigger_test_commit on
+    merged/closed pull requests.
     """
     api = create_api()
     mergeable = create_mergeable()

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1627,6 +1627,7 @@ async def test_mergeable_pull_request_need_test_commit_need_update() -> None:
     pull_request.title = "WIP: add(api): endpoint for checking notifications"
 
     pull_request.mergeable = MergeableState.UNKNOWN
+    pull_request.state = PullRequestState.OPEN
 
     await mergeable(api=api, pull_request=pull_request)
     assert api.set_status.call_count == 0
@@ -1638,6 +1639,46 @@ async def test_mergeable_pull_request_need_test_commit_need_update() -> None:
     assert api.update_branch.called is False
     assert api.merge.called is False
     assert api.queue_for_merge.called is False
+
+
+@pytest.mark.asyncio
+async def test_mergeable_pull_request_need_test_commit_need_update_pr_not_open() -> None:
+    """
+    If a pull request mergeable status is UNKNOWN _and_ it is OPEN we should
+    trigger a test commit and queue it for evaluation.
+    """
+    api = create_api()
+    mergeable = create_mergeable()
+    pull_request = create_pull_request()
+    config = create_config()
+
+    config.update.always = True
+    config.merge.blocking_title_regex = "^WIP:.*"
+    pull_request.title = "WIP: add(api): endpoint for checking notifications"
+
+    pull_request.mergeable = MergeableState.UNKNOWN
+
+    # this test is nearly identical to
+    # test_mergeable_pull_request_need_test_commit_need_update, except our pull
+    # request state is MERGED or CLOSED instead of OPEN.
+    for index, pull_request_state in enumerate(
+        (PullRequestState.MERGED, PullRequestState.CLOSED)
+    ):
+        pull_request.state = pull_request_state
+        await mergeable(api=api, pull_request=pull_request)
+        assert api.set_status.call_count == index + 1
+        assert (
+            "cannot merge (title matches merge.blocking_title_regex"
+            in api.set_status.calls[0]["msg"]
+        )
+        assert api.dequeue.call_count == index + 1
+        assert api.trigger_test_commit.call_count == 0
+        assert api.requeue.call_count == 0
+
+        # verify we haven't tried to update/merge the PR
+        assert api.update_branch.called is False
+        assert api.merge.called is False
+        assert api.queue_for_merge.called is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When a pull request is merged the `mergeable` status becomes `UNKNOWN`. This meant we had an infinite loop where we'd trigger a test commit, queue the PR for another evaluation and continue to trigger test commits.

The fix is to only trigger test commits on open PRs.

Related #482