### PR TITLE
fix(bot): priority merge being lost on PR requeue

### DIFF
--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -15,7 +15,7 @@ from kodiak.errors import (
     PollForever,
     RetryForSkippableChecks,
 )
-from kodiak.evaluation import mergeable, is_priority_merge
+from kodiak.evaluation import is_priority_merge, mergeable
 from kodiak.queries import Client, EventInfoResponse
 
 logger = structlog.get_logger()

--- a/bot/kodiak/queue.py
+++ b/bot/kodiak/queue.py
@@ -314,10 +314,9 @@ async def process_webhook_event(
         )
 
     async def requeue(*, priority_merge: bool) -> None:
-        queue_position = 0 if priority_merge else time.time()
         await connection.zadd(
             webhook_event.get_webhook_queue_name(),
-            {webhook_event.json(): queue_position},
+            {webhook_event.json(): time.time()},
             only_if_not_exists=True,
         )
 
@@ -395,7 +394,7 @@ async def process_repo_queue(
     async def requeue(*, priority_merge: bool) -> None:
         queue_position = 0 if priority_merge else time.time()
         await connection.zadd(
-            webhook_event.get_webhook_queue_name(),
+            webhook_event.get_merge_queue_name(),
             {webhook_event.json(): queue_position},
             only_if_not_exists=True,
         )

--- a/bot/kodiak/queue.py
+++ b/bot/kodiak/queue.py
@@ -313,10 +313,11 @@ async def process_webhook_event(
             webhook_event.get_merge_queue_name(), [webhook_event.json()]
         )
 
-    async def requeue() -> None:
+    async def requeue(*, priority_merge: bool) -> None:
+        queue_position = 0 if priority_merge else time.time()
         await connection.zadd(
             webhook_event.get_webhook_queue_name(),
-            {webhook_event.json(): time.time()},
+            {webhook_event.json(): queue_position},
             only_if_not_exists=True,
         )
 
@@ -391,10 +392,11 @@ async def process_repo_queue(
             webhook_event.get_merge_queue_name(), [webhook_event.json()]
         )
 
-    async def requeue() -> None:
+    async def requeue(*, priority_merge: bool) -> None:
+        queue_position = 0 if priority_merge else time.time()
         await connection.zadd(
             webhook_event.get_webhook_queue_name(),
-            {webhook_event.json(): time.time()},
+            {webhook_event.json(): queue_position},
             only_if_not_exists=True,
         )
 

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -171,8 +171,8 @@ class MockApprovePullRequest(BaseMockFunc):
 
 
 class MockRequeue(BaseMockFunc):
-    async def __call__(self) -> None:
-        self.log_call(dict())
+    async def __call__(self, *, priority_merge: bool) -> None:
+        self.log_call(dict(priority_merge=priority_merge))
 
 
 class MockPrApi:

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -1525,6 +1525,7 @@ async def test_mergeable_pull_request_need_test_commit() -> None:
     assert api.dequeue.call_count == 0
     assert api.trigger_test_commit.call_count == 1
     assert api.requeue.call_count == 1
+    assert api.requeue.calls[0]["priority_merge"] is False
 
     # verify we haven't tried to update/merge the PR
     assert api.update_branch.called is False

--- a/bot/kodiak/test_pull_request.py
+++ b/bot/kodiak/test_pull_request.py
@@ -9,7 +9,12 @@ from typing_extensions import Protocol
 
 from kodiak.config import V1, Merge, MergeMethod
 from kodiak.errors import ApiCallException
-from kodiak.pull_request import PRV2, EventInfoResponse, QueueForMergeCallback
+from kodiak.pull_request import (
+    PRV2,
+    EventInfoResponse,
+    QueueForMergeCallback,
+    RequeueCallback,
+)
 from kodiak.queries import (
     BranchProtectionRule,
     Client,
@@ -221,7 +226,7 @@ def create_prv2(
     number: int = 8634,
     dequeue_callback: Callable[[], Awaitable[None]] = noop,
     queue_for_merge_callback: QueueForMergeCallback = noop,
-    requeue_callback: Callable[[], Awaitable[None]] = noop,
+    requeue_callback: RequeueCallback = noop,
     client: Optional[Type[FakeClientProtocol]] = None,
 ) -> PRV2:
     return PRV2(


### PR DESCRIPTION
When a PR is marked as "priority merge", we place it at the front of the merge queue by setting it's score to `0`. This works. However, we weren't supporting this feature when re-queuing the PR.

This change adds support for priority merge when re-queueing PRs.

related #670