### PR TITLE
Only call `get_subscription` if required

### DIFF
--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -957,7 +957,9 @@ class Client:
             log.warning("could not find repository")
             return None
 
-        subscription = await self.get_subscription()
+        subscription = (
+            await self.get_subscription() if conf.SUBSCRIPTIONS_ENABLED else None
+        )
 
         pull_request = get_pull_request(repo=repository)
         if not pull_request:


### PR DESCRIPTION
This PR removes the call to `get_subscription` for self hosted instances. This was causing problems as the `get_subscription ` method instantiates a second Redis connection pool with a pool size defined by `USAGE_REPORTING_POOL_SIZE` (poor name choice given that it isn't only used when `USAGE_REPORTING is True`, but I suspect this is just a historical artefact). This second pool could quite easily push users over their hosted Redis connection limits, especially, as the undocumented `USAGE_REPORTING_POOL_SIZE` defaults to 50.

With this change the second pool is never instantiated if `USAGE_REPORTING is False && SUBSCRIPTIONS_ENABLED is False`. These are the default values for self hosted instances.

