### PR TITLE
update(web_ui): open install dropdown when user has 0 accounts

### DIFF
--- a/web_ui/src/components/AccountsPage.tsx
+++ b/web_ui/src/components/AccountsPage.tsx
@@ -84,7 +84,8 @@ function AccountsPageInner({
             </li>
           ))}
         </ul>
-        <details>
+        {/* open by default when user has no accounts */}
+        <details open={accounts.data.length === 0}>
           <summary className="mb-2">Not seeing an account?</summary>
           <a href={installUrl}>Install Kodiak</a> and sync your accounts.
           <br />


### PR DESCRIPTION
When a user has zero accounts we now default the details panel to be open. This panel tells them to install Kodiak and to sync their accounts.