### PR TITLE
add(web_api): django type stubs

### DIFF
--- a/web_api/.pylintrc
+++ b/web_api/.pylintrc
@@ -190,7 +190,13 @@ disable=print-statement,
         no-name-in-module,,
         # handled by flake8
         unused-import,
-        unused-variable
+        unused-variable,
+        # gets it wrong
+        assignment-from-no-return,
+        unsubscriptable-object,
+        # isort handles this
+        wrong-import-position,
+
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/web_api/mypy.ini
+++ b/web_api/mypy.ini
@@ -8,7 +8,8 @@ platform=linux
 
 mypy_path=./typings
 
-# flake8-mypy expects the two following for sensible formatting
+show_error_codes = True
+
 show_column_numbers=True
 
 # show error messages from unrelated files

--- a/web_api/poetry.lock
+++ b/web_api/poetry.lock
@@ -153,6 +153,14 @@ pytz = "*"
 sqlparse = ">=0.2.2"
 
 [[package]]
+category = "dev"
+description = "Type subs for Django"
+name = "django-types"
+optional = false
+python-versions = ">=3.7,<4.0"
+version = "0.1.0"
+
+[[package]]
 category = "main"
 description = "DNS toolkit"
 name = "dnspython"
@@ -174,25 +182,20 @@ idna = ">=2.0.0"
 
 [[package]]
 category = "dev"
-description = "Discover and load entry points from installed packages."
-name = "entrypoints"
-optional = false
-python-versions = ">=2.7"
-version = "0.3"
-
-[[package]]
-category = "dev"
-description = "the modular source code checker: pep8, pyflakes and co"
+description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.7.9"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "3.8.4"
 
 [package.dependencies]
-entrypoints = ">=0.3.0,<0.4.0"
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.5.0,<2.6.0"
-pyflakes = ">=2.1.0,<2.2.0"
+pycodestyle = ">=2.6.0a1,<2.7.0"
+pyflakes = ">=2.2.0,<2.3.0"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [[package]]
 category = "main"
@@ -452,7 +455,7 @@ description = "Python style guide checker"
 name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 category = "main"
@@ -468,7 +471,7 @@ description = "passive checker of Python programs"
 name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 category = "dev"
@@ -766,7 +769,7 @@ python-versions = "*"
 version = "0.13.0"
 
 [metadata]
