### PR TITLE
fix(bot): check run date format

### DIFF
--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -1070,7 +1070,7 @@ class Client:
             name=CHECK_RUN_NAME,
             head_sha=head_sha,
             status="completed",
-            completed_at=datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),
+            completed_at=datetime.now(timezone.utc).isoformat(),
             conclusion="neutral",
             output=dict(title=message, summary=summary or ""),
         )

--- a/bot/kodiak/queries.py
+++ b/bot/kodiak/queries.py
@@ -1070,7 +1070,7 @@ class Client:
             name=CHECK_RUN_NAME,
             head_sha=head_sha,
             status="completed",
-            completed_at=datetime.utcnow().isoformat(),
+            completed_at=datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),
             conclusion="neutral",
             output=dict(title=message, summary=summary or ""),
         )


### PR DESCRIPTION
We introduced a bug that caused dates to be sent with an invalid format to GitHub. This meant check runs didn't work at all. This bad change hasn't been released, so we're okay.

 https://github.com/chdsbd/kodiak/commit/c8de897eab3fb1c78516a504fa9f331021384a9a#diff-0958ca2d3d9da20b866adafe99f9e7c8169b99ba53d2a447b5e923a6d0dd3352L1074