### PR TITLE
fix stripping html to correctly handle byte offsets

### DIFF
--- a/bot/kodiak/test_text.py
+++ b/bot/kodiak/test_text.py
@@ -60,9 +60,9 @@ this is an example comment message with a comment from a PR template
 """,
         ),
         (
-'### 🏷️ Jira ticket\r\n <!-- Add the Jira ticket corresponding to this Pull request -->\r\n https://company.atlassian.net/browse/COOL-123\r\n ### 📢 Type of change\r\n <!--- Remove what\'s irrelevant -->\r\n - New feature (non-breaking change which adds functionality)\r\n ### 📜 Description\r\n <!--\r\n    Describe your changes in detail.\r\n    Mainly answer the "What" and "How". What is the PR changing? What is it adding/modifying/removing? What will the new behavior be?\r\n    How is the change introduced?\r\n -->\r\n Add feature which is really cool and useful.\r\n ...\r\n\r\n\r\n\r\n'
+'### 🏷️ Jira ticket\r\n <!-- Add the Jira ticket corresponding to this Pull request -->\r\n'
 ,
-'### 🏷️ Jira ticket\r\n \r\n https://company.atlassian.net/browse/COOL-123\r\n ### 📢 Type of change\r\n \r\n - New feature (non-breaking change which adds functionality)\r\n ### 📜 Description\r\n \r\n Add feature which is really cool and useful.\r\n ...\r\n\r\n\r\n\r\n'
+'### 🏷️ Jira ticket\r\n \r\n'
 )
     ],
 )

--- a/bot/kodiak/test_text.py
+++ b/bot/kodiak/test_text.py
@@ -59,11 +59,7 @@ this is an example comment message with a comment from a PR template
 
 """,
         ),
-        (
-'### 🏷️ Jira ticket\r\n <!-- Add the Jira ticket corresponding to this Pull request -->\r\n'
-,
-'### 🏷️ Jira ticket\r\n \r\n'
-)
+        ("🏷️<!-- -->", "🏷️"),
     ],
 )
 def test_strip_html_comments_from_markdown(original: str, stripped: str) -> None:

