### PR TITLE
fix(bot): ignore external pull requests when enqueuing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Configuration file (`.kodiak.toml`) is now read from a pull request's base branch instead of repository default branch. (#152, #634)
 
+### Fixed
+- fixed handling of "check run" webhooks to ignore pull requests from other repositories. (#644)
+
 ## 0.40.0 - 2021-03-26
 
 ### Changed

--- a/bot/kodiak/event_handlers.py
+++ b/bot/kodiak/event_handlers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Dict, List, Optional, Set
+from typing import Dict, Iterator, List, Optional, Set
 
 import asyncio_redis
 import structlog
@@ -39,7 +39,7 @@ async def pr_event(pr: PullRequestEvent) -> None:
     )
 
 
-async def check_run(check_run_event: CheckRunEvent) -> None:
+def check_run(check_run_event: CheckRunEvent) -> Iterator[WebhookEvent]:
     """
     Trigger evaluation of all PRs included in check run.
     """
@@ -47,15 +47,16 @@ async def check_run(check_run_event: CheckRunEvent) -> None:
     if check_run_event.check_run.name == queries.CHECK_RUN_NAME:
         return
     for pr in check_run_event.check_run.pull_requests:
-        await redis_webhook_queue.enqueue(
-            event=WebhookEvent(
+        # filter out pull requests for other repositories
+        if pr.base.repo.id != check_run_event.repository.id:
+            continue
+        yield WebhookEvent(
                 repo_owner=check_run_event.repository.owner.login,
                 repo_name=check_run_event.repository.name,
                 pull_request_number=pr.number,
                 target_name=pr.base.ref,
                 installation_id=str(check_run_event.installation.id),
             )
-        )
 
 
 def find_branch_names_latest(sha: str, branches: List[Branch]) -> List[str]:
@@ -220,7 +221,8 @@ async def handle_webhook_event(event_name: str, payload: Dict[str, object]) -> N
         log = log.bind(usage_reported=True)
 
     if event_name == "check_run":
-        await check_run(CheckRunEvent.parse_obj(payload))
+        for event in check_run(CheckRunEvent.parse_obj(payload)):
+            await redis_webhook_queue.enqueue(event=event)
     elif event_name == "pull_request":
         await pr_event(PullRequestEvent.parse_obj(payload))
     elif event_name == "pull_request_review":

--- a/bot/kodiak/event_handlers.py
+++ b/bot/kodiak/event_handlers.py
@@ -51,12 +51,12 @@ def check_run(check_run_event: CheckRunEvent) -> Iterator[WebhookEvent]:
         if pr.base.repo.id != check_run_event.repository.id:
             continue
         yield WebhookEvent(
-                repo_owner=check_run_event.repository.owner.login,
-                repo_name=check_run_event.repository.name,
-                pull_request_number=pr.number,
-                target_name=pr.base.ref,
-                installation_id=str(check_run_event.installation.id),
-            )
+            repo_owner=check_run_event.repository.owner.login,
+            repo_name=check_run_event.repository.name,
+            pull_request_number=pr.number,
+            target_name=pr.base.ref,
+            installation_id=str(check_run_event.installation.id),
+        )
 
 
 def find_branch_names_latest(sha: str, branches: List[Branch]) -> List[str]:

--- a/bot/kodiak/events/check_run.py
+++ b/bot/kodiak/events/check_run.py
@@ -5,8 +5,13 @@ import pydantic
 from kodiak.events.base import GithubEvent
 
 
+class PullRequestRepository(pydantic.BaseModel):
+    id: int
+
+
 class Ref(pydantic.BaseModel):
     ref: str
+    repo: PullRequestRepository
 
 
 class PullRequest(pydantic.BaseModel):
@@ -24,6 +29,7 @@ class Owner(pydantic.BaseModel):
 
 
 class Repository(pydantic.BaseModel):
+    id: int
     name: str
     owner: Owner
 
@@ -35,3 +41,4 @@ class CheckRunEvent(GithubEvent):
 
     check_run: CheckRun
     repository: Repository
+

--- a/bot/kodiak/events/check_run.py
+++ b/bot/kodiak/events/check_run.py
@@ -41,4 +41,3 @@ class CheckRunEvent(GithubEvent):
 
     check_run: CheckRun
     repository: Repository
-

--- a/bot/kodiak/test_events.py
+++ b/bot/kodiak/test_events.py
@@ -9,7 +9,6 @@ from kodiak import events
 # register themselves here for testing.
 MAPPING = (
     ("check_run", events.CheckRunEvent),
-    ("check_run", events.CheckRunEvent),
     ("pull_request", events.PullRequestEvent),
     ("pull_request_review", events.PullRequestReviewEvent),
     ("status", events.StatusEvent),

--- a/bot/kodiak/tests/event_handlers/test_check_run.py
+++ b/bot/kodiak/tests/event_handlers/test_check_run.py
@@ -13,6 +13,9 @@ from kodiak.queue import WebhookEvent
 
 
 def test_ignore_external_pull_requests() -> None:
+    """
+    We should filter out pull requests that don't belong to our repository.
+    """
     internal_repository_id = 554453
     internal_pull_request = PullRequest(
         number=123,

--- a/bot/kodiak/tests/event_handlers/test_check_run.py
+++ b/bot/kodiak/tests/event_handlers/test_check_run.py
@@ -1,0 +1,42 @@
+from kodiak.event_handlers import check_run
+from kodiak.events.base import Installation
+from kodiak.events.check_run import (
+    CheckRun,
+    CheckRunEvent,
+    Owner,
+    PullRequest,
+    PullRequestRepository,
+    Ref,
+    Repository,
+)
+from kodiak.queue import WebhookEvent
+
+
+def test_ignore_external_pull_requests() -> None:
+    internal_repository_id = 554453
+    internal_pull_request = PullRequest(
+        number=123,
+        base=Ref(ref="main", repo=PullRequestRepository(id=internal_repository_id)),
+    )
+    external_pull_request = PullRequest(
+        number=534, base=Ref(ref="main", repo=PullRequestRepository(id=22))
+    )
+    event = CheckRunEvent(
+        installation=Installation(id=69039045),
+        check_run=CheckRun(
+            name="circleci: build",
+            pull_requests=[external_pull_request, internal_pull_request],
+        ),
+        repository=Repository(
+            id=internal_repository_id, name="cake-api", owner=Owner(login="acme-corp")
+        ),
+    )
+    assert list(check_run(event)) == [
+        WebhookEvent(
+            repo_owner="acme-corp",
+            repo_name="cake-api",
+            pull_request_number=internal_pull_request.number,
+            installation_id=str(event.installation.id),
+            target_name="main",
+        )
+    ]


### PR DESCRIPTION
GitHub provides pull requests that are outside the current repository. I think this only affects public repositories, but it's a waste of resources to try to process these pull requests since we don't have access.