### PR TITLE
feat(bot): merge.block_on_neutral_required_check_runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.50.0 - 2022-02-03
+
+### Added
+- Added `merge.block_on_neutral_required_check_runs` option to stop Kodiak from merging a pull request if a require check run has a neutral conclusion. (#785)
+
 ## 0.49.0 - 2021-11-26
 
 ### Fixed

--- a/bot/kodiak/config.py
+++ b/bot/kodiak/config.py
@@ -88,6 +88,8 @@ class Merge(BaseModel):
     #
     # block merging if there are outstanding review requests
     block_on_reviews_requested: bool = False
+    # block merging if there are neutral required check runs.
+    block_on_neutral_required_check_runs: bool = False
     # comment on merge conflict and remove automerge label
     notify_on_conflict: bool = True
     # don't wait for status checks to run before updating branch

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -905,10 +905,7 @@ async def mergeable(
                     assert status_context.state == StatusState.SUCCESS
                     passing_contexts.append(status_context.context)
 
-            neutral_check_runs = set()
             for check_run in deduplicate_check_runs(check_runs):
-                if check_run.conclusion == CheckConclusionState.NEUTRAL:
-                    neutral_check_runs.add(check_run.name)
                 if (
                     check_run.name in config.merge.dont_wait_on_status_checks
                     and check_run.conclusion in (None, CheckConclusionState.NEUTRAL)

--- a/bot/kodiak/test/fixtures/config/config-schema.json
+++ b/bot/kodiak/test/fixtures/config/config-schema.json
@@ -27,6 +27,7 @@
         "method": null,
         "delete_branch_on_merge": false,
         "block_on_reviews_requested": false,
+        "block_on_neutral_required_check_runs": false,
         "notify_on_conflict": true,
         "optimistic_updates": true,
         "message": {
@@ -302,6 +303,11 @@
         },
         "block_on_reviews_requested": {
           "title": "Block On Reviews Requested",
+          "default": false,
+          "type": "boolean"
+        },
+        "block_on_neutral_required_check_runs": {
+          "title": "Block On Neutral Required Check Runs",
           "default": false,
           "type": "boolean"
         },

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -111,6 +111,15 @@ versions = ["minor", "patch"]
 usernames = ["dependabot", "renovate"]
 ```
 
+### `merge.block_on_neutral_required_check_runs`
+
+- **type:** `boolean`
+- **default:** `false`
+
+GitHub considers a "neutral" check run conclusion as passing GitHub branch protection requirements.
+
+When enabled, pull requests won't be merged if a required check run has a neutral conclusion.
+
 <span id="mergeblacklist_title_regex"/> <!-- handle old links -->
 
 ### `merge.blocking_title_regex`


### PR DESCRIPTION
When `merge.block_on_neutral_required_check_runs` is enabled, we won't merge the pull request if a required check run has a neutral conclusion.

related: #780