### PR TITLE
fix(doc): formatting mistake in self-hosting docs

### DIFF
--- a/docs/docs/self-hosting.md
+++ b/docs/docs/self-hosting.md
@@ -94,8 +94,6 @@ These instructions describe setting up Kodiak on Heroku using a Docker container
     #
     heroku config:set -a $APP_NAME GITHUB_API_HEADER_NAME="<GITHUB_API_HEADER_NAME>"
     heroku config:set -a $APP_NAME GITHUB_API_HEADER_VALUE="<GITHUB_API_HEADER_VALUE>"
-    ```
-
 
     # Redis v5 is required and provided by RedisCloud
     heroku addons:create -a $APP_NAME rediscloud:30 --wait


### PR DESCRIPTION
We had a misplaced "```", which was throwing off the formatting of the setup instructions.

<img width="885" alt="Screen Shot 2020-11-21 at 2 48 27 PM" src="https://user-images.githubusercontent.com/1929960/99886195-9f5d8980-2c08-11eb-8c0f-2e48d84d6762.png">