### PR TITLE
add(bot): cut_body_after option for merge message

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -44,6 +44,7 @@ class MergeMessage(BaseModel):
     include_coauthors: bool = False
     include_pull_request_url: bool = False
     cut_body_before: str = ""
+    cut_body_after: str = ""
 
 
 # this pattern indicates that the user has the field unset.

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -33,7 +33,8 @@
           "include_pull_request_author": false,
           "include_coauthors": false,
           "include_pull_request_url": false,
-          "cut_body_before": ""
+          "cut_body_before": "",
+          "cut_body_after": ""
         },
         "dont_wait_on_status_checks": [],
         "update_branch_immediately": false,
@@ -143,6 +144,11 @@
           "title": "Cut Body Before",
           "default": "",
           "type": "string"
+        },
+        "cut_body_after": {
+          "title": "Cut Body After",
+          "default": "",
+          "type": "string"
         }
       }
     },
@@ -236,7 +242,8 @@
             "include_pull_request_author": false,
             "include_coauthors": false,
             "include_pull_request_url": false,
-            "cut_body_before": ""
+            "cut_body_before": "",
+            "cut_body_after": ""
           },
           "allOf": [
             {

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -3048,6 +3048,132 @@ def test_get_merge_body_strip_html_comments() -> None:
     assert actual == expected
 
 
+def test_get_merge_body_cut_body_after() -> None:
+    """
+    Basic check of cut_body_after removing content.
+    """
+    pull_request = create_pull_request()
+    pull_request.body = "hello <!-- testing -->world"
+    actual = get_merge_body(
+        config=V1(
+            version=1,
+            merge=Merge(
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body,
+                    cut_body_after="<!-- testing -->",
+                )
+            ),
+        ),
+        pull_request=pull_request,
+        merge_method=MergeMethod.squash,
+        commits=[],
+    )
+    expected = MergeBody(merge_method="squash", commit_message="hello <!-- testing -->")
+    assert actual == expected
+
+
+def test_get_merge_body_cut_body_after_strip_html() -> None:
+    """
+    We should be able to use strip_html_comments with cut_body_after.
+    """
+    pull_request = create_pull_request()
+    pull_request.body = "hello <!-- testing -->world"
+    actual = get_merge_body(
+        config=V1(
+            version=1,
+            merge=Merge(
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body,
+                    cut_body_after="<!-- testing -->",
+                    strip_html_comments=True,
+                )
+            ),
+        ),
+        pull_request=pull_request,
+        merge_method=MergeMethod.squash,
+        commits=[],
+    )
+    expected = MergeBody(merge_method="squash", commit_message="hello ")
+    assert actual == expected
+
+
+def test_get_merge_body_cut_body_after_multiple_markers() -> None:
+    """
+    We should choose the first substring matching cut_body_after.
+    """
+    pull_request = create_pull_request()
+    pull_request.body = "hello <!-- testing -->world<!-- testing --> 123"
+    actual = get_merge_body(
+        config=V1(
+            version=1,
+            merge=Merge(
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body,
+                    cut_body_after="<!-- testing -->",
+                    strip_html_comments=True,
+                )
+            ),
+        ),
+        pull_request=pull_request,
+        merge_method=MergeMethod.squash,
+        commits=[],
+    )
+    expected = MergeBody(merge_method="squash", commit_message="hello ")
+    assert actual == expected
+
+
+def test_get_merge_body_cut_body_after_no_match_found() -> None:
+    """
+    Ensure we don't edit the message if there isn't any match found with
+    cut_body_after.
+    """
+    pull_request = create_pull_request()
+    pr_body = "hello <!-- foo -->world<!-- bar --> 123"
+    pull_request.body = pr_body
+    actual = get_merge_body(
+        config=V1(
+            version=1,
+            merge=Merge(
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body,
+                    cut_body_after="<!-- buzz -->",
+                )
+            ),
+        ),
+        pull_request=pull_request,
+        merge_method=MergeMethod.squash,
+        commits=[],
+    )
+    expected = MergeBody(merge_method="squash", commit_message=pr_body)
+    assert actual == expected
+
+
+def test_get_merge_body_cut_body_before_no_match_found() -> None:
+    """
+    Ensure we don't edit the message if there isn't any match found with
+    cut_body_before.
+    """
+    pull_request = create_pull_request()
+    pr_body = "hello <!-- foo -->world<!-- bar --> 123"
+    pull_request.body = pr_body
+    actual = get_merge_body(
+        config=V1(
+            version=1,
+            merge=Merge(
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body,
+                    cut_body_before="<!-- buzz -->",
+                )
+            ),
+        ),
+        pull_request=pull_request,
+        merge_method=MergeMethod.squash,
+        commits=[],
+    )
+    expected = MergeBody(merge_method="squash", commit_message=pr_body)
+    assert actual == expected
+
+
 def test_get_merge_body_cut_body_before() -> None:
     pull_request = create_pull_request()
     pull_request.body = "hello <!-- testing -->world"


### PR DESCRIPTION
`cut_body_before` was added via https://github.com/chdsbd/kodiak/pull/589

Add the second option, also handle the case where the match isn't found.

rel: https://github.com/chdsbd/kodiak/issues/550