### PR TITLE
fix(web_api): billing payment method updates

### DIFF
--- a/web_api/web_api/models.py
+++ b/web_api/web_api/models.py
@@ -1041,9 +1041,7 @@ class StripeCustomerInformation(models.Model):
     def update_from_stripe(self) -> None:
         customer = stripe.Customer.retrieve(self.customer_id)
         subscription = stripe.Subscription.retrieve(customer.subscriptions.data[0].id)
-        payment_methods = stripe.PaymentMethod.list(
-            customer=customer.id, type="card",
-        )
+        payment_methods = stripe.PaymentMethod.list(customer=customer.id, type="card")
 
         payment_method = stripe.PaymentMethod.retrieve(payment_methods.data[0].id)
 

--- a/web_api/web_api/models.py
+++ b/web_api/web_api/models.py
@@ -1041,9 +1041,11 @@ class StripeCustomerInformation(models.Model):
     def update_from_stripe(self) -> None:
         customer = stripe.Customer.retrieve(self.customer_id)
         subscription = stripe.Subscription.retrieve(customer.subscriptions.data[0].id)
-        payment_method = stripe.PaymentMethod.retrieve(
-            subscription.default_payment_method
+        payment_methods = stripe.PaymentMethod.list(
+            customer=customer.id, type="card",
         )
+
+        payment_method = stripe.PaymentMethod.retrieve(payment_methods.data[0].id)
 
         self.customer_email = customer.email
         self.customer_balance = customer.balance

--- a/web_api/web_api/test_views.py
+++ b/web_api/web_api/test_views.py
@@ -627,6 +627,7 @@ def test_update_subscription(
     )
     assert stripe_subscription_retrieve.call_count == 0
     assert stripe_subscription_modify.call_count == 0
+    assert stripe_payment_method_list.call_count == 0
     assert update_bot.call_count == 0
     res = authed_client.post(
         f"/v1/t/{account.id}/update_subscription",
@@ -636,6 +637,7 @@ def test_update_subscription(
     assert stripe_subscription_retrieve.call_count == 1
     assert update_bot.call_count == 1
     assert stripe_subscription_modify.call_count == 1
+    assert stripe_payment_method_list.call_count == 1
     _args, kwargs = stripe_subscription_modify.call_args
     assert kwargs["items"][0]["plan"] == settings.STRIPE_PLAN_ID
     assert stripe_invoice_create.call_count == 1
@@ -1774,6 +1776,7 @@ def test_stripe_webhook_handler_checkout_session_complete_setup(mocker: Any) -> 
     assert customer_retrieve.call_count == 1
     assert subscription_retrieve.call_count == 1
     assert payment_method_retrieve.call_count == 1
+    assert stripe_payment_method_list.call_count == 1
     assert StripeCustomerInformation.objects.count() == 1
 
     assert update_bot.call_count == 1
@@ -1957,6 +1960,7 @@ def test_stripe_webhook_handler_checkout_session_complete_subscription(
     assert customer_retrieve.call_count == 1
     assert subscription_retrieve.call_count == 1
     assert payment_method_retrieve.call_count == 1
+    assert stripe_payment_method_list.call_count == 1
     assert StripeCustomerInformation.objects.count() == 2
 
     # verify `other_subscription` hasn't been modified
@@ -2050,6 +2054,7 @@ def test_stripe_webhook_handler_invoice_payment_succeeded(mocker: Any) -> None:
     assert retrieve_subscription.call_count == 0
     assert retrieve_customer.call_count == 0
     assert retrieve_payment_method.call_count == 0
+    assert stripe_payment_method_list.call_count == 0
     res = post_webhook(
         """
 {
@@ -2195,6 +2200,7 @@ def test_stripe_webhook_handler_invoice_payment_succeeded(mocker: Any) -> None:
     assert retrieve_subscription.call_count == 1
     assert retrieve_customer.call_count == 1
     assert retrieve_payment_method.call_count == 1
+    assert stripe_payment_method_list.call_count == 1
     assert StripeCustomerInformation.objects.count() == 1
     updated_stripe_customer_info = StripeCustomerInformation.objects.get()
     assert (
@@ -2316,6 +2322,7 @@ def test_stripe_webhook_handler_customer_updated(mocker: Any) -> None:
     assert patched_retrieve_customer.call_count == 0
     assert patched_retrieve_subscription.call_count == 0
     assert patched_retrieve_payment_method.call_count == 0
+    assert stripe_payment_method_list.call_count == 0
     res = post_webhook(make_customer_updated_event(account.stripe_customer_id))
 
     assert res.status_code == 200
@@ -2323,6 +2330,7 @@ def test_stripe_webhook_handler_customer_updated(mocker: Any) -> None:
     assert patched_retrieve_customer.call_count == 1
     assert patched_retrieve_subscription.call_count == 1
     assert patched_retrieve_payment_method.call_count == 1
+    assert stripe_payment_method_list.call_count == 1
     assert StripeCustomerInformation.objects.count() == 1
     updated_stripe_customer_info = StripeCustomerInformation.objects.get()
     assert updated_stripe_customer_info.customer_email == fake_customer.email
@@ -2377,6 +2385,7 @@ def test_stripe_webhook_handler_customer_updated_with_address(mocker: Any) -> No
     assert patched_retrieve_customer.call_count == 0
     assert patched_retrieve_subscription.call_count == 0
     assert patched_retrieve_payment_method.call_count == 0
+    assert stripe_payment_method_list.call_count == 0
     res = post_webhook(make_customer_updated_event(account.stripe_customer_id))
 
     assert res.status_code == 200
@@ -2384,6 +2393,7 @@ def test_stripe_webhook_handler_customer_updated_with_address(mocker: Any) -> No
     assert patched_retrieve_customer.call_count == 1
     assert patched_retrieve_subscription.call_count == 1
     assert patched_retrieve_payment_method.call_count == 1
+    assert stripe_payment_method_list.call_count == 1
     assert StripeCustomerInformation.objects.count() == 1
     updated_stripe_customer_info = StripeCustomerInformation.objects.get()
     assert updated_stripe_customer_info.customer_email == fake_customer.email

--- a/web_api/web_api/test_views.py
+++ b/web_api/web_api/test_views.py
@@ -2452,27 +2452,6 @@ def test_stripe_webhook_handler_customer_updated_no_matching_customer(
 
 
 @pytest.mark.django_db
-def test_stripe_webhook_handler_payment_method_attached(mocker: Any,) -> None:
-    """
-    
-    """
-    account = create_account()
-
-    patched_update_from_stripe = mocker.patch(
-        "web_api.models.StripeCustomerInformation.update_from_stripe",
-        spec=StripeCustomerInformation.update_from_stripe,
-    )
-    mocker.patch("web_api.models.Account.update_bot", spec=Account.update_bot)
-    assert StripeCustomerInformation.objects.count() == 0
-    assert patched_update_from_stripe.call_count == 0
-    res = post_webhook(make_customer_updated_event(account.stripe_customer_id))
-
-    assert res.status_code == 400
-    assert StripeCustomerInformation.objects.count() == 0
-    assert patched_update_from_stripe.call_count == 0
-
-
-@pytest.mark.django_db
 def test_logout(client: Client, user: User) -> None:
     """
     Ensure we delete the cookie on logout.

--- a/web_api/web_api/views.py
+++ b/web_api/web_api/views.py
@@ -645,6 +645,9 @@ def stripe_webhook_handler(request: HttpRequest) -> HttpResponse:
             new_payment_method.customer,
             invoice_settings=dict(default_payment_method=new_payment_method.id),
         )
+        stripe_customer_info = StripeCustomerInformation.objects.filter(
+            customer_id=new_payment_method.customer
+        ).first()
         if stripe_customer_info is None:
             logger.warning(
                 "payment_method.attached event for unknown customer %s", event

--- a/web_api/web_api/views.py
+++ b/web_api/web_api/views.py
@@ -645,6 +645,11 @@ def stripe_webhook_handler(request: HttpRequest) -> HttpResponse:
             new_payment_method.customer,
             invoice_settings=dict(default_payment_method=new_payment_method.id),
         )
+        if stripe_customer_info is None:
+            logger.warning(
+                "payment_method.attached event for unknown customer %s", event
+            )
+            raise BadRequest
         stripe_customer_info.update_from_stripe()
 
     else:

--- a/web_api/web_api/views.py
+++ b/web_api/web_api/views.py
@@ -279,8 +279,14 @@ def update_subscription(request: AuthedHttpRequest, team_id: str) -> HttpRespons
         )
         # we must specify the payment method because our Stripe customers don't have
         # a default payment method, so the default invoicing will fail.
+        payment_methods = stripe.PaymentMethod.list(
+            customer=subscription.customer, type="card",
+        )
+
+        payment_method = payment_methods.data[0].id
+
         stripe.Invoice.pay(
-            invoice.id, payment_method=subscription.default_payment_method
+            invoice.id, payment_method=payment_method
         )
     stripe_customer_info.plan_amount = updated_subscription.plan.amount
     stripe_customer_info.plan_interval = updated_subscription.plan.interval
@@ -623,8 +629,25 @@ def stripe_webhook_handler(request: HttpRequest) -> HttpResponse:
             raise BadRequest
         stripe_customer_info.update_from_stripe()
 
+    elif event.type == "payment_method.attached":
+        # a customer should only have one payment method.
+        #
+        # When a customer attaches a new payment method, remove the old ones to
+        # ensure subscriptions use the newly added method.
+        new_payment_method = event.data.object
+
+        payment_methods = stripe.PaymentMethod.list(
+            customer=new_payment_method.customer, type="card",
+        )
+        for payment_method in payment_methods.data:
+            if payment_method.id != new_payment_method.id:
+                stripe.PaymentMethod.detach(payment_method.id)
+
+        stripe.Customer.modify(new_payment_method.customer,invoice_settings=dict(default_payment_method=new_payment_method.id))
+        stripe_customer_info.update_from_stripe()
+
     else:
-        # Unexpected event type
+        logger.warning('unexpected event type %s', event.type)
         raise BadRequest
 
     return HttpResponse(status=200)

--- a/web_api/web_api/views.py
+++ b/web_api/web_api/views.py
@@ -285,9 +285,7 @@ def update_subscription(request: AuthedHttpRequest, team_id: str) -> HttpRespons
 
         payment_method = payment_methods.data[0].id
 
-        stripe.Invoice.pay(
-            invoice.id, payment_method=payment_method
-        )
+        stripe.Invoice.pay(invoice.id, payment_method=payment_method)
     stripe_customer_info.plan_amount = updated_subscription.plan.amount
     stripe_customer_info.plan_interval = updated_subscription.plan.interval
 
@@ -643,11 +641,14 @@ def stripe_webhook_handler(request: HttpRequest) -> HttpResponse:
             if payment_method.id != new_payment_method.id:
                 stripe.PaymentMethod.detach(payment_method.id)
 
-        stripe.Customer.modify(new_payment_method.customer,invoice_settings=dict(default_payment_method=new_payment_method.id))
+        stripe.Customer.modify(
+            new_payment_method.customer,
+            invoice_settings=dict(default_payment_method=new_payment_method.id),
+        )
         stripe_customer_info.update_from_stripe()
 
     else:
-        logger.warning('unexpected event type %s', event.type)
+        logger.warning("unexpected event type %s", event.type)
         raise BadRequest
 
     return HttpResponse(status=200)


### PR DESCRIPTION
Previously if a user updated their payment method, their old payment method would still be attached to the subscription. This basically caused renewals to error until there was manual intervention.

Now, when a new payment method is attached, we remove the old ones so there is only ever one payment method attached to a customer.

We also use the first payment method available on an account for sending invoices when a user adds seats. Previously we would use the payment method attached to a subscription, but when we delete a user's initial payment method, that subscription.default_payment_method becomes null.