### PR TITLE
feat: prefix URLs with `PR-URL`

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -201,11 +201,6 @@ def get_merge_body(
         MergeBodyStyle.pull_request_body,
         MergeBodyStyle.empty,
     ):
-        if config.merge.message.include_pull_request_url:
-            if merge_body.commit_message is None:
-                merge_body.commit_message = pull_request.url
-            else:
-                merge_body.commit_message += "\n\n" + pull_request.url
 
         # we share coauthor logic between include_pull_request_author and
         # include_coauthors.
@@ -237,12 +232,20 @@ def get_merge_body(
             pull_request_author_id=pull_request.author.databaseId,
         )
 
+        trailer_block = ""
+        if config.merge.message.include_pull_request_url:
+            trailer_block += f"PR-URL: {pull_request.url}"
+
         if coauthor_trailers:
-            trailer_block = "\n".join(coauthor_trailers)
-            if merge_body.commit_message:
+            if trailer_block:
+                trailer_block += "\n"
+            trailer_block += "\n".join(coauthor_trailers)
+
+        if merge_body.commit_message:
+            if trailer_block:
                 merge_body.commit_message += "\n\n" + trailer_block
-            else:
-                merge_body.commit_message = trailer_block
+        else:
+            merge_body.commit_message = trailer_block
 
     return merge_body
 

--- a/bot/kodiak/tests/evaluation/test_merge_message_trailers.py
+++ b/bot/kodiak/tests/evaluation/test_merge_message_trailers.py
@@ -44,7 +44,7 @@ def test_get_merge_body_includes_pull_request_url() -> None:
         commit_message="""\
 # some description
 
-https://github.com/example_org/example_repo/pull/65""",
+PR-URL: https://github.com/example_org/example_repo/pull/65""",
     )
     assert actual == expected
 
@@ -96,8 +96,7 @@ def test_get_merge_body_includes_pull_request_url_with_coauthor() -> None:
         commit_message="""\
 # some description
 
-https://github.com/example_org/example_repo/pull/65
-
+PR-URL: https://github.com/example_org/example_repo/pull/65
 Co-authored-by: Barry Berkman <828352+barry@users.noreply.github.com>""",
     )
     assert actual == expected

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -382,7 +382,7 @@ March 6th, 2020, making this option no longer necessary.
 - **type:** `boolean`
 - **default:** `false`
 
-Append the pull request's URL to the commit message body.
+Append the pull request's URL to the commit message body, prefixed with `PR-URL:`.
 
 This can make accessing the relevant PR for a given commit easier.
 


### PR DESCRIPTION
When enabling `include_pull_request_url` (defaults to false), prefix the URL added to the commit body with `PR-URL`. This follows other trailer syntax such as `Co-Authored-By:` as well as the general recommendations by [conventional commits][1] footer best practices.

Not sure how to handle with the fact that this could be seen as SEMVER breaking; changing expectations of commit body and all..

References: https://github.com/chdsbd/kodiak/issues/671#issuecomment-858240918

[1]: https://www.conventionalcommits.org/en/v1.0.0/