### PR TITLE
cut(bot): unused param valid_signature

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -472,7 +472,6 @@ async def mergeable(
     contexts: List[StatusContext],
     check_runs: List[CheckRun],
     commits: List[Commit],
-    valid_signature: bool,
     valid_merge_methods: List[MergeMethod],
     repository: RepoInfo,
     merging: bool,

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -109,7 +109,6 @@ async def evaluate_pr(
                         contexts=pr.event.status_contexts,
                         check_runs=pr.event.check_runs,
                         commits=pr.event.commits,
-                        valid_signature=pr.event.valid_signature,
                         valid_merge_methods=pr.event.valid_merge_methods,
                         merging=merging,
                         is_active_merge=is_active_merging,

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -329,7 +329,6 @@ class EventInfoResponse:
     reviews: List[PRReview] = field(default_factory=list)
     status_contexts: List[StatusContext] = field(default_factory=list)
     check_runs: List[CheckRun] = field(default_factory=list)
-    valid_signature: bool = False
     valid_merge_methods: List[MergeMethod] = field(default_factory=list)
     commits: List[Commit] = field(default_factory=list)
 
@@ -635,13 +634,6 @@ def get_check_runs(*, pr: Dict[str, Any]) -> List[CheckRun]:
         except ValueError:
             logger.warning("Could not parse CheckRun", exc_info=True)
     return check_runs
-
-
-def get_valid_signature(*, pr: Dict[str, Any]) -> bool:
-    try:
-        return bool(pr["commits"]["nodes"][0]["commit"]["signature"]["isValid"])
-    except (IndexError, KeyError, TypeError):
-        return False
 
 
 def get_head_exists(*, pr: Dict[str, Any]) -> bool:
@@ -984,7 +976,6 @@ class Client:
             commits=get_commits(pr=pull_request),
             check_runs=get_check_runs(pr=pull_request),
             head_exists=get_head_exists(pr=pull_request),
-            valid_signature=get_valid_signature(pr=pull_request),
             valid_merge_methods=get_valid_merge_methods(repo=repository),
         )
 

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -352,7 +352,6 @@ class MergeableType(Protocol):
         contexts: List[StatusContext] = ...,
         check_runs: List[CheckRun] = ...,
         commits: List[Commit] = ...,
-        valid_signature: bool = ...,
         valid_merge_methods: List[MergeMethod] = ...,
         merging: bool = ...,
         is_active_merge: bool = ...,
@@ -380,7 +379,6 @@ def create_mergeable() -> MergeableType:
         contexts: List[StatusContext] = [create_context()],
         check_runs: List[CheckRun] = [create_check_run()],
         commits: List[Commit] = [],
-        valid_signature: bool = False,
         valid_merge_methods: List[MergeMethod] = [
             MergeMethod.merge,
             MergeMethod.squash,
@@ -411,7 +409,6 @@ def create_mergeable() -> MergeableType:
             contexts=contexts,
             check_runs=check_runs,
             commits=commits,
-            valid_signature=valid_signature,
             valid_merge_methods=valid_merge_methods,
             repository=repository,
             merging=merging,

--- a/bot/kodiak/test_pull_request.py
+++ b/bot/kodiak/test_pull_request.py
@@ -83,7 +83,6 @@ method = "squash"
         reviews=[],
         status_contexts=[],
         check_runs=[],
-        valid_signature=True,
         valid_merge_methods=[MergeMethod.squash],
         subscription=None,
     )

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -254,7 +254,6 @@ method = "squash"
         check_runs=[
             CheckRun(name="WIP (beta)", conclusion=CheckConclusionState.SUCCESS)
         ],
-        valid_signature=True,
         valid_merge_methods=[MergeMethod.squash],
     )
 


### PR DESCRIPTION
This param is passed down into the evaluation logic, but isn't used.

We validate webhook signatures before putting them on the queue.

`git log -S` points to this param never being used.