### PR TITLE
Slight tweak to wording in "Automated dependency updates" recipe in docs

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -23,7 +23,7 @@ require_automerge_label = false # default: true
 
 Kodiak can automerge all Dependabot PRs if you configure Dependabot to open pull requests with our [`merge.automerge_label`](/docs/config-reference#mergeautomerge_label) label.
 
-If you want to only merge specific upgrade types, like "major", "minor", "patch", you can configure [`merge.automerge_dependencies`](#configuring-automerge-by-upgrade-type).
+If you want to only merge specific upgrade types, like "major", "minor", "patch", instead configure [`merge.automerge_dependencies`](#configuring-automerge-by-upgrade-type).
 
 ### Configuring automerge by upgrade type
 


### PR DESCRIPTION
I ran into a similar issue as #795 and added a slight tweak to the documentation that I think will clear the confusion for future readers.