### PR TITLE
ref(mypy): don't ignore missing imports by default

### DIFF
--- a/bot/mypy.ini
+++ b/bot/mypy.ini
@@ -12,8 +12,8 @@ show_column_numbers=True
 # show error messages from unrelated files
 follow_imports=normal
 
-# suppress errors about unsatisfied imports
-ignore_missing_imports=True
+# don't suppress errors about unsatisfied imports
+ignore_missing_imports=False
 
 # be strict
 disallow_untyped_calls=True
@@ -34,6 +34,32 @@ check_untyped_defs=True
 # enable pydantic mypy plugin.
 plugins = pydantic.mypy
 
+[mypy-arrow.*]
+ignore_missing_imports=True
+
+[mypy-requests_async.*]
+ignore_missing_imports=True
+
+[mypy-structlog.*]
+ignore_missing_imports=True
+
+[mypy-rure.*]
+ignore_missing_imports=True
+
+[mypy-pytest_mock.*]
+ignore_missing_imports=True
+
+[mypy-markdown_html_finder.*]
+ignore_missing_imports=True
+
+[mypy-asyncio_redis.*]
+ignore_missing_imports=True
+
+[mypy-zstandard.*]
+ignore_missing_imports=True
+
+[mypy-inflection.*]
+ignore_missing_imports=True
 
 # https://pydantic-docs.helpmanual.io/mypy_plugin/#plugin-settings
 [pydantic-mypy]

--- a/web_api/mypy.ini
+++ b/web_api/mypy.ini
@@ -12,8 +12,8 @@ show_column_numbers=True
 # show error messages from unrelated files
 follow_imports=normal
 
-# suppress errors about unsatisfied imports
-ignore_missing_imports=True
+# don't suppress errors about unsatisfied imports
+ignore_missing_imports=False
 
 # be strict
 disallow_untyped_calls=True
@@ -33,6 +33,24 @@ check_untyped_defs=True
 
 # enable pydantic mypy plugin.
 plugins = pydantic.mypy
+
+[mypy-django.*]
+ignore_missing_imports=True
+
+[mypy-dj_database_url.*]
+ignore_missing_imports=True
+
+[mypy-zstandard.*]
+ignore_missing_imports=True
+
+[mypy-responses.*]
+ignore_missing_imports=True
+
+[mypy-stripe.*]
+ignore_missing_imports=True
+
+[mypy-pytest_mock.*]
+ignore_missing_imports=True
 
 
 # https://pydantic-docs.helpmanual.io/mypy_plugin/#plugin-settings


### PR DESCRIPTION
Now we explicitly ignore specific imports instead of a blanket ignore
on all missing types.

Upgraded databases and pytest to get their latest versions which include
types, for the rest we're ignoring them explicitly.
see https://github.com/chdsbd/kodiak/pull/485

- arrow

  doesn't have types but we can replace it with std library calls

- requests_async

  deprecated in favor of httpx, so we'd need to upgrade to get types.
  The API of httpx is a little different as well.

- structlog

  doesn't have types currently

  https://github.com/hynek/structlog/issues/165

- rure

  No stubs yet

  https://github.com/davidblewett/rure-python/issues/23

- pytest_mock

  types recently added to the typeshed so we'll need to wait for the next
  release of mypy.

  https://github.com/pytest-dev/pytest-mock/issues/152

- markdown_html_finder

  Wrapper around some Rust code. Needs stubs to be added.

  https://github.com/chdsbd/markdown-html-finder/issues/5

- asyncio_redis

  We're using our own fork of it, but adding types would be rather manual.
  Granted we aren't using that much of the API surface.

  https://github.com/chdsbd/asyncio-redis

- zstandard

  No stubs yet, so we're ignoring for the time being

  https://github.com/indygreg/python-zstandard/issues/120

- inflection

  Types, but I think they're misconfigured, once they're fixed we can
  unignore.

  https://github.com/jpvanhal/inflection/issues/49

- django

  Need to setup django-stubs for this to work since django doesn't have
  any static types.

  https://github.com/TypedDjango/django-stubs

- dj_database_url

  Doesn't have any static types yet

  https://github.com/jacobian/dj-database-url/issues/135

- responses

  No types yet

  https://github.com/getsentry/responses/issues/339

- stripe

  Plan for types, but they don't exist currently

  https://github.com/stripe/stripe-python/issues/650