### PR TITLE
fix(bot): remove http client timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.42.1 - 2021-06-23
+
+### Fixed
+- fixed short HTTP timeouts for GitHub API requests negatively impacting Kodiak's reliability. (#678)
+
 ## 0.42.0 - 2021-06-20
 
 ### Added

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -728,7 +728,11 @@ class Client:
         self.installation_id = installation_id
         # NOTE: We must call `await session.close()` when we are finished with our session.
         # We implement an async context manager this handle this.
-        self.session = http.AsyncClient()
+        self.session = http.AsyncClient(
+            # infinite timeout to match behavior of old, requests_async http
+            # client. As a backup we have an asyncio timeout of 30 seconds.
+            timeout=None
+        )
         self.session.headers[
             "Accept"
         ] = "application/vnd.github.antiope-preview+json,application/vnd.github.merge-info-preview+json"


### PR DESCRIPTION
We recently (ae99de3ddaef1aca839c74c04c2fdb0fa8362858) replaced our old HTTP client, `requests_async`, with `httpx`. This gave us better testing support and allows us to specify an HTTP proxy for outgoing requests. One problem is `httpx` sets default timeouts that are different from `requests_async`.

`requests_async` has no default timeouts, which works for us because we set a [30 second](https://github.com/chdsbd/kodiak/blob/2111f3b07123ddd47c4157adf2d394984c259ae9/bot/kodiak/pull_request.py#L90) [timeout](https://github.com/chdsbd/kodiak/blob/2111f3b07123ddd47c4157adf2d394984c259ae9/bot/kodiak/pull_request.py#L119) for all PR evaluations by default. `httpx` uses a 5 second timeout for connect and read. We've been encountering frequent read timeouts since deploying ae99de3ddaef1aca839c74c04c2fdb0fa8362858. By removing the default HTTP timeouts and depending on the 30 second timeout, we should hopefully improve the reliability of Kodiak.