### PR TITLE
add(ci): skip build if no changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes bot
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
@@ -48,6 +51,9 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes bot
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
@@ -94,6 +100,9 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes docs
       - restore_cache:
           keys:
             - docs-site-v1-{{ checksum "docs/yarn.lock" }}
@@ -120,6 +129,9 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes docs
       - restore_cache:
           keys:
             - docs-site-v1-{{ checksum "docs/yarn.lock" }}
@@ -144,6 +156,9 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes docs
       - restore_cache:
           keys:
             - docs-site-v1-{{ checksum "docs/yarn.lock" }}
@@ -181,6 +196,9 @@ jobs:
       DATABASE_URL: postgres://postgres:my_test_postgres_password@127.0.0.1:5432/web_api_test
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes web_api
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
@@ -216,6 +234,9 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes web_api
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
@@ -256,6 +277,9 @@ jobs:
       DATABASE_URL: postgres://postgres:my_test_postgres_password@127.0.0.1:5432/web_api_test
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes web_api
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
@@ -307,6 +331,9 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes web_ui
       - restore_cache:
           keys:
             - web-ui-v1-{{ checksum "web_ui/yarn.lock" }}
@@ -331,6 +358,9 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: check for changes
+          command: ./s/exit_circleci_if_no_changes web_ui
       - restore_cache:
           keys:
             - web-ui-v1-{{ checksum "web_ui/yarn.lock" }}

--- a/s/exit_circleci_if_no_changes
+++ b/s/exit_circleci_if_no_changes
@@ -16,7 +16,7 @@ def main(path: str) -> None:
         return
     if res.returncode == 1:
         return
-    raise ValueError(f"Unexpected return code {res.returncode}")
+    raise ValueError("Unexpected return code {}".format(res.returncode))
 
 
 if __name__ == '__main__':

--- a/s/exit_circleci_if_no_changes
+++ b/s/exit_circleci_if_no_changes
@@ -1,25 +1,30 @@
 #!/usr/bin/env python3
+"""
+Skip job if there are no changes against master within path.
+
+With this utility, changes to docs don't require running the bot tests.
+"""
+
 import subprocess
 import sys
 
 
 def main(path: str) -> None:
-    """
-
-    - if the branch doesn't have a pull request
-    """
-
-    res = subprocess.run(["git", "diff", "--name-only", "--exit-code", "master...", path], capture_output=True)
+    res = subprocess.run(
+        ["git", "diff", "--name-only", "--exit-code", "master...", path]
+    )
     # if we have changes, return now
     if res.returncode == 0:
+        print("no changes found, halting circleci job")
         subprocess.run(["circleci", "step", "halt"], check=True)
         return
     if res.returncode == 1:
+        print("changes found, continuing with build")
         return
     raise ValueError("Unexpected return code {}".format(res.returncode))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     progname = sys.argv[0]
     path = sys.argv[1]
     main(path)

--- a/s/exit_circleci_if_no_changes
+++ b/s/exit_circleci_if_no_changes
@@ -10,6 +10,8 @@ import sys
 
 
 def main(path: str) -> None:
+    # fix refs: https://steve.dignam.xyz/2020/05/03/faster-ci-builds-in-a-monorepo/
+    subprocess.run(["git", "branch", "-f", "master", "origin/master"], check=True)
     res = subprocess.run(
         ["git", "diff", "--name-only", "--exit-code", "master...", path]
     )

--- a/s/exit_circleci_if_no_changes
+++ b/s/exit_circleci_if_no_changes
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+def main(path: str) -> None:
+    """
+
+    - if the branch doesn't have a pull request
+    """
+
+    res = subprocess.run(["git", "diff", "--name-only", "--exit-code", "master...", path], capture_output=True)
+    # if we have changes, return now
+    if res.returncode == 0:
+        subprocess.run(["circleci", "step", "halt"], check=True)
+        return
+    if res.returncode == 1:
+        return
+    raise ValueError(f"Unexpected return code {res.returncode}")
+
+
+if __name__ == '__main__':
+    progname = sys.argv[0]
+    path = sys.argv[1]
+    main(path)

--- a/s/exit_circleci_if_no_changes
+++ b/s/exit_circleci_if_no_changes
@@ -11,7 +11,9 @@ import sys
 
 def main(path: str) -> None:
     # fix refs: https://steve.dignam.xyz/2020/05/03/faster-ci-builds-in-a-monorepo/
+    print("updating master ref")
     subprocess.run(["git", "branch", "-f", "master", "origin/master"], check=True)
+    print("checking for changes")
     res = subprocess.run(
         ["git", "diff", "--name-only", "--exit-code", "master...", path]
     )


### PR DESCRIPTION
The GitHub bot, docs, web ui, and web api are isolated in their own folders and do not depend on anything outside of those folders.

Assuming master is always green, we only need to run tests in a specific folder when there is a difference against master.

With this change we can reduce our CI time by only running tests for modified folders. Updating the docs does not require testing the GitHub bot.