### PR TITLE
fix(bot): error parsing response with no commits

### DIFF
--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -1036,9 +1036,15 @@ query {
             log.warning("Could not find PR")
             return None
 
+        latest_sha = get_sha(pr=pull_request)
+        if latest_sha is None:
+            # PR didn't have a diff associated with it!
+            log.info("pull request missing sha")
+            return None
+
         # update the dictionary to match what we need for parsing
         pull_request["labels"] = get_labels(pr=pull_request)
-        pull_request["latest_sha"] = get_sha(pr=pull_request)
+        pull_request["latest_sha"] = latest_sha
         pull_request["number"] = pr_number
         try:
             pr = PullRequest.parse_obj(pull_request)

--- a/bot/kodiak/test/fixtures/api/get_event/no_latest_sha.json
+++ b/bot/kodiak/test/fixtures/api/get_event/no_latest_sha.json
@@ -1,0 +1,174 @@
+{
+    "data": {
+        "repository": {
+            "branchProtectionRules": {
+                "nodes": [
+                    {
+                        "matchingRefs": {
+                            "nodes": [
+                                {
+                                    "name": "master"
+                                }
+                            ]
+                        },
+                        "requiresApprovingReviews": true,
+                        "requiredApprovingReviewCount": 2,
+                        "requiresStatusChecks": true,
+                        "requiredStatusCheckContexts": [
+                            "ci/circleci: backend_lint",
+                            "ci/circleci: backend_test",
+                            "ci/circleci: frontend_lint",
+                            "ci/circleci: frontend_test",
+                            "WIP (beta)"
+                        ],
+                        "requiresStrictStatusChecks": true,
+                        "requiresCodeOwnerReviews": false,
+                        "requiresCommitSignatures": false,
+                        "requiresConversationResolution": false,
+                        "restrictsPushes": true,
+                        "pushAllowances": {
+                            "nodes": [
+                                {
+                                    "actor": {}
+                                },
+                                {
+                                    "actor": {
+                                        "databaseId": 53453
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "mergeCommitAllowed": false,
+            "rebaseMergeAllowed": false,
+            "squashMergeAllowed": true,
+            "deleteBranchOnMerge": true,
+            "isPrivate": true,
+            "pullRequest": {
+                "id": "e14ff7599399478fb9dbc2dacb87da72",
+                "isDraft": false,
+                "mergeStateStatus": "BEHIND",
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "isCrossRepository": false,
+                "author": {
+                    "login": "arnold",
+                    "databaseId": 49118,
+                    "type": "Bot"
+                },
+                "reviewRequests": {
+                    "nodes": [
+                        {
+                            "requestedReviewer": {
+                                "__typename": "User",
+                                "login": "ghost"
+                            }
+                        },
+                        {
+                            "requestedReviewer": {
+                                "__typename": "Team",
+                                "name": "ghost-team"
+                            }
+                        },
+                        {
+                            "requestedReviewer": {
+                                "__typename": "Mannequin",
+                                "login": "ghost-mannequin"
+                            }
+                        }
+                    ]
+                },
+                "reviewThreads": {
+                    "nodes": [
+                        {
+                            "isCollapsed": true
+                        },
+                        {
+                            "isCollapsed": false
+                        }
+                    ]
+                },
+                "title": "Update README.md",
+                "body": "",
+                "bodyText": "",
+                "bodyHTML": "",
+                "url": "https://github.com/delos-corp/hive-mind/pull/324",
+                "reviews": {
+                    "nodes": [
+                        {
+                            "createdAt": "2019-05-22T15:29:34Z",
+                            "state": "COMMENTED",
+                            "author": {
+                                "login": "ghost",
+                                "type": "User"
+                            }
+                        },
+                        {
+                            "createdAt": "2019-05-22T15:29:52Z",
+                            "state": "CHANGES_REQUESTED",
+                            "author": {
+                                "login": "ghost",
+                                "type": "User"
+                            }
+                        },
+                        {
+                            "createdAt": "2019-05-22T15:30:52Z",
+                            "state": "COMMENTED",
+                            "author": {
+                                "login": "kodiak",
+                                "type": "User"
+                            }
+                        },
+                        {
+                            "createdAt": "2019-05-22T15:43:17Z",
+                            "state": "APPROVED",
+                            "author": {
+                                "login": "ghost",
+                                "type": "User"
+                            }
+                        },
+                        {
+                            "createdAt": "2019-05-23T15:13:29Z",
+                            "state": "APPROVED",
+                            "author": {
+                                "login": "walrus",
+                                "type": "User"
+                            }
+                        },
+                        {
+                            "createdAt": "2019-05-24T10:21:32Z",
+                            "state": "APPROVED",
+                            "author": {
+                                "login": "kodiakhq",
+                                "type": "Bot"
+                            }
+                        }
+                    ],
+                    "totalCount": 2
+                },
+                "baseRefName": "master",
+                "headRefName": "df825f90-9825-424c-a97e-733522027e4c",
+                "headRef": {
+                    "id": "092059105"
+                },
+                "commits": {
+                    "nodes": []
+                },
+                "labels": {
+                    "nodes": [
+                        {
+                            "name": "automerge"
+                        }
+                    ],
+                    "totalCount": 1
+                }
+            },
+            "rootConfigFile": {
+                "text": "version = 1\n[merge]\nmethod = \"squash\"\n"
+            },
+            "githubConfigFile": null
+        }
+    }
+}


### PR DESCRIPTION
When a PR doesn't have any commits, we were failing to parse the response.

I think we could probably improve our mocking situation so its at the actual http response level rather than mocking the method, since the method gets called multiple times with different params.