### PR TITLE
less timedelta to prevent time drift

### DIFF
--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -1247,7 +1247,7 @@ def generate_jwt(*, private_key: str, app_identifier: str) -> str:
     This is different from authenticating as an installation
     """
     issued_at = int(datetime.now().timestamp())
-    expiration = int((datetime.now() + timedelta(minutes=10)).timestamp())
+    expiration = int((datetime.now() + timedelta(minutes=9, seconds=30)).timestamp())
     payload = dict(iat=issued_at, exp=expiration, iss=app_identifier)
     return jwt.encode(payload=payload, key=private_key, algorithm="RS256").decode()
 

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -1277,7 +1277,8 @@ async def get_token_for_install(
                 Authorization=f"Bearer {app_token}",
             ),
         )
-    assert res.status_code < 300
+    if res.status_code > 300:
+        raise Exception(f"Failed to get token, github response: {res.text}")
     token_response = TokenResponse(**res.json())
     installation_cache[installation_id] = token_response
     return token_response.token


### PR DESCRIPTION
fix #721 

after debugging, I found that it is because the time drifting make github server think this request is making a too ambitious exp value.

the response is 
```
Expiration time\' claim (\'exp\') is too far in the future
```