### PR TITLE
ref(bot): move get_commit_authors into separate file

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -35,7 +35,6 @@ from kodiak.queries import (
     BranchProtectionRule,
     CheckConclusionState,
     CheckRun,
-    CommitAuthor,
     MergeableState,
     MergeStateStatus,
     Permission,
@@ -43,6 +42,7 @@ from kodiak.queries import (
     PRReviewRequest,
     PRReviewState,
     PullRequest,
+    PullRequestCommitUser,
     PullRequestReviewDecision,
     PullRequestState,
     PushAllowance,
@@ -125,7 +125,7 @@ def get_merge_body(
     config: V1,
     merge_method: MergeMethod,
     pull_request: PullRequest,
-    commit_authors: List[CommitAuthor],
+    commit_authors: List[PullRequestCommitUser],
 ) -> MergeBody:
     """
     Get merge options for a pull request to call GitHub API.
@@ -422,7 +422,7 @@ async def mergeable(
     reviews: List[PRReview],
     contexts: List[StatusContext],
     check_runs: List[CheckRun],
-    commit_authors: List[CommitAuthor],
+    commit_authors: List[PullRequestCommitUser],
     valid_signature: bool,
     valid_merge_methods: List[MergeMethod],
     repository: RepoInfo,

--- a/bot/kodiak/queries/commits.py
+++ b/bot/kodiak/queries/commits.py
@@ -6,10 +6,6 @@ import structlog
 logger = structlog.get_logger()
 
 
-class CommitConnection(pydantic.BaseModel):
-    totalCount: int
-
-
 class User(pydantic.BaseModel):
     databaseId: Optional[int]
     login: str
@@ -26,7 +22,6 @@ class GitActor(pydantic.BaseModel):
 
 
 class Commit(pydantic.BaseModel):
-    parents: CommitConnection
     author: Optional[GitActor]
 
 

--- a/bot/kodiak/queries/commits.py
+++ b/bot/kodiak/queries/commits.py
@@ -1,0 +1,63 @@
+from typing import Any, Dict, List, Optional
+
+import pydantic
+import structlog
+
+logger = structlog.get_logger()
+
+
+class CommitConnection(pydantic.BaseModel):
+    totalCount: int
+
+
+class User(pydantic.BaseModel):
+    databaseId: Optional[int]
+    login: str
+    name: Optional[str]
+    type: str
+
+    def __hash__(self) -> int:
+        # defining a hash method allows us to deduplicate CommitAuthors easily.
+        return hash(self.databaseId) + hash(self.login) + hash(self.name)
+
+
+class GitActor(pydantic.BaseModel):
+    user: Optional[User]
+
+
+class Commit(pydantic.BaseModel):
+    parents: CommitConnection
+    author: Optional[GitActor]
+
+
+class PullRequestCommit(pydantic.BaseModel):
+    commit: Commit
+
+
+class PullRequestCommitConnection(pydantic.BaseModel):
+    nodes: Optional[List[PullRequestCommit]]
+
+
+class PullRequest(pydantic.BaseModel):
+    commitHistory: PullRequestCommitConnection
+
+
+def get_commit_authors(*, pr: Dict[str, Any]) -> List[User]:
+    """
+    Extract the commit authors from the pull request commits.
+    """
+    # we use a dict as an ordered set.
+    commit_authors = {}
+    try:
+        pull_request = PullRequest.parse_obj(pr)
+    except pydantic.ValidationError:
+        logger.warning("problem parsing commit authors", exc_info=True)
+        return []
+    nodes = pull_request.commitHistory.nodes
+    if not nodes:
+        return []
+    for node in nodes:
+        if node.commit.author is None or node.commit.author.user is None:
+            continue
+        commit_authors[node.commit.author.user] = True
+    return list(commit_authors.keys())

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -26,7 +26,6 @@ from kodiak.queries import (
     BranchProtectionRule,
     CheckConclusionState,
     CheckRun,
-    CommitAuthor,
     MergeableState,
     MergeStateStatus,
     NodeListPushAllowance,
@@ -37,6 +36,7 @@ from kodiak.queries import (
     PRReviewState,
     PullRequest,
     PullRequestAuthor,
+    PullRequestCommitUser,
     PullRequestReviewDecision,
     PullRequestState,
     PushAllowance,
@@ -342,7 +342,7 @@ class MergeableType(Protocol):
         reviews: List[PRReview] = ...,
         contexts: List[StatusContext] = ...,
         check_runs: List[CheckRun] = ...,
-        commit_authors: List[CommitAuthor] = ...,
+        commit_authors: List[PullRequestCommitUser] = ...,
         valid_signature: bool = ...,
         valid_merge_methods: List[MergeMethod] = ...,
         merging: bool = ...,
@@ -370,7 +370,7 @@ def create_mergeable() -> MergeableType:
         reviews: List[PRReview] = [create_review()],
         contexts: List[StatusContext] = [create_context()],
         check_runs: List[CheckRun] = [create_check_run()],
-        commit_authors: List[CommitAuthor] = [],
+        commit_authors: List[PullRequestCommitUser] = [],
         valid_signature: bool = False,
         valid_merge_methods: List[MergeMethod] = [
             MergeMethod.merge,
@@ -3242,16 +3242,20 @@ def test_get_merge_body_include_coauthors() -> None:
         merge_method=MergeMethod.merge,
         pull_request=pull_request,
         commit_authors=[
-            CommitAuthor(
+            PullRequestCommitUser(
                 databaseId=9023904, name="Bernard Lowe", login="b-lowe", type="User"
             ),
-            CommitAuthor(
+            PullRequestCommitUser(
                 databaseId=590434, name="Maeve Millay", login="maeve-m", type="Bot"
             ),
             # we default to the login when name is None.
-            CommitAuthor(databaseId=771233, name=None, login="d-abernathy", type="Bot"),
+            PullRequestCommitUser(
+                databaseId=771233, name=None, login="d-abernathy", type="Bot"
+            ),
             # without a databaseID the commit author will be ignored.
-            CommitAuthor(databaseId=None, name=None, login="william", type="User"),
+            PullRequestCommitUser(
+                databaseId=None, name=None, login="william", type="User"
+            ),
         ],
     )
     expected = MergeBody(
@@ -3275,8 +3279,10 @@ def test_get_merge_body_include_coauthors_invalid_body_style() -> None:
         pull_request=pull_request,
         merge_method=MergeMethod.merge,
         commit_authors=[
-            CommitAuthor(databaseId=9023904, name="", login="b-lowe", type="User"),
-            CommitAuthor(
+            PullRequestCommitUser(
+                databaseId=9023904, name="", login="b-lowe", type="User"
+            ),
+            PullRequestCommitUser(
                 databaseId=590434, name="Maeve Millay", login="maeve-m", type="Bot"
             ),
         ],
@@ -3301,7 +3307,7 @@ async def test_mergeable_include_coauthors() -> None:
             api=api,
             config=config,
             commit_authors=[
-                CommitAuthor(
+                PullRequestCommitUser(
                     databaseId=73213123,
                     name="Barry Block",
                     login="b-block",

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -674,8 +674,8 @@ def test_get_commit_authors_error_handling() -> None:
     pull_request_data = {
         "commitHistory": {
             "nodes": [
-                {"commit": {"author": {"user": {}}}},
-                {"commit": {"author": {}}},
+                {"commit": {"author": {"user": None}}},
+                {"commit": {"author": None}},
                 {
                     "commit": {
                         "author": {

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -16,7 +16,6 @@ from kodiak.queries import (
     CheckConclusionState,
     CheckRun,
     Client,
-    CommitAuthor,
     EventInfoResponse,
     GraphQLResponse,
     MergeableState,
@@ -31,6 +30,7 @@ from kodiak.queries import (
     PRReviewState,
     PullRequest,
     PullRequestAuthor,
+    PullRequestCommitUser,
     PullRequestState,
     PushAllowance,
     PushAllowanceActor,
@@ -652,12 +652,18 @@ def test_get_commit_authors() -> None:
     }
     res = get_commit_authors(pr=pull_request_data)
     assert res == [
-        CommitAuthor(
+        PullRequestCommitUser(
             name="Christopher Dignam", databaseId=1929960, login="chdsbd", type="User"
         ),
-        CommitAuthor(name="b-lowe", databaseId=5345234, login="b-lowe", type="User"),
-        CommitAuthor(name=None, databaseId=435453, login="kodiakhq", type="Bot"),
-        CommitAuthor(name=None, databaseId=None, login="j-doe", type="SomeGitActor"),
+        PullRequestCommitUser(
+            name="b-lowe", databaseId=5345234, login="b-lowe", type="User"
+        ),
+        PullRequestCommitUser(
+            name=None, databaseId=435453, login="kodiakhq", type="Bot"
+        ),
+        PullRequestCommitUser(
+            name=None, databaseId=None, login="j-doe", type="SomeGitActor"
+        ),
     ]
 
 
@@ -711,11 +717,15 @@ def test_get_commit_authors_error_handling() -> None:
     }
     res = get_commit_authors(pr=pull_request_data)
     assert res == [
-        CommitAuthor(name=None, databaseId=435453, login="kodiakhq", type="Bot"),
-        CommitAuthor(
+        PullRequestCommitUser(
+            name=None, databaseId=435453, login="kodiakhq", type="Bot"
+        ),
+        PullRequestCommitUser(
             name="Christopher Dignam", databaseId=1929960, login="chdsbd", type="User"
         ),
-        CommitAuthor(name=None, databaseId=None, login="j-doe", type="SomeGitActor"),
+        PullRequestCommitUser(
+            name=None, databaseId=None, login="j-doe", type="SomeGitActor"
+        ),
     ]
 
 


### PR DESCRIPTION
I think long term we should break up queries.py into multiple fields. I find it confusing having all the pydantic schemas in the same file.