### PR TITLE
feat(bot): support older GraphQL schemas

### DIFF
--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -53,8 +53,8 @@ query (
     $repo: String!,
     $rootConfigFileExpression: String!,
     $githubConfigFileExpression: String!,
-    $orgRootConfigFileExpression: String!,
-    $orgGithubConfigFileExpression: String!
+    $orgRootConfigFileExpression: String,
+    $orgGithubConfigFileExpression: String
   ) {
   repository(owner: $owner, name: $repo) {
     rootConfigFile: object(expression: $rootConfigFileExpression) {

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -891,7 +891,7 @@ class Client:
         first client to make an API request, we use their credentials to view
         schema metadata and cache the results.
         """
-        global _api_features_cache
+        global _api_features_cache  # pylint: disable=global-statement
         if _api_features_cache is not None:
             return _api_features_cache
         res = await self.send_query(


### PR DESCRIPTION
The `requiresConversationResolution` BranchProtectionRule isn't available until later GitHub Enterprise (GHE) versions, so we check the API before trying to use it.

I think in the future, if we use new fields we should update this logic to check for the field availability to ensure better GHE compatibility.

resolves #727
related #728