### PR TITLE
add(bot): rebase fast forward merge

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -11,6 +11,7 @@ class MergeMethod(str, Enum):
     merge = "merge"
     squash = "squash"
     rebase = "rebase"
+    rebase_fast_forward = "rebase-fast-forward"
 
 
 class MergeTitleStyle(Enum):

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -160,7 +160,7 @@ def get_coauthor_trailers(
 
 @dataclass
 class MergeBody:
-    merge_method: str
+    merge_method: MergeMethod
     commit_title: Optional[str] = None
     commit_message: Optional[str] = None
 
@@ -295,6 +295,9 @@ class PRAPI(Protocol):
         commit_title: Optional[str],
         commit_message: Optional[str],
     ) -> None:
+        ...
+
+    async def update_ref(self, *, ref: str, sha: str) -> None:
         ...
 
     async def queue_for_merge(self, *, first: bool) -> Optional[int]:
@@ -1034,11 +1037,16 @@ branch protection requirements.
         merge_args = get_merge_body(config, merge_method, pull_request, commits=commits)
         await set_status("⛴ attempting to merge PR (merging)")
         try:
-            await api.merge(
-                merge_method=merge_args.merge_method,
-                commit_title=merge_args.commit_title,
-                commit_message=merge_args.commit_message,
-            )
+            if merge_args.merge_method is MergeMethod.rebase_fast_forward:
+                await api.update_ref(
+                    ref=pull_request.baseRefName, sha=pull_request.latest_sha
+                )
+            else:
+                await api.merge(
+                    merge_method=merge_args.merge_method,
+                    commit_title=merge_args.commit_title,
+                    commit_message=merge_args.commit_message,
+                )
         # if we encounter an internal server error (status code 500), it is
         # _not_ safe to retry. Instead we mark the pull request as unmergable
         # and require a user to re-enable Kodiak on the pull request.

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -1047,6 +1047,16 @@ class Client:
         async with self.throttler:
             return await self.session.put(url, headers=headers, json=body)
 
+    async def update_ref(self, *, ref: str, sha: str) -> http.Response:
+        # we must not pass the keys for commit_title or commit_message when they
+        # are null because GitHub will error saying the title/message cannot be
+        # null. When the keys are not passed, GitHub creates a title and
+        # message.
+        headers = await get_headers(installation_id=self.installation_id)
+        url = conf.v3_url(f"/repos/{self.owner}/{self.repo}/git/refs/heads/{ref}")
+        async with self.throttler:
+            return await self.session.patch(url, headers=headers, json=dict(sha=sha))
+
     async def create_notification(
         self, head_sha: str, message: str, summary: Optional[str] = None
     ) -> http.Response:


### PR DESCRIPTION
For GitHub's [merge pull request API](https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request), rebased commits will be recreated on merge. This is counter to normal git rebase. To preserve the commits on merge we can use [ref API](https://docs.github.com/en/rest/reference/git#update-a-reference) to point the base branch to the new commits. This way the commits in the pull request are merged unchanged.