### PR TITLE
update algolia to support new indexing scheme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,5 +19,5 @@ yarn install
 s/dev
 s/typecheck --watch
 s/fmt
-AGOLIA_API_KEY= AGOLIA_INDEX_NAME= yarn build
+ALGOLIA_APP_ID= AGOLIA_API_KEY= AGOLIA_INDEX_NAME= yarn build
 ```

--- a/docs/siteConfig.js
+++ b/docs/siteConfig.js
@@ -32,6 +32,7 @@ const siteConfig = {
   //   organizationName: 'JoelMarcey'
 
   algolia: {
+    appId: process.env.ALGOLIA_APP_ID,
     apiKey: process.env.AGOLIA_API_KEY,
     indexName: process.env.AGOLIA_INDEX_NAME,
   },


### PR DESCRIPTION
Algolia's removing their old indexing setup in three months, so we need to update our credentials to continue supporting indexing.

https://docsearch.algolia.com/docs/migrating-from-legacy/