### PR TITLE
update(bot): update.ignored_usernames should never update branch

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -641,7 +641,8 @@ async def mergeable(
         and pull_request.author.login in config.update.blacklist_usernames
     ):
         await set_status(
-            f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}"
+            f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}",
+            markdown_content="Apply the `update.autoupdate_label` label to enable updates for this pull request.",
         )
         await api.dequeue()
         return
@@ -651,7 +652,8 @@ async def mergeable(
         and pull_request.author.login in config.update.ignored_usernames
     ):
         await set_status(
-            f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}"
+            f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}",
+            markdown_content="Apply the `update.autoupdate_label` label to enable updates for this pull request.",
         )
         await api.dequeue()
         return

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -638,13 +638,15 @@ async def mergeable(
     if need_branch_update and not has_autoupdate_label:
         if pull_request.author.login in config.update.blacklist_usernames:
             await set_status(
-                f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}"
+                f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}",
+                markdown_content="Apply the `update.autoupdate_label` label to enable updates for this pull request.",
             )
             await api.dequeue()
             return
         if pull_request.author.login in config.update.ignored_usernames:
             await set_status(
-                f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}"
+                f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}",
+                markdown_content="Apply the `update.autoupdate_label` label to enable updates for this pull request.",
             )
             await api.dequeue()
             return

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -641,8 +641,7 @@ async def mergeable(
         and pull_request.author.login in config.update.blacklist_usernames
     ):
         await set_status(
-            f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}",
-            markdown_content="Apply the `update.autoupdate_label` label to enable updates for this pull request.",
+            f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}"
         )
         await api.dequeue()
         return
@@ -652,8 +651,7 @@ async def mergeable(
         and pull_request.author.login in config.update.ignored_usernames
     ):
         await set_status(
-            f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}",
-            markdown_content="Apply the `update.autoupdate_label` label to enable updates for this pull request.",
+            f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}"
         )
         await api.dequeue()
         return

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -635,19 +635,26 @@ async def mergeable(
     #
     # If `update.autoupdate_label` is applied to the pull request, bypass
     # `update.ignored_usernames` and let the pull request update.
-    if need_branch_update and not has_autoupdate_label:
-        if pull_request.author.login in config.update.blacklist_usernames:
-            await set_status(
-                f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}"
-            )
-            await api.dequeue()
-            return
-        if pull_request.author.login in config.update.ignored_usernames:
-            await set_status(
-                f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}"
-            )
-            await api.dequeue()
-            return
+    if (
+        need_branch_update
+        and not has_autoupdate_label
+        and pull_request.author.login in config.update.blacklist_usernames
+    ):
+        await set_status(
+            f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}"
+        )
+        await api.dequeue()
+        return
+    if (
+        need_branch_update
+        and not has_autoupdate_label
+        and pull_request.author.login in config.update.ignored_usernames
+    ):
+        await set_status(
+            f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}"
+        )
+        await api.dequeue()
+        return
 
     if need_branch_update and not merging and auto_update_enabled:
         await set_status(

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -635,26 +635,19 @@ async def mergeable(
     #
     # If `update.autoupdate_label` is applied to the pull request, bypass
     # `update.ignored_usernames` and let the pull request update.
-    if (
-        need_branch_update
-        and not has_autoupdate_label
-        and pull_request.author.login in config.update.blacklist_usernames
-    ):
-        await set_status(
-            f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}"
-        )
-        await api.dequeue()
-        return
-    if (
-        need_branch_update
-        and not has_autoupdate_label
-        and pull_request.author.login in config.update.ignored_usernames
-    ):
-        await set_status(
-            f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}"
-        )
-        await api.dequeue()
-        return
+    if need_branch_update and not has_autoupdate_label:
+        if pull_request.author.login in config.update.blacklist_usernames:
+            await set_status(
+                f"🛑 updates blocked by update.blacklist_usernames: {config.update.blacklist_usernames!r}"
+            )
+            await api.dequeue()
+            return
+        if pull_request.author.login in config.update.ignored_usernames:
+            await set_status(
+                f"🛑 updates blocked by update.ignored_usernames: {config.update.ignored_usernames!r}"
+            )
+            await api.dequeue()
+            return
 
     if need_branch_update and not merging and auto_update_enabled:
         await set_status(

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -3372,7 +3372,7 @@ async def test_mergeable_update_username_blacklist() -> None:
             )
             assert api.update_branch.call_count == 0
             assert api.set_status.call_count == 1
-            assert "not auto updating for update." in api.set_status.calls[0]["msg"]
+            assert "updates blocked by update." in api.set_status.calls[0]["msg"]
             assert api.dequeue.call_count == 1
 
             assert api.queue_for_merge.call_count == 0


### PR DESCRIPTION
When a pull request's author matches `update.ignored_usernames`, Kodiak will never update the pull request, unless `update.autoupdate_label` is applied to the pull request.

Previously Kodiak would still update the pull request just before merge. This caused merge conflicts with Dependabot workflows. Now Dependabot will handle updating the dependency pull requests.

related #537