### PR TITLE
add(bot): limit coauthor trailer whitespace

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -197,7 +197,7 @@ def get_merge_body(
     ):
         trailer_block = "\n".join(coauthor_trailers)
         if merge_body.commit_message:
-            merge_body.commit_message += "\n\n"
+            merge_body.commit_message += "\n\n" + trailer_block
         else:
             merge_body.commit_message = trailer_block
 

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -202,6 +202,10 @@ def get_merge_body(
             commit_message + "\n\n" + "\n".join(coauthor_trailers)
         )
 
+    # remove extraneous whitespace.
+    if merge_body.commit_message is not None:
+        merge_body.commit_message = merge_body.commit_message.strip()
+
     return merge_body
 
 

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -195,16 +195,11 @@ def get_merge_body(
         MergeBodyStyle.pull_request_body,
         MergeBodyStyle.empty,
     ):
-        # comment_message should never be None when using
-        # MergeBodyStyle.pull_request_body, but I'm not going to assert on that!
-        commit_message = merge_body.commit_message or ""
-        merge_body.commit_message = (
-            commit_message + "\n\n" + "\n".join(coauthor_trailers)
-        )
-
-    # remove extraneous whitespace.
-    if merge_body.commit_message is not None:
-        merge_body.commit_message = merge_body.commit_message.strip()
+        trailer_block = "\n".join(coauthor_trailers)
+        if merge_body.commit_message:
+            merge_body.commit_message += "\n\n"
+        else:
+            merge_body.commit_message = trailer_block
 
     return merge_body
 

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -3294,7 +3294,16 @@ async def test_mergeable_include_coauthors() -> None:
     config = create_config()
     config.merge.message.include_coauthors = True
 
-    for body_style in (MergeBodyStyle.pull_request_body, MergeBodyStyle.empty):
+    for body_style, commit_message in (
+        (
+            MergeBodyStyle.pull_request_body,
+            "# some description\n\nCo-authored-by: Barry Block <73213123+b-block@users.noreply.github.com>",
+        ),
+        (
+            MergeBodyStyle.empty,
+            "Co-authored-by: Barry Block <73213123+b-block@users.noreply.github.com>",
+        ),
+    ):
         config.merge.message.body = body_style
         api = create_api()
         await mergeable(
@@ -3315,10 +3324,7 @@ async def test_mergeable_include_coauthors() -> None:
         assert api.set_status.calls[1]["msg"] == "merge complete 🎉"
 
         assert api.merge.call_count == 1
-        assert (
-            "Co-authored-by: Barry Block <73213123+b-block@users.noreply.github.com>"
-            in api.merge.calls[0]["commit_message"]
-        )
+        assert commit_message == api.merge.calls[0]["commit_message"]
         assert api.update_branch.call_count == 0
         assert api.queue_for_merge.call_count == 0
         assert api.dequeue.call_count == 0


### PR DESCRIPTION
If the commit message body is empty, don't add the two line spacing before coauthor trailers. GitHub adds it's own line between the title and body, so we'll have a three line space between the title and trailers if we don't remove our added spacing.

related #577