### PR TITLE
fix(bot): skip redis-dependent test if Redis isn't running

### DIFF
--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -43,7 +43,7 @@ from kodiak.queries import (
 )
 from kodiak.queries.commits import CommitConnection, GitActor
 from kodiak.test_utils import wrap_future
-from kodiak.tests.fixtures import FakeThottler, create_commit
+from kodiak.tests.fixtures import FakeThottler, create_commit, requires_redis
 
 
 @pytest.fixture
@@ -281,6 +281,7 @@ async def setup_redis(github_installation_id: str) -> None:
 
 
 # TODO: serialize EventInfoResponse to JSON to parametrize test
+@requires_redis
 @pytest.mark.asyncio
 async def test_get_event_info_blocked(
     api_client: Client,

--- a/bot/kodiak/tests/fixtures.py
+++ b/bot/kodiak/tests/fixtures.py
@@ -1,5 +1,8 @@
 from typing import Any, Optional
 
+import pytest
+
+from kodiak import app_config as conf
 from kodiak.queries import Commit, CommitConnection, GitActor, PullRequestCommitUser
 
 
@@ -27,3 +30,24 @@ class FakeThottler:
 
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         ...
+
+
+def redis_running() -> bool:
+    """
+    Check if service is listening at the REDIS host and port.
+    """
+    import socket
+
+    s = socket.socket()
+    host = conf.REDIS_URL.hostname
+    port = conf.REDIS_URL.port
+    assert host and port
+    try:
+        s.connect((host, port))
+        s.close()
+        return True
+    except ConnectionRefusedError:
+        return False
+
+
+requires_redis = pytest.mark.skipif(not redis_running(), reason="redis is not running")


### PR DESCRIPTION
fixes #656