### PR TITLE
ref(bot): change config related warning to an info log

### DIFF
--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -507,7 +507,7 @@ async def mergeable(
         await api.set_status(msg, markdown_content=markdown_content)
 
     if not isinstance(config, V1):
-        log.warning("problem fetching config")
+        log.info("invalid config")
         await set_status(
             '⚠️ Invalid configuration (Click "Details" for more info.)',
             markdown_content=get_markdown_for_config(


### PR DESCRIPTION
We're getting sentry errors for whenever a PR is processed with an invalid config.
Kodiak gives a proper error message for this, so it's not important to report to sentry, so instead we can convert it to an info log.