### PR TITLE
feat(bot): optionally strip the cut separator

### DIFF
--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -47,6 +47,7 @@ class MergeMessage(BaseModel):
     include_pull_request_url: bool = False
     cut_body_before: str = ""
     cut_body_after: str = ""
+    cut_body_and_text: bool = False
 
 
 # this pattern indicates that the user has the field unset.

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -74,6 +74,7 @@ def get_body_content(
     strip_html_comments: bool,
     cut_body_before: str,
     cut_body_after: str,
+    cut_body_and_text: bool,
     pull_request: PullRequest,
 ) -> str:
     if body_type is BodyText.markdown:
@@ -82,10 +83,14 @@ def get_body_content(
             start_index = body.find(cut_body_before)
             if start_index != -1:
                 body = body[start_index:]
+                if cut_body_and_text:
+                    body = body.replace(cut_body_before, "", 1)
         if cut_body_after != "":
             end_index = body.find(cut_body_after)
             if end_index != -1:
                 body = body[: end_index + len(cut_body_after)]
+                if cut_body_and_text:
+                    body = body.replace(cut_body_after, "", 1)
         if strip_html_comments:
             return strip_html_comments_from_markdown(body)
         return body
@@ -182,6 +187,7 @@ def get_merge_body(
         body = get_body_content(
             body_type=config.merge.message.body_type,
             strip_html_comments=config.merge.message.strip_html_comments,
+            cut_body_and_text=config.merge.message.cut_body_and_text,
             cut_body_before=config.merge.message.cut_body_before,
             cut_body_after=config.merge.message.cut_body_after,
             pull_request=pull_request,

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -39,7 +39,8 @@
           "include_coauthors": false,
           "include_pull_request_url": false,
           "cut_body_before": "",
-          "cut_body_after": ""
+          "cut_body_after": "",
+          "cut_body_and_text": false
         },
         "dont_wait_on_status_checks": [],
         "update_branch_immediately": false,
@@ -216,6 +217,11 @@
           "title": "Cut Body After",
           "default": "",
           "type": "string"
+        },
+        "cut_body_and_text": {
+          "title": "Cut Body And Text",
+          "default": false,
+          "type": "boolean"
         }
       }
     },
@@ -321,7 +327,8 @@
             "include_coauthors": false,
             "include_pull_request_url": false,
             "cut_body_before": "",
-            "cut_body_after": ""
+            "cut_body_after": "",
+            "cut_body_and_text": false
           },
           "allOf": [
             {

--- a/bot/kodiak/tests/evaluation/test_merge_message_cut_body.py
+++ b/bot/kodiak/tests/evaluation/test_merge_message_cut_body.py
@@ -31,6 +31,56 @@ def test_get_merge_body_cut_body_after() -> None:
     assert actual == expected
 
 
+def test_get_merge_body_cut_body_and_text_after() -> None:
+    """
+    Verify that the separator is also gone after removing content.
+    """
+    pull_request = create_pull_request()
+    pull_request.body = "hello <!-- testing -->world"
+    actual = get_merge_body(
+        config=V1(
+            version=1,
+            merge=Merge(
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body,
+                    cut_body_after="<!-- testing -->",
+                    cut_body_and_text=True
+                )
+            ),
+        ),
+        pull_request=pull_request,
+        merge_method=MergeMethod.squash,
+        commits=[],
+    )
+    expected = MergeBody(merge_method="squash", commit_message="hello ")
+    assert actual == expected
+
+
+def test_get_merge_body_cut_body_and_text_before() -> None:
+    """
+    Verify that the separator is also gone after removing content.
+    """
+    pull_request = create_pull_request()
+    pull_request.body = "hello <!-- testing -->world"
+    actual = get_merge_body(
+        config=V1(
+            version=1,
+            merge=Merge(
+                message=MergeMessage(
+                    body=MergeBodyStyle.pull_request_body,
+                    cut_body_before="<!-- testing -->",
+                    cut_body_and_text=True
+                )
+            ),
+        ),
+        pull_request=pull_request,
+        merge_method=MergeMethod.squash,
+        commits=[],
+    )
+    expected = MergeBody(merge_method="squash", commit_message="world")
+    assert actual == expected
+
+
 def test_get_merge_body_cut_body_after_strip_html() -> None:
     """
     We should be able to use strip_html_comments with cut_body_after.

--- a/bot/kodiak/tests/evaluation/test_merge_message_cut_body.py
+++ b/bot/kodiak/tests/evaluation/test_merge_message_cut_body.py
@@ -44,7 +44,7 @@ def test_get_merge_body_cut_body_and_text_after() -> None:
                 message=MergeMessage(
                     body=MergeBodyStyle.pull_request_body,
                     cut_body_after="<!-- testing -->",
-                    cut_body_and_text=True
+                    cut_body_and_text=True,
                 )
             ),
         ),
@@ -69,7 +69,7 @@ def test_get_merge_body_cut_body_and_text_before() -> None:
                 message=MergeMessage(
                     body=MergeBodyStyle.pull_request_body,
                     cut_body_before="<!-- testing -->",
-                    cut_body_and_text=True
+                    cut_body_and_text=True,
                 )
             ),
         ),

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -350,6 +350,17 @@ This setting is useful when we want to include only a part of the pull request d
 
 This option only applies when `merge.message.body_type = "markdown"`.
 
+### `merge.message.cut_body_and_text`
+
+- **type:** `boolean`
+- **default:** `False`
+
+Remove the string used to handle body in `cut_body_before` and `cut_body_after`.
+
+This setting is useful if you believe that the separator doesn't belong in the commit message.
+
+This option only applies if `cut_body_after` or `cut_body_before` is in use.
+
 ### `merge.message.include_coauthors`
 
 - **type:** `boolean`


### PR DESCRIPTION
If `cut_body_after` or `cut_body_before` is in use, setting this option to `True` also strips the separator itself.

~Note, this is a draft; awaiting the following input:~
1. [x] Is there a better name? (renamed to `cut_body_and_text`)
2. [x] Should we improve the way the body string is managed?
3. [x] json schema generation is [having issues](https://github.com/chdsbd/kodiak/issues/770#issuecomment-998293493) with `REDISCLOUD_URL` and `SECRET_KEY`

Fixes: https://github.com/chdsbd/kodiak/issues/770
