### PR TITLE
support Python 3.8 in tests

### DIFF
--- a/bot/kodiak/test_utils.py
+++ b/bot/kodiak/test_utils.py
@@ -1,10 +1,20 @@
 import asyncio
+import sys
 from typing import TypeVar
 
 T = TypeVar("T")
 
+# some change happened in Python 3.8 to eliminate the need for wrapping mock
+# results.
+if sys.version_info < (3, 8):
 
-def wrap_future(x: T) -> "asyncio.Future[T]":
-    fut: "asyncio.Future[T]" = asyncio.Future()
-    fut.set_result(x)
-    return fut
+    def wrap_future(x: T) -> "asyncio.Future[T]":
+        fut: "asyncio.Future[T]" = asyncio.Future()
+        fut.set_result(x)
+        return fut
+
+
+else:
+
+    def wrap_future(x: T) -> "T":
+        return x


### PR DESCRIPTION
I upgraded my local Python version to 3.8 and some of the tests were failing. Removing the future wrapping fixes the issue.