-content-hash = "cfa09010bb638699331accad33a013b75ab6acc6d6f6d2700b202415650175b9"
+content-hash = "1767f08b03154650a89320df62035192ffe390f0a6e285d4f97cfb7ba4d0a174"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -786,10 +789,10 @@ coverage = ["00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a", 
 decorator = ["54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce", "5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"]
 dj-database-url = ["4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163", "851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"]
 django = ["2f1ba1db8648484dd5c238fb62504777b7ad090c81c5f1fd8d5eb5ec21b5f283", "c91c91a7ad6ef67a874a4f76f58ba534f9208412692a840e1d125eb5c279cb0a"]
+django-types = ["bebd7e71cad62aec2d73e3371831b1ed68824c1297158568e0d5b3343fe7e97e", "e75b97f32eb2bacc726aa0880d6ff86045b4efa4d3628b67e29291c7fc0818db"]
 dnspython = ["36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01", "f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d"]
 email-validator = ["5f246ae8d81ce3000eade06595b7bb55a4cf350d559e890182a1466a21f25067", "63094045c3e802c3d3d575b18b004a531c36243ca8d1cec785ff6bfcb04185bb"]
-entrypoints = ["589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19", "c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"]
-flake8 = ["45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb", "49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"]
+flake8 = ["749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839", "aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"]
 gunicorn = ["1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626", "cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"]
 idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
 importlib-metadata = ["06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302", "b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"]
@@ -815,9 +818,9 @@ prompt-toolkit = ["a402e9bf468b63314e37460b68ba68243d55b2f8c4d0192f85a019af39450
 psycopg2 = ["4212ca404c4445dc5746c0d68db27d2cbfb87b523fe233dc84ecd24062e35677", "47fc642bf6f427805daf52d6e52619fe0637648fe27017062d898f3bf891419d", "72772181d9bad1fa349792a1e7384dde56742c14af2b9986013eb94a240f005b", "8396be6e5ff844282d4d49b81631772f80dabae5658d432202faf101f5283b7c", "893c11064b347b24ecdd277a094413e1954f8a4e8cdaf7ffbe7ca3db87c103f0", "92a07dfd4d7c325dd177548c4134052d4842222833576c8391aab6f74038fc3f", "965c4c93e33e6984d8031f74e51227bd755376a9df6993774fd5b6fb3288b1f4", "9ab75e0b2820880ae24b7136c4d230383e07db014456a476d096591172569c38", "b0845e3bdd4aa18dc2f9b6fb78fbd3d9d371ad167fd6d1b7ad01c0a6cdad4fc6", "dca2d7203f0dfce8ea4b3efd668f8ea65cd2b35112638e488a4c12594015f67b", "ed686e5926929887e2c7ae0a700e32c6129abb798b4ad2b846e933de21508151", "ef6df7e14698e79c59c7ee7cf94cd62e5b869db369ed4b1b8f7b729ea825712a", "f898e5cc0a662a9e12bde6f931263a1bbd350cfb18e1d5336a12927851825bb6"]
 ptyprocess = ["923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0", "d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"]
 py = ["366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2", "9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"]
-pycodestyle = ["95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56", "e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"]
+pycodestyle = ["2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367", "c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"]
 pydantic = ["012c422859bac2e03ab3151ea6624fecf0e249486be7eb8c6ee69c91740c6752", "07911aab70f3bc52bb845ce1748569c5e70478ac977e106a150dd9d0465ebf04", "47b8db7024ba3d46c3d4768535e1cf87b6c8cf92ccd81e76f4e1cb8ee47688b3", "50e4e948892a6815649ad5a9a9379ad1e5f090f17842ac206535dfaed75c6f2f", "51f11c8bbf794a68086540da099aae4a9107447c7a9d63151edbb7d50110cf21", "6100d7862371115c40be55cc4b8d766a74b1d0dbaf99dbfe72bb4bac0faf89ed", "61d22d36808087d3184ed6ac0d91dd71c533b66addb02e4a9930e1e30833202f", "72184c1421103cca128300120f8f1185fb42a9ea73a1c9845b1c53db8c026a7d", "831a0265a9e3933b3d0f04d1a81bba543bafbe4119c183ff2771871db70524ab", "8848b4eb458469739126e4c1a202d723dd092e087f8dbe3104371335f87ba5df", "bbbed364376f4a0aebb9ea452ff7968b306499a9e74f4db69b28ff2cd4043a11", "e27559cedbd7f59d2375bfd6eea29a330ea1a5b0589c34d6b4e0d7bec6027bbf", "f17ec336e64d4583311249fb179528e9a2c27c8a2eaf590ec6ec2c6dece7cb3f", "f863456d3d4bf817f2e5248553dee3974c5dc796f48e6ddb599383570f4215ac"]
-pyflakes = ["17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0", "d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"]
+pyflakes = ["0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92", "35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"]
 pygments = ["2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b", "98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"]
 pylint = ["3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd", "886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"]
 pyparsing = ["4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f", "c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"]

--- a/web_api/pyproject.toml
+++ b/web_api/pyproject.toml
@@ -27,7 +27,7 @@ pytest = "6.0.1"
 mypy = "^0.770.0"
 isort = "^4.3"
 black = "^19.10b0"
-flake8 = "^3.7"
+flake8 = "3.8.4"
 pytest-django = "^3.8"
 ipython = "^7.12"
 responses = "^0.10.9"
@@ -37,6 +37,7 @@ pytest-env = "^0.6.2"
 pytest-mock = "3.3.1"
 ipdb = "^0.12.3"
 pytest-cov = "^2.10"
+django-types = "^0.1.0"
 
 [build-system]
 requires = ["poetry>=0.12", "setuptools"]

--- a/web_api/web_api/auth.py
+++ b/web_api/web_api/auth.py
@@ -1,22 +1,47 @@
+from __future__ import annotations
+
 from functools import wraps
-from typing import Callable, cast
+from typing import Any, TypeVar, Union, cast
 
 from django.http import HttpRequest, HttpResponse
+from typing_extensions import Protocol
 
 from web_api.exceptions import AuthenticationRequired
 from web_api.models import AnonymousUser, User
 
 
-def login_required(view_func: Callable) -> Callable:
+class AuthedHttpRequest(HttpRequest):
+    user: User  # type: ignore [assignment]
+
+
+class RequestHandler1(Protocol):
+    def __call__(self, request: AuthedHttpRequest) -> HttpResponse:
+        ...
+
+
+class RequestHandler2(Protocol):
+    def __call__(self, request: AuthedHttpRequest, __arg1: Any) -> HttpResponse:
+        ...
+
+
+RequestHandler = Union[RequestHandler1, RequestHandler2]
+
+
+# Verbose bound arg due to limitations of Python typing.
+# see: https://github.com/python/mypy/issues/5876
+_F = TypeVar("_F", bound=RequestHandler)
+
+
+def login_required(view_func: _F) -> _F:
     @wraps(view_func)
     def wrapped_view(
-        request: HttpRequest, *args: object, **kwargs: object
+        request: AuthedHttpRequest, *args: object, **kwargs: object
     ) -> HttpResponse:
         if request.user.is_authenticated:
-            return view_func(request, *args, **kwargs)
+            return view_func(request, *args, **kwargs)  # type: ignore [call-arg]
         raise AuthenticationRequired
 
-    return wrapped_view
+    return cast(_F, wrapped_view)
 
 
 def get_user(request: HttpRequest) -> User:
@@ -33,8 +58,8 @@ def get_user(request: HttpRequest) -> User:
             pass
         else:
             user = User.objects.filter(id=user_id).first()
-        request._cached_user = user or AnonymousUser()
-    return cast(User, request._cached_user)
+        request._cached_user = user or AnonymousUser()  # type: ignore [attr-defined]
+    return request._cached_user  # type: ignore [attr-defined, no-any-return]
 
 
 def login(user: User, request: HttpRequest) -> None:
@@ -42,7 +67,7 @@ def login(user: User, request: HttpRequest) -> None:
     https://github.com/django/django/blob/6e99585c19290fb9bec502cac8210041fdb28484/django/contrib/auth/__init__.py#L86-L131
     """
     request.session["user_id"] = str(user.id)
-    request.user = user
+    request.user = user  # type: ignore [assignment]
 
 
 def logout(request: HttpRequest) -> None:
@@ -50,4 +75,4 @@ def logout(request: HttpRequest) -> None:
     https://github.com/django/django/blob/6e99585c19290fb9bec502cac8210041fdb28484/django/contrib/auth/__init__.py#L134-L148
     """
     request.session.flush()
-    request.user = AnonymousUser()
+    request.user = AnonymousUser()  # type: ignore [assignment]

--- a/web_api/web_api/middleware.py
+++ b/web_api/web_api/middleware.py
@@ -23,7 +23,7 @@ class AuthenticationMiddleware(MiddlewareMixin):
     """
 
     def process_request(self, request: HttpRequest) -> None:
-        request.user = SimpleLazyObject(lambda: get_user(request))
+        request.user = SimpleLazyObject(lambda: get_user(request))  # type: ignore [assignment]
 
 
 class ExceptionMiddleware(MiddlewareMixin):

--- a/web_api/web_api/patches.py
+++ b/web_api/web_api/patches.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from django.db.models.manager import BaseManager
+from django.db.models.query import QuerySet
+
+
+def patch_django() -> None:
+    for cls in (QuerySet, BaseManager):
+        cls.__class_getitem__ = classmethod(lambda cls, *args, **kwargs: cls)  # type: ignore [attr-defined]

--- a/web_api/web_api/patches.py
+++ b/web_api/web_api/patches.py
@@ -5,5 +5,9 @@ from django.db.models.query import QuerySet
 
 
 def patch_django() -> None:
+    """
+    On Django versions < 3.1 we need to monkey patch the class get item
+    method so that we can type QuerySet and Managers with a generic argument.
+    """
     for cls in (QuerySet, BaseManager):
         cls.__class_getitem__ = classmethod(lambda cls, *args, **kwargs: cls)  # type: ignore [attr-defined]

--- a/web_api/web_api/settings.py
+++ b/web_api/web_api/settings.py
@@ -7,9 +7,10 @@ from dotenv import load_dotenv
 from sentry_sdk.integrations.django import DjangoIntegration
 from yarl import URL
 
+from web_api.patches import patch_django
+
 load_dotenv()
 
-from web_api.patches import patch_django
 
 patch_django()
 

--- a/web_api/web_api/settings.py
+++ b/web_api/web_api/settings.py
@@ -9,6 +9,10 @@ from yarl import URL
 
 load_dotenv()
 
+from web_api.patches import patch_django
+
+patch_django()
+
 
 sentry_sdk.init(integrations=[DjangoIntegration()], send_default_pii=True)
 

--- a/web_api/web_api/test_account.py
+++ b/web_api/web_api/test_account.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 import pytest
 import redis
@@ -235,16 +235,13 @@ def create_account(
         datetime.datetime(1900, 2, 13)
     )
 ) -> Account:
-    return cast(
-        Account,
-        Account.objects.create(
-            github_installation_id=1066615,
-            github_account_login="acme-corp",
-            github_account_id=523412234,
-            github_account_type="Organization",
-            stripe_customer_id="cus_H2pvQ2kt7nk0JY",
-            trial_expiration=trial_expiration,
-        ),
+    return Account.objects.create(
+        github_installation_id=1066615,
+        github_account_login="acme-corp",
+        github_account_id=523412234,
+        github_account_type="Organization",
+        stripe_customer_id="cus_H2pvQ2kt7nk0JY",
+        trial_expiration=trial_expiration,
     )
 
 
@@ -283,7 +280,7 @@ def test_get_subscription_blocker_expired_trial_subscription_ok(
 
 
 def create_user() -> User:
-    return cast(User, User.objects.create(github_id=2341234, github_login="b-lowe"))
+    return User.objects.create(github_id=2341234, github_login="b-lowe")
 
 
 @pytest.mark.django_db

--- a/web_api/web_api/test_stripe_views.py
+++ b/web_api/web_api/test_stripe_views.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Tuple, cast
+from typing import Tuple
 
 import pytest
 import stripe
@@ -34,26 +34,23 @@ def create_account() -> Tuple[User, Account]:
 
 
 def create_stripe_customer_info() -> StripeCustomerInformation:
-    return cast(
-        StripeCustomerInformation,
-        StripeCustomerInformation.objects.create(
-            customer_id="cus_H2pvQ2kt7nk0JY",
-            subscription_id="sub_Gu1xedsfo1",
-            plan_id="plan_G2df31A4G5JzQ",
-            payment_method_id="pm_22dldxf3",
-            customer_email="accounting@acme-corp.com",
-            customer_balance=0,
-            customer_created=1585781308,
-            payment_method_card_brand="mastercard",
-            payment_method_card_exp_month="03",
-            payment_method_card_exp_year="32",
-            payment_method_card_last4="4242",
-            plan_amount=499,
-            subscription_quantity=3,
-            subscription_start_date=1585781784,
-            subscription_current_period_start=0,
-            subscription_current_period_end=100,
-        ),
+    return StripeCustomerInformation.objects.create(
+        customer_id="cus_H2pvQ2kt7nk0JY",
+        subscription_id="sub_Gu1xedsfo1",
+        plan_id="plan_G2df31A4G5JzQ",
+        payment_method_id="pm_22dldxf3",
+        customer_email="accounting@acme-corp.com",
+        customer_balance=0,
+        customer_created=1585781308,
+        payment_method_card_brand="mastercard",
+        payment_method_card_exp_month="03",
+        payment_method_card_exp_year="32",
+        payment_method_card_last4="4242",
+        plan_amount=499,
+        subscription_quantity=3,
+        subscription_start_date=1585781784,
+        subscription_current_period_start=0,
+        subscription_current_period_end=100,
     )
 
 

--- a/web_api/web_api/test_user.py
+++ b/web_api/web_api/test_user.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 import pytest
 import responses
@@ -8,13 +8,10 @@ from web_api.models import Account, AccountMembership, SyncAccountsError, User
 
 @pytest.fixture
 def user() -> User:
-    return cast(
-        User,
-        User.objects.create(
-            github_id=10137,
-            github_login="ghost",
-            github_access_token="33149942-C986-42F8-9A45-AD83D5077776",
-        ),
+    return User.objects.create(
+        github_id=10137,
+        github_login="ghost",
+        github_access_token="33149942-C986-42F8-9A45-AD83D5077776",
     )
 
 

--- a/web_api/web_api/test_views.py
+++ b/web_api/web_api/test_views.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import time
-from typing import Any, Iterator, Optional, Tuple, Type, Union, cast
+from typing import Any, Iterator, Optional, Tuple, Type, Union
 
 import pytest
 import responses
@@ -25,25 +25,19 @@ from web_api.testutils import TestClient as Client
 
 @pytest.fixture
 def user() -> User:
-    return cast(
-        User,
-        User.objects.create(
-            github_id=10137,
-            github_login="ghost",
-            github_access_token="33149942-C986-42F8-9A45-AD83D5077776",
-        ),
+    return User.objects.create(
+        github_id=10137,
+        github_login="ghost",
+        github_access_token="33149942-C986-42F8-9A45-AD83D5077776",
     )
 
 
 @pytest.fixture
 def other_user() -> User:
-    return cast(
-        User,
-        User.objects.create(
-            github_id=67647,
-            github_login="bear",
-            github_access_token="D2F92D26-BC64-427C-93CC-13E7110F3EB7",
-        ),
+    return User.objects.create(
+        github_id=67647,
+        github_login="bear",
+        github_access_token="D2F92D26-BC64-427C-93CC-13E7110F3EB7",
     )
 
 
@@ -61,15 +55,12 @@ def create_account(
     github_account_type: Literal["User", "Organization"] = "User",
 ) -> Account:
 
-    return cast(
-        Account,
-        Account.objects.create(
-            github_installation_id=create_pk(),
-            github_account_id=create_pk(),
-            github_account_login=github_account_login,
-            github_account_type=github_account_type,
-            stripe_customer_id=stripe_customer_id,
-        ),
+    return Account.objects.create(
+        github_installation_id=create_pk(),
+        github_account_id=create_pk(),
+        github_account_login=github_account_login,
+        github_account_type=github_account_type,
+        stripe_customer_id=stripe_customer_id,
     )
 
 
@@ -97,27 +88,24 @@ def create_stripe_customer_info(
     subscription_current_period_start: int = 1650581784,
     subscription_current_period_end: int = 1658357784,
 ) -> StripeCustomerInformation:
-    return cast(
-        StripeCustomerInformation,
-        StripeCustomerInformation.objects.create(
-            customer_id=customer_id,
-            subscription_id=subscription_id,
-            plan_id="plan_G2df31A4G5JzQ",
-            payment_method_id="pm_22dldxf3",
-            customer_email="accounting@acme-corp.com",
-            customer_balance=0,
-            customer_created=1585781308,
-            payment_method_card_brand="mastercard",
-            payment_method_card_exp_month="03",
-            payment_method_card_exp_year="32",
-            payment_method_card_last4="4242",
-            plan_amount=499,
-            plan_interval="month",
-            subscription_quantity=3,
-            subscription_start_date=1585781784,
-            subscription_current_period_start=subscription_current_period_start,
-            subscription_current_period_end=subscription_current_period_end,
-        ),
+    return StripeCustomerInformation.objects.create(
+        customer_id=customer_id,
+        subscription_id=subscription_id,
+        plan_id="plan_G2df31A4G5JzQ",
+        payment_method_id="pm_22dldxf3",
+        customer_email="accounting@acme-corp.com",
+        customer_balance=0,
+        customer_created=1585781308,
+        payment_method_card_brand="mastercard",
+        payment_method_card_exp_month="03",
+        payment_method_card_exp_year="32",
+        payment_method_card_last4="4242",
+        plan_amount=499,
+        plan_interval="month",
+        subscription_quantity=3,
+        subscription_start_date=1585781784,
+        subscription_current_period_start=subscription_current_period_start,
+        subscription_current_period_end=subscription_current_period_end,
     )
 
 
@@ -616,6 +604,7 @@ def test_update_subscription(
         "web_api.models.stripe.Invoice.create", return_value=fake_invoice
     )
     stripe_invoice_pay = mocker.patch("web_api.models.stripe.Invoice.pay")
+    assert user.github_login is not None
     account = create_account(
         github_account_login=user.github_login, stripe_customer_id="cus_Ged32s2xnx12",
     )
@@ -773,6 +762,7 @@ def test_update_subscription_missing_customer(
     stripe_subscription_modify = mocker.patch(
         "web_api.models.stripe.Subscription.modify", return_value=fake_subscription
     )
+    assert user.github_login is not None
     account = create_account(
         github_account_login=user.github_login, stripe_customer_id="cus_Ged32s2xnx12",
     )
@@ -910,6 +900,7 @@ def test_cancel_subscription_admin_limit_billing_access_to_owners(
 
 @pytest.mark.django_db
 def test_activity(authed_client: Client, user: User,) -> None:
+    assert user.github_login is not None
     user_account = create_account(github_account_login=user.github_login,)
     AccountMembership.objects.create(account=user_account, user=user, role="member")
     pull_request_activity = PullRequestActivity.objects.create(
@@ -940,6 +931,7 @@ def test_activity(authed_client: Client, user: User,) -> None:
 
 @pytest.mark.django_db
 def test_activity_authentication(authed_client: Client, other_user: User,) -> None:
+    assert other_user.github_login is not None
     user_account = create_account(github_account_login=other_user.github_login,)
     AccountMembership.objects.create(
         account=user_account, user=other_user, role="member"
@@ -953,6 +945,7 @@ def test_start_checkout(authed_client: Client, user: User, mocker: Any) -> None:
     """
     Start a Stripe checkout session and return the required credentials to the frontend.
     """
+    assert user.github_login is not None
     user_account = create_account(github_account_login=user.github_login,)
     AccountMembership.objects.create(account=user_account, user=user, role="member")
 
@@ -1184,7 +1177,7 @@ def test_update_contact_emails(
     account, membership = create_org_account(user)
 
     original_email = "j.doe@acme-inc.corp"
-    account.original_email = original_email
+    account.contact_emails = original_email
     account.save()
 
     # by default a user should be able to set the contact emails fields.
@@ -1394,6 +1387,7 @@ def test_sync_accounts_failure(
 
 @pytest.mark.django_db
 def test_current_account(authed_client: Client, user: User) -> None:
+    assert user.github_login is not None
     user_account = create_account(github_account_login=user.github_login,)
     AccountMembership.objects.create(account=user_account, user=user, role="member")
     org_account = create_account(
@@ -1430,6 +1424,7 @@ def test_current_account(authed_client: Client, user: User) -> None:
 def test_current_account_authentication(
     authed_client: Client, other_user: User,
 ) -> None:
+    assert other_user.github_login is not None
     user_account = create_account(github_account_login=other_user.github_login,)
     AccountMembership.objects.create(
         account=user_account, user=other_user, role="member"
@@ -1440,6 +1435,7 @@ def test_current_account_authentication(
 
 @pytest.mark.django_db
 def test_accounts(authed_client: Client, user: User) -> None:
+    assert user.github_login is not None
     user_account = create_account(
         github_account_login=user.github_login, github_account_type="User",
     )
@@ -1476,6 +1472,7 @@ def test_start_trial(
     When a user starts a trial we should update their account.
     """
     update_bot = mocker.patch("web_api.models.Account.update_bot")
+    assert user.github_login is not None
     account = create_account(
         github_account_login=user.github_login, github_account_type="User",
     )
@@ -1503,11 +1500,14 @@ def test_start_trial(
     assert account.trial_email == "b.lowe@example.com"
 
 
-def similar_dates(a: datetime.datetime, b: datetime.datetime) -> bool:
+def similar_dates(
+    a: Optional[datetime.datetime], b: Optional[datetime.datetime]
+) -> bool:
     """
     Dates are equal if they are within 5 minutes of each other. This should
     hopefully reduce flakiness is tests.
     """
+    assert a is not None and b is not None
     return abs(int(a.timestamp()) - int(b.timestamp())) < 60 * 5
 
 
@@ -1519,6 +1519,7 @@ def test_start_trial_existing_trial(
     Starting a trial when there is already an existing trial shouldn't alter
     current trial.
     """
+    assert user.github_login is not None
     account = create_account(
         github_account_login=user.github_login, github_account_type="User",
     )

--- a/web_api/web_api/testutils.py
+++ b/web_api/web_api/testutils.py
@@ -1,7 +1,7 @@
 from importlib import import_module
+from typing import Any, cast
 
 from django.conf import settings
-from django.contrib.sessions.backends.base import SessionBase as SessionStore
 from django.http import HttpRequest, SimpleCookie
 from django.test.client import Client as DjangoTestClient
 
@@ -10,8 +10,8 @@ from web_api.models import User
 
 
 class TestClient(DjangoTestClient):
-    def login(self, user: User) -> None:
-        engine: SessionStore = import_module(settings.SESSION_ENGINE)
+    def login(self, user: User) -> None:  # type: ignore [override]
+        engine = cast(Any, import_module(settings.SESSION_ENGINE))
 
         # Create a fake request to store login details.
         request = HttpRequest()
@@ -40,10 +40,10 @@ class TestClient(DjangoTestClient):
     def logout(self) -> None:
         """Log out the user by removing the cookies and session object."""
         request = HttpRequest()
-        engine: SessionStore = import_module(settings.SESSION_ENGINE)
+        engine = cast(Any, import_module(settings.SESSION_ENGINE))
         if self.session:
             request.session = self.session
-            request.user = auth.get_user(request)
+            request.user = auth.get_user(request)  # type: ignore [assignment]
         else:
             request.session = engine.SessionStore()
         auth.logout(request)

--- a/web_api/web_api/views.py
+++ b/web_api/web_api/views.py
@@ -21,6 +21,7 @@ from typing_extensions import Literal
 from yarl import URL
 
 from web_api import auth
+from web_api.auth import AuthedHttpRequest
 from web_api.exceptions import BadRequest, PermissionDenied, UnprocessableEntity
 from web_api.models import (
     Account,
@@ -39,10 +40,7 @@ stripe.api_key = settings.STRIPE_SECRET_KEY
 
 
 def get_account_or_404(*, team_id: str, user: User) -> Account:
-    return cast(
-        Account,
-        get_object_or_404(Account.objects.filter(memberships__user=user), id=team_id),
-    )
+    return get_object_or_404(Account.objects.filter(memberships__user=user), id=team_id)
 
 
 @auth.login_required
@@ -54,7 +52,7 @@ DEFAULT_CURRENCY = "usd"
 
 
 @auth.login_required
-def usage_billing(request: HttpRequest, team_id: str) -> HttpResponse:
+def usage_billing(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     account = get_account_or_404(user=request.user, team_id=team_id)
     active_users = UserPullRequestActivity.get_active_users_in_last_30_days(account)
     subscription = None
@@ -85,6 +83,11 @@ def usage_billing(request: HttpRequest, team_id: str) -> HttpResponse:
         plan_interval = (
             "year" if stripe_customer_info.plan_interval == "year" else "month"
         )
+        brand_title = (
+            stripe_customer_info.payment_method_card_brand.title()
+            if stripe_customer_info.payment_method_card_brand is not None
+            else None
+        )
         subscription = dict(
             seats=stripe_customer_info.subscription_quantity,
             nextBillingDate=stripe_customer_info.next_billing_date,
@@ -100,7 +103,7 @@ def usage_billing(request: HttpRequest, team_id: str) -> HttpResponse:
             contactEmails=account.contact_emails,
             customerName=stripe_customer_info.customer_name,
             customerAddress=customer_address,
-            cardInfo=f"{stripe_customer_info.payment_method_card_brand.title()} ({stripe_customer_info.payment_method_card_last4})",
+            cardInfo=f"{brand_title} ({stripe_customer_info.payment_method_card_last4})",
             viewerIsOrgOwner=request.user.is_admin(account),
             viewerCanModify=request.user.can_edit_subscription(account),
             limitBillingAccessToOwners=account.limit_billing_access_to_owners,
@@ -145,7 +148,7 @@ def usage_billing(request: HttpRequest, team_id: str) -> HttpResponse:
 
 
 @auth.login_required
-def activity(request: HttpRequest, team_id: str) -> HttpResponse:
+def activity(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     account = get_account_or_404(team_id=team_id, user=request.user)
     kodiak_activity_labels = []
     kodiak_activity_approved = []
@@ -189,7 +192,7 @@ def activity(request: HttpRequest, team_id: str) -> HttpResponse:
 
 
 @auth.login_required
-def current_account(request: HttpRequest, team_id: str) -> HttpResponse:
+def current_account(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     account = get_account_or_404(team_id=team_id, user=request.user)
     return JsonResponse(
         dict(
@@ -216,7 +219,7 @@ def current_account(request: HttpRequest, team_id: str) -> HttpResponse:
 
 
 @auth.login_required
-def start_trial(request: HttpRequest, team_id: str) -> HttpResponse:
+def start_trial(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     account = get_account_or_404(team_id=team_id, user=request.user)
     billing_email = request.POST["billingEmail"]
     account.start_trial(request.user, billing_email=billing_email)
@@ -230,7 +233,7 @@ class UpdateSubscriptionModel(pydantic.BaseModel):
 
 
 @auth.login_required
-def update_subscription(request: HttpRequest, team_id: str) -> HttpResponse:
+def update_subscription(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     payload = UpdateSubscriptionModel.parse_obj(request.POST.dict())
     account = get_account_or_404(team_id=team_id, user=request.user)
     if not request.user.can_edit_subscription(account):
@@ -300,7 +303,9 @@ class UpdateBillingInfoModel(pydantic.BaseModel):
 
 
 @auth.login_required
-def update_stripe_customer_info(request: HttpRequest, team_id: str) -> HttpResponse:
+def update_stripe_customer_info(
+    request: AuthedHttpRequest, team_id: str
+) -> HttpResponse:
     """
     Endpoint to allow users to update Stripe customer info.
     """
@@ -350,7 +355,7 @@ class StartCheckoutModal(pydantic.BaseModel):
 
 
 @auth.login_required
-def start_checkout(request: HttpRequest, team_id: str) -> HttpResponse:
+def start_checkout(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     payload = StartCheckoutModal.parse_obj(request.POST.dict())
     account = get_account_or_404(team_id=team_id, user=request.user)
     # if available, using the existing customer_id allows us to pre-fill the
@@ -386,7 +391,7 @@ def start_checkout(request: HttpRequest, team_id: str) -> HttpResponse:
 
 @auth.login_required
 def redirect_to_stripe_self_serve_portal(
-    request: HttpRequest, team_id: str
+    request: AuthedHttpRequest, team_id: str
 ) -> HttpResponse:
     """
     Redirect the user to the temp URL so they can access the stripe self serve portal
@@ -406,7 +411,7 @@ def redirect_to_stripe_self_serve_portal(
 
 
 @auth.login_required
-def modify_payment_details(request: HttpRequest, team_id: str) -> HttpResponse:
+def modify_payment_details(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     account = get_account_or_404(team_id=team_id, user=request.user)
     if not request.user.can_edit_subscription(account):
         raise PermissionDenied
@@ -427,7 +432,7 @@ def modify_payment_details(request: HttpRequest, team_id: str) -> HttpResponse:
 
 
 @auth.login_required
-def cancel_subscription(request: HttpRequest, team_id: str) -> HttpResponse:
+def cancel_subscription(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     account = get_account_or_404(team_id=team_id, user=request.user)
     if not request.user.can_edit_subscription(account):
         raise PermissionDenied
@@ -440,7 +445,7 @@ def cancel_subscription(request: HttpRequest, team_id: str) -> HttpResponse:
 
 @auth.login_required
 @require_http_methods(["GET"])
-def get_subscription_info(request: HttpRequest, team_id: str) -> JsonResponse:
+def get_subscription_info(request: AuthedHttpRequest, team_id: str) -> JsonResponse:
     account = get_account_or_404(team_id=team_id, user=request.user)
 
     subscription_status = account.get_subscription_blocker()
@@ -487,7 +492,7 @@ class FetchProrationModal(pydantic.BaseModel):
 
 
 @auth.login_required
-def fetch_proration(request: HttpRequest, team_id: str) -> HttpResponse:
+def fetch_proration(request: AuthedHttpRequest, team_id: str) -> HttpResponse:
     payload = FetchProrationModal.parse_obj(request.POST.dict())
     account = get_account_or_404(user=request.user, team_id=team_id)
 
@@ -613,7 +618,7 @@ def stripe_webhook_handler(request: HttpRequest) -> HttpResponse:
 
 
 @auth.login_required
-def accounts(request: HttpRequest) -> HttpResponse:
+def accounts(request: AuthedHttpRequest) -> HttpResponse:
     return JsonResponse(
         [
             dict(id=x.id, name=x.github_account_login, profileImgUrl=x.profile_image())
@@ -681,8 +686,8 @@ def process_login_request(request: HttpRequest) -> Union[Success, Error]:
     # handle errors
     if request.POST.get("error"):
         return Error(
-            error=request.POST.get("error"),
-            error_description=request.POST.get("error_description"),
+            error=request.POST["error"],
+            error_description=request.POST["error_description"],
         )
 
     code = request.POST.get("code")
@@ -786,13 +791,13 @@ def oauth_complete(request: HttpRequest) -> HttpResponse:
 
 def logout(request: HttpRequest) -> HttpResponse:
     request.session.flush()
-    request.user = AnonymousUser()
+    request.user = AnonymousUser()  # type: ignore [assignment]
     return HttpResponse(status=201)
 
 
 @auth.login_required
 @require_http_methods(["POST"])
-def sync_accounts(request: HttpRequest) -> HttpResponse:
+def sync_accounts(request: AuthedHttpRequest) -> HttpResponse:
     try:
         request.user.sync_accounts()
     except SyncAccountsError:

--- a/web_api/web_api/views.py
+++ b/web_api/web_api/views.py
@@ -687,7 +687,7 @@ def process_login_request(request: HttpRequest) -> Union[Success, Error]:
     if request.POST.get("error"):
         return Error(
             error=request.POST["error"],
-            error_description=request.POST["error_description"],
+            error_description=request.POST.get("error_description") or "",
         )
 
     code = request.POST.get("code")


### PR DESCRIPTION
Add some basic django type stubs. There are some ignores around
`Request.user` since we don't inherit from `AbstractBaseUser`.

We're on an older version of Django that doesn't support indexing
into `QuerySet` or `BaseManager`, so we monkey patch those.