### PR TITLE
ref(docs): use s/ folder instead of package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,7 @@ jobs:
       - run:
           name: run typechecker
           working_directory: docs
-          command: |
-            yarn typecheck
+          command: s/typecheck
 
   docs_fmt:
     docker:
@@ -136,7 +135,7 @@ jobs:
       - run:
           name: run fmt
           working_directory: docs
-          command: yarn fmt-ci
+          command: s/fmt-ci
 
   docs_build:
     docker:
@@ -160,7 +159,7 @@ jobs:
       - run:
           name: build
           working_directory: docs
-          command: yarn build
+          command: s/build
 
   web_api_test:
     docker:

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,8 @@ Add another markdown file to the `docs/` folder and update the
 ```shell
 # docs/
 yarn install
-yarn start
-yarn typecheck --watch
-yarn fmt
+s/dev
+s/typecheck --watch
+s/fmt
 AGOLIA_API_KEY= AGOLIA_INDEX_NAME= yarn build
 ```

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,16 +1,5 @@
 {
-  "scripts": {
-    "examples": "docusaurus-examples",
-    "start": "docusaurus-start",
-    "build": "docusaurus-build",
-    "fmt": "yarn prettier '**/*.{md,js,json}' --write",
-    "fmt-ci": "yarn prettier '**/*.{md,js,json}' --check",
-    "typecheck": "tsc --project tsconfig.json",
-    "publish-gh-pages": "docusaurus-publish",
-    "write-translations": "docusaurus-write-translations",
-    "version": "docusaurus-version",
-    "rename-version": "docusaurus-rename-version"
-  },
+  "private": true,
   "devDependencies": {
     "@types/react": "^16.9.17",
     "docusaurus": "^1.14.3",

--- a/docs/s/build
+++ b/docs/s/build
@@ -1,7 +1,5 @@
 #!/bin/sh
-yarn_bin_path=$(yarn bin)
-npm_bin_path=$(npm bin)
-echo "|$yarn_bin_path|"
-echo "|$npm_bin_path|"
-exec "${yarn_bin_path}/docusaurus-build"
-g
+# Netlify sets FORCE_COLOR=true and a bug in Yarn causes `yarn bin` to return an
+# invalid path: `[2K[1G/opt/build/repo/docs/node_modules/.bin`
+# https://github.com/yarnpkg/yarn/issues/5945
+exec "$(FORCE_COLOR=0 yarn bin)/docusaurus-build"

--- a/docs/s/build
+++ b/docs/s/build
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec "$(yarn bin)/docusaurus-build"
+exec "$(npm bin)/docusaurus-build"

--- a/docs/s/build
+++ b/docs/s/build
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec "$(npm bin)/docusaurus-build"
+exec "$(yarn bin)/docusaurus-build"

--- a/docs/s/build
+++ b/docs/s/build
@@ -3,9 +3,5 @@ yarn_bin_path=$(yarn bin)
 npm_bin_path=$(npm bin)
 echo "|$yarn_bin_path|"
 echo "|$npm_bin_path|"
-echo "${yarn_bin_path}/docusaurus-build"
-echo "${npm_bin_path}/docusaurus-build"
-ls "$yarn_bin_path"
-ls "$npm_bin_path"
-diff  <(echo "$yarn_bin_path" ) <(echo "$npm_bin_path")
 exec "${yarn_bin_path}/docusaurus-build"
+g

--- a/docs/s/build
+++ b/docs/s/build
@@ -7,4 +7,5 @@ echo "${yarn_bin_path}/docusaurus-build"
 echo "${npm_bin_path}/docusaurus-build"
 ls "$yarn_bin_path"
 ls "$npm_bin_path"
+diff  <(echo "$yarn_bin_path" ) <(echo "$npm_bin_path")
 exec "${yarn_bin_path}/docusaurus-build"

--- a/docs/s/build
+++ b/docs/s/build
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec "$(yarn bin)/docusaurus-build"
+exec ./node_modules/.bin/docusaurus-build

--- a/docs/s/build
+++ b/docs/s/build
@@ -1,2 +1,6 @@
 #!/bin/sh
-exec ./node_modules/.bin/docusaurus-build
+yarn_bin_path=$(yarn bin)
+npm_bin_path=$(npm bin)
+echo "|$yarn_bin_path|"
+echo "|$npm_bin_path|"
+exec "${yarn_bin_path}/docusaurus-build"

--- a/docs/s/build
+++ b/docs/s/build
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(yarn bin)/docusaurus-build"

--- a/docs/s/build
+++ b/docs/s/build
@@ -3,4 +3,8 @@ yarn_bin_path=$(yarn bin)
 npm_bin_path=$(npm bin)
 echo "|$yarn_bin_path|"
 echo "|$npm_bin_path|"
+echo "${yarn_bin_path}/docusaurus-build"
+echo "${npm_bin_path}/docusaurus-build"
+ls "$yarn_bin_path"
+ls "$npm_bin_path"
 exec "${yarn_bin_path}/docusaurus-build"

--- a/docs/s/dev
+++ b/docs/s/dev
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec $(npm bin)/docusaurus-start
+exec $(yarn bin)/docusaurus-start

--- a/docs/s/dev
+++ b/docs/s/dev
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec $(yarn bin)/docusaurus-start

--- a/docs/s/dev
+++ b/docs/s/dev
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec $(yarn bin)/docusaurus-start
+exec $(npm bin)/docusaurus-start

--- a/docs/s/dev
+++ b/docs/s/dev
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec $(yarn bin)/docusaurus-start
+exec "$(yarn bin)/docusaurus-start"

--- a/docs/s/fmt
+++ b/docs/s/fmt
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(yarn bin)/prettier" '**/*.{md,js,json}' --write

--- a/docs/s/fmt-ci
+++ b/docs/s/fmt-ci
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(yarn bin)/prettier" '**/*.{md,js,json}' --check

--- a/docs/s/typecheck
+++ b/docs/s/typecheck
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(yarn bin)/tsc" --project tsconfig.json

--- a/docs/s/typecheck
+++ b/docs/s/typecheck
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec "$(yarn bin)/tsc" --project tsconfig.json
+exec "$(yarn bin)/tsc" --project tsconfig.json "$@"


### PR DESCRIPTION
This makes the `docs/` project consistent with `bot/`, `web_ui/`, and `web_api/` where we use `s/dev`, `s/lint`, etc., for our utility scripts.