### PR TITLE
fix(bot): owner/.github repos being null

### DIFF
--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -53,8 +53,8 @@ query (
     $repo: String!,
     $rootConfigFileExpression: String!,
     $githubConfigFileExpression: String!,
-    $orgRootConfigFileExpression: String!,
-    $orgGithubConfigFileExpression: String!
+    $orgRootConfigFileExpression: String,
+    $orgGithubConfigFileExpression: String
   ) {
   repository(owner: $owner, name: $repo) {
     rootConfigFile: object(expression: $rootConfigFileExpression) {


### PR DESCRIPTION
Before this change, if an installation didn't have a .github repository, the GraphQL API request would error because we would provide a null value for the file expressions, when they're typed as non-null in the query.

Marking these arguments as nullable in the query resolves this issue.