### PR TITLE
fix: `automerge_labels` => `automerge_label`

### DIFF
--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -36,7 +36,7 @@ merge.automerge_label = "🚀 merge it!"
 If multiple labels are specified in an array, any of the specified labels will trigger merge.
 
 ```toml
-merge.automerge_labels = ["🚢 it!", "merge it!"]
+merge.automerge_label = ["🚢 it!", "merge it!"]
 ```
 
 ### `merge.require_automerge_label`


### PR DESCRIPTION
## Issue

When implementing this **awesome** tool 🙏, I observed that `automerge_label` accepts a `string` or `array`. 
I attempted to use  `automerge_labels`, which matches the docs but causes an error when Github Checks ran. 

> I believe the error was, **"automerge_label is not defined"**.

## Fix

I continued to use my` automerge_label` **array** to fix the issue but changed the text from `automerge_labels` to `automerge_label`

Thanks for your great work!