### PR TITLE
update(bot): support merge.message.include_coauthors empty merge bodies

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -191,9 +191,9 @@ def get_merge_body(
                 )
             )
 
-    if (
-        coauthor_trailers
-        and config.merge.message.body == MergeBodyStyle.pull_request_body
+    if coauthor_trailers and config.merge.message.body in (
+        MergeBodyStyle.pull_request_body,
+        MergeBodyStyle.empty,
     ):
         # comment_message should never be None when using
         # MergeBodyStyle.pull_request_body, but I'm not going to assert on that!


### PR DESCRIPTION
Given the following Kodiak config,
```toml
merge.message.include_coauthors = true
merge.message.body = "empty"
```

before,

```
commit_message == ""
```

after,

```
commit_message == 'Co-authored-by: Barry Block <73213123+b-block@users.noreply.github.com>'
```

related: https://github.com/chdsbd/kodiak/issues/277#issuecomment-728304324