### PR TITLE
tool(bot): tag sentry events with installation id

### DIFF
--- a/bot/kodiak/test_queue.py
+++ b/bot/kodiak/test_queue.py
@@ -1,0 +1,22 @@
+import pytest
+
+from kodiak.queue import installation_id_from_queue
+
+
+@pytest.mark.parametrize(
+    "queue_name, expected_installation_id",
+    (
+        ("merge_queue:11256551.sbdchd/squawk/main.test.foo", "11256551"),
+        ("merge_queue:11256551.sbdchd/squawk", "11256551"),
+        ("merge_queue:11256551.sbdchd/squawk:repo/main:test.branch", "11256551"),
+        ("webhook:11256551", "11256551"),
+        ("", ""),
+    ),
+)
+def test_installation_id_from_queue(
+    queue_name: str, expected_installation_id: str
+) -> None:
+    """
+    We should gracefully parse an installation id from the queue name
+    """
+    assert installation_id_from_queue(queue_name) == expected_installation_id


### PR DESCRIPTION
Using queue names isn't a great way to match events to installation ids. By adding a new tag just for installation we can more easily lookup Sentry events by installation.