### PR TITLE
update(bot): use warnings for normal errors

### DIFF
--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -143,11 +143,11 @@ async def evaluate_pr(
                     api_call_retries_remaining -= 1
                     log.info("problem contacting remote api. retrying")
                     continue
-                log.exception("api_call_retries_remaining")
+                log.warning("api_call_retries_remaining", exc_info=True)
             return
         except asyncio.TimeoutError:
             # On timeout we add the PR to the back of the queue to try again.
-            log.exception("mergeable_timeout")
+            log.warning("mergeable_timeout", exc_info=True)
             await requeue_callback()
 
 
@@ -218,7 +218,7 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.exception("failed to create notification", res=res)
+                self.log.warning("failed to create notification", res=res, exc_info=True)
 
     async def pull_requests_for_ref(self, ref: str) -> Optional[int]:
         log = self.log.bind(ref=ref)
@@ -245,7 +245,7 @@ class PRV2:
                 if e.response is not None and e.response.status_code == 422:
                     self.log.info("branch already deleted, nothing to do", res=res)
                 else:
-                    self.log.exception("failed to delete branch", res=res)
+                    self.log.warning("failed to delete branch", res=res, exc_info=True)
 
     async def update_branch(self) -> None:
         self.log.info("update_branch")
@@ -256,7 +256,7 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.exception("failed to update branch", res=res)
+                self.log.warning("failed to update branch", res=res, exc_info=True)
                 # we raise an exception to retry this request.
                 raise ApiCallException(
                     method="pull_request/update_branch",
@@ -273,7 +273,7 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.exception("failed to approve pull request", res=res)
+                self.log.warning("failed to approve pull request", res=res, exc_info=True)
 
     async def trigger_test_commit(self) -> None:
         self.log.info("trigger_test_commit")
@@ -284,7 +284,7 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.exception(
+                self.log.warning(
                     "failed to get pull request for test commit trigger", res=res
                 )
 
@@ -312,7 +312,7 @@ class PRV2:
                         "branch is not mergeable. PR likely already merged.", res=res
                     )
                 else:
-                    self.log.exception("failed to merge pull request", res=res)
+                    self.log.warning("failed to merge pull request", res=res, exc_info=True)
                 if e.response is not None and e.response.status_code == 500:
                     raise GitHubApiInternalServerError
                 # we raise an exception to retry this request.
@@ -334,7 +334,7 @@ class PRV2:
                 if e.response is not None and e.response.status_code == 422:
                     self.log.info("fast forward update not possible.", res=res)
                 else:
-                    self.log.exception("failed to update ref", res=res)
+                    self.log.warning("failed to update ref", res=res, exc_info=True)
                 # we raise an exception to retry this request.
                 raise ApiCallException(
                     method="pull_request/update_ref",
@@ -358,7 +358,7 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.exception("failed to add label", label=label, res=res)
+                self.log.warning("failed to add label", label=label, res=res, exc_info=True)
                 raise ApiCallException(
                     method="pull_request/add_label",
                     http_status_code=res.status_code,
@@ -377,7 +377,7 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.exception("failed to delete label", label=label, res=res)
+                self.log.warning("failed to delete label", label=label, res=res, exc_info=True)
                 # we raise an exception to retry this request.
                 raise ApiCallException(
                     method="pull_request/delete_label",
@@ -397,4 +397,4 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.exception("failed to create comment", res=res)
+                self.log.warning("failed to create comment", res=res, exc_info=True)

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -218,7 +218,9 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.warning("failed to create notification", res=res, exc_info=True)
+                self.log.warning(
+                    "failed to create notification", res=res, exc_info=True
+                )
 
     async def pull_requests_for_ref(self, ref: str) -> Optional[int]:
         log = self.log.bind(ref=ref)
@@ -273,7 +275,9 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.warning("failed to approve pull request", res=res, exc_info=True)
+                self.log.warning(
+                    "failed to approve pull request", res=res, exc_info=True
+                )
 
     async def trigger_test_commit(self) -> None:
         self.log.info("trigger_test_commit")
@@ -312,7 +316,9 @@ class PRV2:
                         "branch is not mergeable. PR likely already merged.", res=res
                     )
                 else:
-                    self.log.warning("failed to merge pull request", res=res, exc_info=True)
+                    self.log.warning(
+                        "failed to merge pull request", res=res, exc_info=True
+                    )
                 if e.response is not None and e.response.status_code == 500:
                     raise GitHubApiInternalServerError
                 # we raise an exception to retry this request.
@@ -358,7 +364,9 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.warning("failed to add label", label=label, res=res, exc_info=True)
+                self.log.warning(
+                    "failed to add label", label=label, res=res, exc_info=True
+                )
                 raise ApiCallException(
                     method="pull_request/add_label",
                     http_status_code=res.status_code,
@@ -377,7 +385,9 @@ class PRV2:
             try:
                 res.raise_for_status()
             except HTTPError:
-                self.log.warning("failed to delete label", label=label, res=res, exc_info=True)
+                self.log.warning(
+                    "failed to delete label", label=label, res=res, exc_info=True
+                )
                 # we raise an exception to retry this request.
                 raise ApiCallException(
                     method="pull_request/delete_label",

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -289,7 +289,9 @@ class PRV2:
                 res.raise_for_status()
             except HTTPError:
                 self.log.warning(
-                    "failed to get pull request for test commit trigger", res=res
+                    "failed to get pull request for test commit trigger",
+                    res=res,
+                    exc_info=True,
                 )
 
     async def merge(

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -794,7 +794,7 @@ class Client:
                 ),
                 headers=headers,
             )
-        log = log.bind(res=res, username=username)
+        log = self.log.bind(res=res, username=username)
         try:
             res.raise_for_status()
         except http.HTTPError:

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -778,7 +778,7 @@ class Client:
         log = log.bind(rate_limit=rate_limit)
         try:
             res.raise_for_status()
-        except HTTPError:
+        except http.HTTPError:
             log.warning("github api request error", res=res, exc_info=True)
             return None
         return cast(GraphQLResponse, res.json())

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -1210,7 +1210,7 @@ class Client:
                     real_response.get(b"data")  # type: ignore
                 )
             except pydantic.ValidationError:
-                logger.warning("failed to parse seats_exceeded data", exc_info=True)
+                logger.exception("failed to parse seats_exceeded data", exc_info=True)
                 subscription_blocker = SeatsExceeded(allowed_user_ids=[])
         if subscription_blocker_kind == "trial_expired":
             subscription_blocker = TrialExpired()

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -784,7 +784,6 @@ class Client:
         return cast(GraphQLResponse, res.json())
 
     async def get_permissions_for_username(self, username: str) -> Permission:
-        log = self.log.bind(username=username)
         headers = await get_headers(
             session=self.session, installation_id=self.installation_id
         )
@@ -795,7 +794,7 @@ class Client:
                 ),
                 headers=headers,
             )
-        log = log.bind(res=res)
+        log = log.bind(res=res, username=username)
         try:
             res.raise_for_status()
         except http.HTTPError:

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -14,7 +14,6 @@ import structlog
 import toml
 from mypy_extensions import TypedDict
 from pydantic import BaseModel
-from starlette import status
 from typing_extensions import Literal, Protocol
 
 import kodiak.app_config as conf

--- a/bot/kodiak/queries/commits.py
+++ b/bot/kodiak/queries/commits.py
@@ -50,7 +50,7 @@ def get_commits(*, pr: Dict[str, Any]) -> List[Commit]:
     try:
         pull_request = PullRequest.parse_obj(pr)
     except pydantic.ValidationError:
-        logger.warning("problem parsing commit authors", exc_info=True)
+        logger.exception("problem parsing commit authors")
         return []
     nodes = pull_request.commitHistory.nodes
     if not nodes:


### PR DESCRIPTION
We should only log errors or exceptions for behavior that requires developer intervention