### PR TITLE
ref(bot): use exhaustiveness checking via NoReturn type

### DIFF
--- a/bot/.pylintrc
+++ b/bot/.pylintrc
@@ -206,7 +206,9 @@ disable=print-statement,
         # doesn't handle .pyi files
         useless-import-alias,
         # conflicts with type stubs for structlog
-        keyword-arg-before-vararg
+        keyword-arg-before-vararg,
+        # not smart enough about refinement
+        inconsistent-return-statements,
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/bot/kodiak/assertions.py
+++ b/bot/kodiak/assertions.py
@@ -1,0 +1,9 @@
+from typing import NoReturn
+
+
+def assert_never(value: NoReturn) -> NoReturn:
+    """
+    Enable exhaustiveness checking when comparing against enums and unions
+    of literals.
+    """
+    raise Exception(f"expected never, got {value}")

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -12,6 +12,7 @@ import toml
 from typing_extensions import Protocol
 
 from kodiak import app_config, config, messages
+from kodiak.assertions import assert_never
 from kodiak.config import (
     DEFAULT_TITLE_REGEX,
     UNSET_TITLE_REGEX,
@@ -74,7 +75,7 @@ def get_body_content(
     cut_body_after: str,
     pull_request: PullRequest,
 ) -> str:
-    if body_type == BodyText.markdown:
+    if body_type is BodyText.markdown:
         body = pull_request.body
         if cut_body_before != "":
             start_index = body.find(cut_body_before)
@@ -87,11 +88,11 @@ def get_body_content(
         if strip_html_comments:
             return strip_html_comments_from_markdown(body)
         return body
-    if body_type == BodyText.plain_text:
+    if body_type is BodyText.plain_text:
         return pull_request.bodyText
-    if body_type == BodyText.html:
+    if body_type is BodyText.html:
         return pull_request.bodyHTML
-    raise Exception(f"Unknown body_type: {body_type}")
+    assert_never(body_type)
 
 
 EMPTY_STRING = ""


### PR DESCRIPTION
`NoReturn` is Python's `never` which we can use to help ensure we handle
all cases.

I tried looking for other places where we could use this, but didn't
really find any easy places to add it.

Also we need to use `is` when comparing enum variants due to mypy's
backwards compatible refinement outlined in: https://github.com/python/mypy/issues/6366