### PR TITLE
ref(bot): log repo info w/ fail in fetch default branch name

### DIFF
--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -792,7 +792,7 @@ class Client:
         data = res.get("data")
         errors = res.get("errors")
         if errors is not None or data is None:
-            logger.error("could not fetch default branch name", res=res)
+            self.log.error("could not fetch default branch name", res=res)
             return None
         return cast(str, data["repository"]["defaultBranchRef"]["name"])
 


### PR DESCRIPTION
Currently we only log the message and the response which doesn't give us
much to go off.

Instead we can use the logger with the repo name and org already bound.