### PR TITLE
chore(bot): change Docker base image to python:3.7-slim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   bot_test:
     docker:
-      - image: python:3.7
+      - image: python:3.7-slim
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -12,6 +12,11 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
+      - run:
+          name: install git
+          command: |
+            apt update
+            apt install -y git
       - checkout
       - run:
           name: skip build if no changes
@@ -84,7 +89,7 @@ jobs:
   # https://circleci.com/docs/2.0/building-docker-images/
   bot_build_container:
     docker:
-      - image: docker:18.05.0-ce
+      - image: docker:20.10.23
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,32 +1,32 @@
-FROM python:3.7@sha256:6eaf19442c358afc24834a6b17a3728a45c129de7703d8583392a138ecbdb092
+FROM python:3.7-slim
 
-RUN set -ex && mkdir -p /var/app
-
-RUN apt-get update && apt-get install -y supervisor
-
-RUN mkdir -p /var/log/supervisor
-
-# use cryptography version for poetry that doesn't require Rust
-RUN python3 -m pip install cryptography===37.0.4
-RUN python3 -m pip install poetry===1.1.13
-
-RUN poetry config virtualenvs.in-project true
-
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+RUN apt update && \
+  apt-get install --no-install-recommends -y \
+    supervisor \
+    git && \
+  python -m pip install --upgrade pip && \
+  pip install \
+    --no-cache-dir \
+    --root-user-action=ignore \
+    cryptography===37.0.4 \
+    poetry===1.1.15 && \
+  poetry config virtualenvs.in-project true && \
+  groupadd kodiak && \
+  useradd --uid 1000 --gid kodiak kodiak && \
+  mkdir -p /var/app && \
+  chown -R kodiak:kodiak /var/app
 
 WORKDIR /var/app
 
-COPY pyproject.toml poetry.lock /var/app/
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+COPY --chown=kodiak pyproject.toml poetry.lock /var/app
 
 # install deps
 RUN poetry install
 
-COPY . /var/app
+COPY --chown=kodiak . /var/app
 
-# workaround for: https://github.com/sdispater/poetry/issues/1123
-RUN rm -rf /var/app/pip-wheel-metadata/
-
-# install cli
-RUN poetry install
+USER kodiak
 
 CMD ["/usr/bin/supervisord"]

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -20,12 +20,12 @@ WORKDIR /var/app
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-COPY --chown=kodiak pyproject.toml poetry.lock /var/app
+COPY --chown=kodiak pyproject.toml poetry.lock ./
 
 # install deps
 RUN poetry install
 
-COPY --chown=kodiak . /var/app
+COPY --chown=kodiak . ./
 
 USER kodiak
 

--- a/bot/supervisord.conf
+++ b/bot/supervisord.conf
@@ -1,12 +1,15 @@
 [supervisord]
 nodaemon=true
+user=kodiak
 
 [program:ingest]
 command=/var/app/.venv/bin/python -m kodiak.entrypoints.ingest
 stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:worker]
 command=/var/app/.venv/bin/python -m kodiak.entrypoints.worker
 stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
While scanning the Kodiak Docker image with [Grype](https://github.com/anchore/grype), we noticed a significant amount of vulnerabilities.

This PR upgrade the base image to the latest 3.7 image and use the slim version which come with a smaller size and reduce the attack surface. I also took the opportunity to use a non root user.

- previously: image size 1.31GB, 3694 vulnerabilities
- now: image size 607Mb, 87 vulnerabilities