### PR TITLE
ref(bot): make merge.automerge_label accept arrays

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -51,11 +51,8 @@ DEFAULT_TITLE_REGEX = "^WIP:.*"
 
 
 class Merge(BaseModel):
-    # label to enable merging of pull request.
-    automerge_label: str = "automerge"
-    # labels to enable merging of pull request.
-    # allows specifying additional automerge labels.
-    automerge_labels: List[str] = []
+    # label or labels to enable merging of pull request.
+    automerge_label: Union[str, List[str]] = "automerge"
     # if disabled, kodiak won't require a label to queue a PR for merge
     require_automerge_label: bool = True
     # regex to match against title and block merging. Set to empty string to

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -564,7 +564,7 @@ async def mergeable(
 
     pull_request_labels = set(pull_request.labels)
     config_automerge_labels = (
-        set([config.merge.automerge_label])
+        {config.merge.automerge_label}
         if isinstance(config.merge.automerge_label, str)
         else set(config.merge.automerge_label)
     )

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -563,8 +563,10 @@ async def mergeable(
             return
 
     pull_request_labels = set(pull_request.labels)
-    config_automerge_labels = set(
-        config.merge.automerge_labels + [config.merge.automerge_label]
+    config_automerge_labels = (
+        set([config.merge.automerge_label])
+        if isinstance(config.merge.automerge_label, str)
+        else set(config.merge.automerge_label)
     )
     pull_request_automerge_labels = config_automerge_labels.intersection(
         pull_request_labels

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -14,7 +14,6 @@
       "title": "Merge",
       "default": {
         "automerge_label": "automerge",
-        "automerge_labels": [],
         "require_automerge_label": true,
         "blacklist_title_regex": ":::|||kodiak|||internal|||reserved|||:::",
         "blocking_title_regex": ":::|||kodiak|||internal|||reserved|||:::",
@@ -146,15 +145,17 @@
         "automerge_label": {
           "title": "Automerge Label",
           "default": "automerge",
-          "type": "string"
-        },
-        "automerge_labels": {
-          "title": "Automerge Labels",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         },
         "require_automerge_label": {
           "title": "Require Automerge Label",

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -2550,7 +2550,7 @@ async def test_mergeable_passing() -> None:
 @pytest.mark.asyncio
 async def test_mergeable_merge_automerge_labels() -> None:
     """
-    Test merge.automerge_label allows a pull request to be merged.
+    Test merge.automerge_label array allows a pull request to be merged.
     """
     mergeable = create_mergeable()
     api = create_api()

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1416,7 +1416,7 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_automerg
     """
     We should only notify on conflict when we have an automerge label.
 
-    If we have a merge.automerge_labels label, we should remove it like we do
+    If we have a merge.automerge_label label, we should remove it like we do
     with merge.automerge_label.
     """
     api = create_api()
@@ -1429,8 +1429,7 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_automerg
     config.merge.notify_on_conflict = True
     config.merge.require_automerge_label = True
     pull_request.labels = ["ship it!!!"]
-    config.merge.automerge_labels = ["ship it!!!"]
-    assert config.merge.automerge_label != config.merge.automerge_labels[0]
+    config.merge.automerge_label = ["ship it!!!"]
 
     await mergeable(api=api, config=config, pull_request=pull_request)
     assert api.set_status.call_count == 1
@@ -2551,14 +2550,14 @@ async def test_mergeable_passing() -> None:
 @pytest.mark.asyncio
 async def test_mergeable_merge_automerge_labels() -> None:
     """
-    Test merge.automerge_labels allows a pull request to be merged.
+    Test merge.automerge_label allows a pull request to be merged.
     """
     mergeable = create_mergeable()
     api = create_api()
     pull_request = create_pull_request()
     pull_request.labels = ["ship it!"]
     config = create_config()
-    config.merge.automerge_labels = ["ship it!"]
+    config.merge.automerge_label = ["ship it!"]
     await mergeable(api=api, config=config, pull_request=pull_request)
     assert api.set_status.call_count == 1
     assert "enqueued for merge (position=4th)" in api.set_status.calls[0]["msg"]

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1416,8 +1416,8 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_automerg
     """
     We should only notify on conflict when we have an automerge label.
 
-    If we have a merge.automerge_label label, we should remove it like we do
-    with merge.automerge_label.
+    If we have an array of merge.automerge_label labels, we should remove each
+    one like we do with merge.automerge_label.
     """
     api = create_api()
     mergeable = create_mergeable()


### PR DESCRIPTION
I think it will be less confusing for users if we have a single automerge label field instead of two.

`merge.automerge_labels` hasn't been released yet, so it's safe to remove. After seeing some ideas for using multiple labels with `merge.automerge_label` https://github.com/chdsbd/kodiak/issues/521#issue-718325968, I think it's better if we accept either a string or union of strings.

related #516