### PR TITLE
feat(doc): mention renovate support

### DIFF
--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -68,10 +68,10 @@ See ["Configuring automerge by upgrade type"](recipes.md##configuring-automerge-
 # only auto merge "minor" and "patch" version upgrades.
 # do not automerge "major" version upgrades.
 versions = ["minor", "patch"]
-usernames = ["dependabot"]
+usernames = ["dependabot", "renovate"]
 ```
 
-Dependency upgrade types are parsed from the pull request title. The following table shows version upgrade examples:
+Dependency upgrade types are parsed from the pull request title and body. The following table shows version upgrade examples for Dependabot pull request titles:
 
 | title                           | upgrade |
 | ------------------------------- | ------- |
@@ -96,8 +96,8 @@ See ["Configuring automerge by upgrade type"](recipes.md##configuring-automerge-
 # .kodiak.toml
 [merge.automerge_dependencies]
 versions = ["minor", "patch"]
-# only automerge by upgrade version for pull requests authored by dependabot.
-usernames = ["dependabot"]
+# automerge by upgrade version for pull requests authored by dependabot or renovate.
+usernames = ["dependabot", "renovate"]
 ```
 
 <span id="mergeblacklist_title_regex"/> <!-- handle old links -->

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -17,7 +17,9 @@ always = true # default: false
 require_automerge_label = false # default: true
 ```
 
-## Automated dependency updates with Dependabot
+## Automated dependency updates with Dependabot (or Renovate)
+
+> **NOTE:** Kodiak supports Dependabot and Renovate for dependency updates. Any mention of Dependabot can be substituted with Renovate.
 
 Kodiak can automerge all Dependabot PRs if you configure Dependabot to open pull requests with our [`merge.automerge_label`](/docs/config-reference#mergeautomerge_label) label.
 
@@ -28,7 +30,7 @@ If you want to only merge specific upgrade types, like "major", "minor", "patch"
 1. Install Kodiak following the [quick start guide](/docs/quickstart).
 2. Add `"dependabot"` and your automerge upgrade types to the `.kodiak.toml`
 
-> **NOTE:** Remove the `[bot]` suffix from GitHub Bot usernames. Instead of `"dependabot[bot]"` use `"dependabot"`.
+> **NOTE:** Remove the `[bot]` suffix from GitHub Bot usernames. Instead of `"dependabot[bot]"` use `"dependabot"`. Instead of `"renovate[bot]"` use `"renovate"`.
 
 ```toml
 # .kodiak.toml
@@ -76,7 +78,7 @@ When "Required approving reviews" is configured via GitHub Branch Protection, ev
 
 Kodiak can add an approval to pull requests via [`approve.auto_approve_usernames`](/docs/config-reference#approveauto_approve_usernames), enabling Dependabot PRs to be merged without human intervention.
 
-> **NOTE:** Remove the `[bot]` suffix from GitHub Bot usernames. Instead of `"dependabot[bot]"` use `"dependabot"`.
+> **NOTE:** Remove the `[bot]` suffix from GitHub Bot usernames. Instead of `"dependabot[bot]"` use `"dependabot"`. Instead of `"renovate[bot]"` use `"renovate"`.
 
 ```toml
 # .kodiak.toml


### PR DESCRIPTION
I didn't want to duplicate every reference for Dependabot, so I sprinkled around a few mentions of Renovate.