### PR TITLE
add(docs): self-hosting note about watching repo for releases

### DIFF
--- a/docs/docs/self-hosting.md
+++ b/docs/docs/self-hosting.md
@@ -6,6 +6,8 @@ sidebar_label: Self Hosting
 
 If you don't want to use the [GitHub App](https://github.com/marketplace/kodiakhq#pricing-and-setup), you can run Kodiak on your own infrastructure.
 
+> We recommend [watching the Kodiak repo for releases](https://docs.github.com/en/enterprise-server@2.20/github/receiving-notifications-about-activity-on-github/watching-and-unwatching-releases-for-a-repository#watching-releases-for-a-repository), so that you can get bug fixes and avoid issues with GitHub API changes.
+
 ## Heroku
 
 These instructions describe setting up Kodiak on Heroku using a Docker container, but you should be able to adapt this for other container platforms.


### PR DESCRIPTION
When self hosting, Kodiak doesn't auto update so users need to be mindful
about bug fixes and changes related to GitHub API changes.

Easiest way is by watching the repo for new releases.