### PR TITLE
fix(docs): add height & width to image to avoid layout shift

### DIFF
--- a/docs/pages/en/index.js
+++ b/docs/pages/en/index.js
@@ -851,7 +851,11 @@ function HomeSplash(props) {
   return (
     <SplashContainer>
       <div className="projLogo">
-        <Logo img_src={`${baseUrl}img/kodiak-pr-flow.svg`} />
+        <Logo
+          img_src={`${baseUrl}img/kodiak-pr-flow.svg`}
+          height={349}
+          width={271}
+        />
       </div>
       <div className="inner">
         <ProjectTitle />


### PR DESCRIPTION
Noticed we were missing the height and width for the image, so we were
getting some shifting.

The dimensions are chosen from what was being rendered.