### PR TITLE
fix(bot): merge queue merging timestamp

### DIFF
--- a/bot/kodiak/queue.py
+++ b/bot/kodiak/queue.py
@@ -132,7 +132,7 @@ async def process_repo_queue(
     target_name = webhook_event.get_merge_target_queue_name()
     # mark this PR as being merged currently. we check this elsewhere to set proper status codes
     await connection.set(target_name, webhook_event.json())
-    await connection.set(target_name + ":time", str(time.time()))
+    await connection.set(target_name + ":time", str(webhook_event_json.score))
 
     async def dequeue() -> None:
         await connection.zrem(

--- a/bot/typings/asyncio_redis/replies.pyi
+++ b/bot/typings/asyncio_redis/replies.pyi
@@ -16,5 +16,7 @@ class SetReply:
 class BlockingZPopReply:
     @property
     def value(self) -> bytes: ...
+    @property
+    def score(self) -> float: ...
 
 __all__ = ["DictReply", "BlockingZPopReply", "StatusReply"]


### PR DESCRIPTION
With the recent changes to the merge queue display, the merging pull requests loses the time it was added to the queue and instead shows the time it started merging.

We can use the sorted set score to track the time the pull request was added to the merge queue and display that time when merging.