### PR TITLE
tools(ci): trigger docker build on git tag creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,10 @@ workflows:
     jobs:
       - bot_test
       - bot_lint
-      - bot_build_container
+      - bot_build_container:
+          filters:
+            tags:
+              only: /^v\d*\.\d*\.\d*$/
   docs:
     jobs:
       - docs_typecheck
@@ -346,11 +349,17 @@ workflows:
     jobs:
       - web_ui_lint
       - web_ui_test
-      - web_ui_build_container
+      - web_ui_build_container:
+          filters:
+            tags:
+              only: /^v\d*\.\d*\.\d*$/
 
   web_api:
     jobs:
       - web_api_test
       - web_api_lint
       - web_api_squawk
-      - web_api_build_container
+      - web_api_build_container:
+          filters:
+            tags:
+              only: /^v\d*\.\d*\.\d*$/


### PR DESCRIPTION
The [circleci documentation](https://circleci.com/docs/2.0/configuration-reference/#filters-1) is not super clear, let's try this configuration. If the jobs doesn't get trigger anymore when change are made in a branch, we could add this additional snippet:
```
filters:
  branches:
    only: /.*/
  tags:
    only: /^v\d*\.\d*\.\d*$/
```

fix: https://github.com/chdsbd/kodiak/issues/493