### PR TITLE
add(doc): update.autoupdate_label docs

### DIFF
--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -319,6 +319,27 @@ When disable, Kodiak will update any PR.
 
 This option only applies when `update.always = true`.
 
+### `update.autoupdate_label`
+
+- **type:** `string`
+- **default:** `null`
+
+Pull requests with the `update.autoupdate_label` will be updated when they are out-of-date with their base branch.
+
+This configuration option is similar to `update.always`, but only pull requests with the configured label are affected.
+
+#### example
+
+```toml
+version = 1
+
+[merge]
+automerge_label = "ship it!"
+
+[update]
+autoupdate_label = "update me please!"
+```
+
 <span id="updateblacklist_usernames"/> <!-- handle old links -->
 
 ### `update.ignored_usernames`


### PR DESCRIPTION
The `update.autoupdate_label` configuration option added in #536 has been deployed so we can document this new option.