### PR TITLE
retry when merging

### DIFF
--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -90,10 +90,17 @@ async def evaluate_pr(
                 ),
                 timeout=60,
             )
-            if pr is None:
-                log.info("failed to get_pr")
-                return
             try:
+                if pr is None:
+                    log.info("failed to get_pr")
+                    if merging:
+                        raise ApiCallException(
+                            method="kodiak/get_pr",
+                            http_status_code=0,
+                            response="",
+                        )
+                    else:
+                        return
                 await asyncio.wait_for(
                     mergeable(
                         api=pr,

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -97,7 +97,7 @@ async def evaluate_pr(
                         raise ApiCallException(
                             method="kodiak/get_pr",
                             http_status_code=0,
-                            response="",
+                            response=b"",
                         )
                     else:
                         return

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -99,8 +99,7 @@ async def evaluate_pr(
                             http_status_code=0,
                             response=b"",
                         )
-                    else:
-                        return
+                    return
                 await asyncio.wait_for(
                     mergeable(
                         api=pr,


### PR DESCRIPTION
If we get an error when making an API request, we generally return none.

If we're merging a PR, we should retry instead of returning early in this case.