### PR TITLE
ref(dev): call python executables directly instead of through poetry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             source $BASH_ENV
             command -v poetry || python -m pip install --user poetry==0.12.12
+            poetry config settings.virtualenvs.in-project true
             poetry install
       - save_cache:
           paths:
@@ -60,6 +61,7 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             source $BASH_ENV
             command -v poetry || python -m pip install --user poetry==0.12.12
+            poetry config settings.virtualenvs.in-project true
             poetry install
       - save_cache:
           paths:
@@ -193,6 +195,7 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             source $BASH_ENV
             command -v poetry || python -m pip install --user poetry==0.12.12
+            poetry config settings.virtualenvs.in-project true
             poetry install
       - save_cache:
           paths:
@@ -228,6 +231,7 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             source $BASH_ENV
             command -v poetry || python -m pip install --user poetry==0.12.12
+            poetry config settings.virtualenvs.in-project true
             poetry install
       - save_cache:
           paths:
@@ -268,6 +272,7 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             source $BASH_ENV
             command -v poetry || python -m pip install --user poetry==0.12.12
+            poetry config settings.virtualenvs.in-project true
             poetry install
       - save_cache:
           paths:

--- a/bot/.isort.cfg
+++ b/bot/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=redis
+known_third_party=redis,asyncio_redis

--- a/bot/README.md
+++ b/bot/README.md
@@ -10,6 +10,7 @@ The follow shows how to run commands for testing and development. For informatio
 # bot/
 
 # install dependencies
+poetry config settings.virtualenvs.in-project true
 poetry install
 
 # format and lint using black, isort, mypy, flake8, pylint

--- a/bot/s/dev
+++ b/bot/s/dev
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eux
 
-poetry run uvicorn kodiak.main:app "$@"
+./.venv/bin/uvicorn kodiak.main:app "$@"

--- a/bot/s/fmt
+++ b/bot/s/fmt
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 set -eu
-poetry run black .
+./.venv/bin/black .

--- a/bot/s/lint
+++ b/bot/s/lint
@@ -3,16 +3,16 @@ set -ex
 
 # format code
 if [[ $CI ]]; then
-    poetry run black --check .
-    poetry run isort --check-only
+    ./.venv/bin/black --check .
+    ./.venv/bin/isort --check-only
 else
-    poetry run black .
-    poetry run isort -y
+    ./.venv/bin/black .
+    ./.venv/bin/isort -y
 fi
 
 # type check code
-poetry run mypy .
+./.venv/bin/mypy .
 
 # lint
-poetry run flake8 kodiak
-poetry run pylint --rcfile='.pylintrc' kodiak
+./.venv/bin/flake8 kodiak
+./.venv/bin/pylint --rcfile='.pylintrc' kodiak

--- a/bot/s/test
+++ b/bot/s/test
@@ -3,7 +3,7 @@ set -ex
 
 
 if [ "$CI" ]; then
-  poetry run pytest --cov=. --cov-report xml "$@"
+  ./.venv/bin/pytest --cov=. --cov-report xml "$@"
 else
-  poetry run pytest "$@"
+  ./.venv/bin/pytest "$@"
 fi

--- a/web_api/README.md
+++ b/web_api/README.md
@@ -6,6 +6,7 @@ The web API for the Kodiak dashboard.
 
 ```console
 # install dependencies
+poetry config settings.virtualenvs.in-project true
 poetry install
 
 # copy & modify example .env file

--- a/web_api/s/dev
+++ b/web_api/s/dev
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eux
 
-poetry run ./manage.py runserver
+./.venv/bin/python ./manage.py runserver

--- a/web_api/s/fmt
+++ b/web_api/s/fmt
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 set -eu
-poetry run black .
+./.venv/bin/black .

--- a/web_api/s/lint
+++ b/web_api/s/lint
@@ -3,16 +3,16 @@ set -ex
 
 # format code
 if [[ $CI ]]; then
-    poetry run black --check .
-    poetry run isort --check-only
+    ./.venv/bin/black --check .
+    ./.venv/bin/isort --check-only
 else
-    poetry run black .
-    poetry run isort -y
+    ./.venv/bin/black .
+    ./.venv/bin/isort -y
 fi
 
 # type check code
-poetry run mypy .
+./.venv/bin/mypy .
 
 # lint
-poetry run flake8 web_api
-poetry run pylint --rcfile='.pylintrc' web_api
+./.venv/bin/flake8 web_api
+./.venv/bin/pylint --rcfile='.pylintrc' web_api

--- a/web_api/s/test
+++ b/web_api/s/test
@@ -2,7 +2,7 @@
 set -ex
 
 if [ "$CI" ]; then
-  poetry run pytest --cov=. --cov-report xml "$@"
+  ./.venv/bin/pytest --cov=. --cov-report xml "$@"
 else
-  poetry run pytest "$@"
+  ./.venv/bin/pytest "$@"
 fi


### PR DESCRIPTION
`poetry run` is slow as it spawns a sub shell. Instead we can call the
executables directly from the venv which will achieve the same thing, but
quicker.