--- a/bot/kodiak/test_text.py
+++ b/bot/kodiak/test_text.py
@@ -59,6 +59,11 @@ this is an example comment message with a comment from a PR template
 
 """,
         ),
+        (
+'### 🏷️ Jira ticket\r\n <!-- Add the Jira ticket corresponding to this Pull request -->\r\n https://company.atlassian.net/browse/COOL-123\r\n ### 📢 Type of change\r\n <!--- Remove what\'s irrelevant -->\r\n - New feature (non-breaking change which adds functionality)\r\n ### 📜 Description\r\n <!--\r\n    Describe your changes in detail.\r\n    Mainly answer the "What" and "How". What is the PR changing? What is it adding/modifying/removing? What will the new behavior be?\r\n    How is the change introduced?\r\n -->\r\n Add feature which is really cool and useful.\r\n ...\r\n\r\n\r\n\r\n'
+,
+'### 🏷️ Jira ticket\r\n \r\n https://company.atlassian.net/browse/COOL-123\r\n ### 📢 Type of change\r\n \r\n - New feature (non-breaking change which adds functionality)\r\n ### 📜 Description\r\n \r\n Add feature which is really cool and useful.\r\n ...\r\n\r\n\r\n\r\n'
+)
     ],
 )
 def test_strip_html_comments_from_markdown(original: str, stripped: str) -> None:

--- a/bot/kodiak/test_text.py
+++ b/bot/kodiak/test_text.py
@@ -15,7 +15,7 @@ Totam dolor [exercitationem laborum](https://numquam.com)
 <!--
 - Voluptatem voluptas officiis
 - Voluptates nulla tempora
-- Officia distinctio ut ab
+- Officia distinctio ut ab 👾
   + Est ut voluptatum consequuntur recusandae aspernatur
   + Quidem debitis atque dolorum est enim
 -->
@@ -32,13 +32,13 @@ Totam dolor [exercitationem laborum](https://numquam.com)
             'Non dolor velit vel quia mollitia.\r\n\r\nVoluptates nulla tempora.\r\n\r\n<!--\r\n- Voluptatem voluptas officiis\r\n- Voluptates nulla tempora\r\n- Officia distinctio ut ab\r\n  + "Est ut voluptatum" consequuntur recusandae aspernatur\r\n  + Quidem debitis atque dolorum est enim\r\n-->',
             "Non dolor velit vel quia mollitia.\n\nVoluptates nulla tempora.\n\n",
         ),
-        ("hello <!-- testing -->world", "hello world"),
+        ("hello <!-- testing 👾 -->world", "hello world"),
         (
-            "hello <span>  <p>  <!-- testing --> hello</p></span>world",
+            "hello <span>  <p>  <!-- testing 👾 --> hello</p></span>world",
             "hello <span>  <p>   hello</p></span>world",
         ),
         (
-            "hello <span>  <p>  <!-- testing --> hello<!-- 123 --></p></span>world",
+            "hello <span>  <p>  <!-- testing 👾 --> hello<!-- 123 👾 --></p></span>world",
             "hello <span>  <p>   hello</p></span>world",
         ),
         (
@@ -47,7 +47,7 @@ this is an example comment message with a comment from a PR template
 
 <!--
 - bullet one
-- bullet two
+- bullet two 👾
 - bullet three
   + sub bullet one
   + sub bullet two

--- a/bot/kodiak/text.py
+++ b/bot/kodiak/text.py
@@ -1,7 +1,8 @@
+from collections import defaultdict
 from html.parser import HTMLParser
 from typing import List, Tuple
 
-from markdown_html_finder import find_html_positions
+from markdown_html_finder import find_html_positions as find_html_byte_positions
 
 
 class CommentHTMLParser(HTMLParser):
@@ -39,19 +40,39 @@ def strip_html_comments_from_markdown(raw_message: str) -> str:
     # html correctly. pulldown-cmark doesn't handle carriage returns well.
     # remark-parse also doesn't handle carriage returns:
     # https://github.com/remarkjs/remark/issues/195#issuecomment-230760892
-    message = raw_message.replace("\r", "")
-    html_node_positions = find_html_positions(message)
-    comment_locations = []
+    stripped_message = raw_message.replace("\r", "")
+    html_node_positions = find_html_byte_positions(stripped_message)
+    comment_locations = defaultdict(list)
+
+    message_bytes = stripped_message.encode()
     for html_start, html_end in html_node_positions:
-        html_text = message[html_start:html_end]
+        # snippet of HTML bytes
+        html_text = message_bytes[html_start:html_end].decode()
         html_parser.feed(html_text)
         for comment_start, comment_end in html_parser.comments:
-            comment_locations.append(
-                (html_start + comment_start, html_start + comment_end)
+            comment_locations[(html_start, html_end)].append(
+                (comment_start, comment_end)
             )
         html_parser.reset()
 
-    new_message = message
-    for comment_start, comment_end in reversed(comment_locations):
-        new_message = new_message[:comment_start] + new_message[comment_end:]
-    return new_message
+    new_message_bytes = message_bytes
+    for html_positions, comment_pos in sorted(
+        comment_locations.items(), key=lambda x: -x[0][0]
+    ):
+        html_start_bytes, html_end_bytes = html_positions
+        new_message_piece_start = new_message_bytes[:html_start_bytes]
+        new_message_piece_middle = new_message_bytes[
+            html_start_bytes:html_end_bytes
+        ].decode()
+        new_message_piece_end = new_message_bytes[html_end_bytes:]
+        for comment_start, comment_end in reversed(comment_pos):
+            new_message_piece_middle = (
+                new_message_piece_middle[:comment_start]
+                + new_message_piece_middle[comment_end:]
+            )
+        new_message_bytes = (
+            new_message_piece_start
+            + new_message_piece_middle.encode()
+            + new_message_piece_end
+        )
+    return new_message_bytes.decode()


### PR DESCRIPTION
`markdown_html_finder` returns offsets in terms of bytes, but our Python code works in terms of unicode. `🏷️<!-- -->` is 11 characters, but 16 bytes. So if we have unicode in our PR body, stripping html characters doesn't work correctly.

The fix is to correctly handle byte offsets and unicode offsets. We must convert to bytes to accept the offsets from `markdown_html_finder`. But we must use unicode to parse HTML comments from those HTML snippets.

related #800