### PR TITLE
fix(bot): invalid event schema

### DIFF
--- a/bot/kodiak/events/status.py
+++ b/bot/kodiak/events/status.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import pydantic
 
@@ -6,7 +6,7 @@ from kodiak.events.base import GithubEvent
 
 
 class Commit(pydantic.BaseModel):
-    sha: str
+    sha: Optional[str]
 
 
 class Branch(pydantic.BaseModel):

--- a/bot/kodiak/test/fixtures/events/status/status_event.json
+++ b/bot/kodiak/test/fixtures/events/status/status_event.json
@@ -101,6 +101,14 @@
                 "sha": "fd353d4ae7c19d2268397459524f849c129944a7",
                 "url": "https://api.github.com/repos/Codertocat/Hello-World/commits/fd353d4ae7c19d2268397459524f849c129944a7"
             }
+        },
+        {
+            "name":"chdsbd-patch-20",
+            "commit": {
+                "sha": null,
+                "url": null
+            },
+            "protected": false
         }
     ],
     "created_at": "2018-05-30T20:18:46+00:00",


### PR DESCRIPTION
Apparently the sha of a commit can be nullable.