### PR TITLE
docs(troubleshooting): remove codeowners caveat now that it is supported

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -21,10 +21,6 @@ Kodiak won't activate if branch protection is disabled.
 
 Kodiak is able to [create signatures](https://help.github.com/en/articles/about-required-commit-signing) for merge and squash commits, but not rebase merges due to GitHub API limitations. ([kodiak#89](https://github.com/chdsbd/kodiak/issues/89))
 
-### CodeOwners
-
-GitHub CODEOWNERS is only fully supported with [`update.always`](config-reference.md#updatealways). In other cases, partial support exists where Kodiak will be able to merge the PR once all checks pass, but Kodiak will update out of date PRs if a Code Owner review is the only requirement blocking merge. ([kodiak#87](https://github.com/chdsbd/kodiak/issues/87))
-
 ### Restricting pushes
 
 If you use the "Restrict who can push to matching branches" branch protection setting you must add Kodiak as an allowed user, like the following screenshot.


### PR DESCRIPTION
Kodiak now fully supports code owners as of https://github.com/chdsbd/kodiak/releases/tag/v0.30.0