### PR TITLE
fix(bot): refresh pull requests ref handling

### DIFF
--- a/bot/kodiak/refresh_pull_requests.py
+++ b/bot/kodiak/refresh_pull_requests.py
@@ -81,8 +81,8 @@ query ($login: String!) {
         pullRequests(first: 100, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
           nodes {
             number
-            base {
-                ref
+            baseRef {
+              name
             }
           }
         }
@@ -96,8 +96,8 @@ query ($login: String!) {
         pullRequests(first: 100, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
           nodes {
             number
-            base {
-                ref
+            baseRef {
+              name
             }
           }
         }
@@ -156,7 +156,7 @@ async def refresh_pull_requests_for_installation(
                 WebhookEvent(
                     repo_owner=login,
                     repo_name=repo_name,
-                    target_name=pull_request["base"]["ref"],
+                    target_name=pull_request["baseRef"]["name"],
                     pull_request_number=pull_request["number"],
                     installation_id=installation_id,
                 )

--- a/bot/kodiak/refresh_pull_requests.py
+++ b/bot/kodiak/refresh_pull_requests.py
@@ -81,6 +81,9 @@ query ($login: String!) {
         pullRequests(first: 100, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
           nodes {
             number
+            base {
+                ref
+            }
           }
         }
       }
@@ -93,6 +96,9 @@ query ($login: String!) {
         pullRequests(first: 100, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
           nodes {
             number
+            base {
+                ref
+            }
           }
         }
       }


### PR DESCRIPTION
We weren't fetching the base refs for pull requests, so this service was failing when we tried to access the non-existent fields.