### PR TITLE
ref(bot): cleanup asyncio test setup code

### DIFF
--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -207,7 +207,6 @@ class MockPrApi:
         return False
 
 
-@pytest.mark.asyncio
 async def test_mock_pr_api() -> None:
     api = MockPrApi()
     await api.dequeue()
@@ -403,7 +402,6 @@ def create_mergeable() -> MergeableType:
     return mergeable
 
 
-@pytest.mark.asyncio
 async def test_mergeable_abort_is_active_merge() -> None:
     """
     If we set is_active_merge, that means that in the merge queue the current PR
@@ -423,7 +421,6 @@ async def test_mergeable_abort_is_active_merge() -> None:
     assert api.merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_config_error_sets_warning() -> None:
     """
     If we have a problem finding or parsing a configuration error we should set
@@ -446,7 +443,6 @@ async def test_mergeable_config_error_sets_warning() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_different_app_id() -> None:
     """
     If our app id doesn't match the one in the config, we shouldn't touch the repo.
@@ -465,7 +461,6 @@ async def test_mergeable_different_app_id() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_branch_protection() -> None:
     """
     We should warn when we cannot retrieve branch protection settings.
@@ -484,7 +479,6 @@ async def test_mergeable_missing_branch_protection() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_automerge_label() -> None:
     """
     If we're missing an automerge label we should not merge the PR.
@@ -507,7 +501,6 @@ async def test_mergeable_missing_automerge_label() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_automerge_label_no_message() -> None:
     """
     No status message if show_missing_automerge_label_message is disabled
@@ -530,7 +523,6 @@ async def test_mergeable_missing_automerge_label_no_message() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_automerge_label_require_automerge_label() -> None:
     """
     We can work on a PR if we're missing labels and we have require_automerge_label disabled.
@@ -553,7 +545,6 @@ async def test_mergeable_missing_automerge_label_require_automerge_label() -> No
     assert api.merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_has_blacklist_labels() -> None:
     """
     blacklist labels should prevent merge
@@ -579,7 +570,6 @@ async def test_mergeable_has_blacklist_labels() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_has_blocking_labels() -> None:
     """
     blocking labels should prevent merge
@@ -605,7 +595,6 @@ async def test_mergeable_has_blocking_labels() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_blacklist_title_regex() -> None:
     """
     block merge if blacklist_title_regex matches pull request
@@ -630,7 +619,6 @@ async def test_mergeable_blacklist_title_regex() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_blocking_title_regex() -> None:
     """
     block merge if blocking_title_regex matches pull request
@@ -655,7 +643,6 @@ async def test_mergeable_blocking_title_regex() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_blocking_title_regex_invalid() -> None:
     """
     raise config error if regex is invalid.
@@ -678,7 +665,6 @@ async def test_mergeable_blocking_title_regex_invalid() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_blocking_title_regex_default() -> None:
     """
     We should default to "^WIP.*" if unset.
@@ -705,7 +691,6 @@ async def test_mergeable_blocking_title_regex_default() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_blocking_title_disabled() -> None:
     """
     We should be able to disable the title regex by setting it to empty string.
@@ -738,7 +723,6 @@ async def test_mergeable_blocking_title_disabled() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_blacklist_title_match_with_exp_regex(mocker: Any) -> None:
     """
     Ensure Kodiak uses a linear time regex engine.
@@ -765,7 +749,6 @@ async def test_mergeable_blacklist_title_match_with_exp_regex(mocker: Any) -> No
     assert kodiak_evaluation_re_search.called, "we should hit our regex search"
 
 
-@pytest.mark.asyncio
 async def test_mergeable_draft_pull_request() -> None:
     """
     block merge if pull request is in draft state
@@ -791,7 +774,6 @@ async def test_mergeable_draft_pull_request() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_draft_pull_request_is_draft_field() -> None:
     """
     block merge if pull request is in draft state.
@@ -817,7 +799,6 @@ async def test_mergeable_draft_pull_request_is_draft_field() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_invalid_merge_method() -> None:
     """
     block merge if configured merge method is not enabled
@@ -842,7 +823,6 @@ async def test_mergeable_invalid_merge_method() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_default_merge_method() -> None:
     """
     Should default to `merge` commits.
@@ -864,7 +844,6 @@ async def test_mergeable_default_merge_method() -> None:
     assert api.update_branch.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_single_merge_method() -> None:
     """
     If an account only has one merge method configured, use that if they haven't
@@ -894,7 +873,6 @@ async def test_mergeable_single_merge_method() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_two_merge_methods() -> None:
     """
     If we have two options available, choose the first one, based on our ordered
@@ -925,7 +903,6 @@ async def test_mergeable_two_merge_methods() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_no_valid_methods() -> None:
     """
     We should always have at least one valid_merge_method in production, but
@@ -949,7 +926,6 @@ async def test_mergeable_no_valid_methods() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_method_override_with_label() -> None:
     """
     We should be able to override merge methods with a label.
@@ -984,7 +960,6 @@ async def test_mergeable_method_override_with_label() -> None:
         assert api.update_branch.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_block_on_reviews_requested() -> None:
     """
     block merge if reviews are requested and merge.block_on_reviews_requested is
@@ -1009,7 +984,6 @@ async def test_mergeable_block_on_reviews_requested() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merged_no_delete_branch() -> None:
     """
     if a PR is already merged we shouldn't take anymore action on it besides
@@ -1036,7 +1010,6 @@ async def test_mergeable_pull_request_merged_no_delete_branch() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merged_delete_branch() -> None:
     """
     if a PR is already merged we shouldn't take anymore action on it besides
@@ -1064,7 +1037,6 @@ async def test_mergeable_pull_request_merged_delete_branch() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merged_delete_branch_with_branch_dependencies() -> None:
     """
     if a PR is already merged we shouldn't take anymore action on it besides
@@ -1092,7 +1064,6 @@ async def test_mergeable_pull_request_merged_delete_branch_with_branch_dependenc
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merged_delete_branch_cross_repo_pr() -> None:
     """
     if a PR is already merged we shouldn't take anymore action on it besides
@@ -1122,7 +1093,6 @@ async def test_mergeable_pull_request_merged_delete_branch_cross_repo_pr() -> No
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merged_delete_branch_repo_delete_enabled() -> None:
     """
     If the repository has delete_branch_on_merge enabled we shouldn't bother
@@ -1151,7 +1121,6 @@ async def test_mergeable_pull_request_merged_delete_branch_repo_delete_enabled()
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_closed() -> None:
     """
     if a PR is closed we don't want to act on it.
@@ -1172,7 +1141,6 @@ async def test_mergeable_pull_request_closed() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict() -> None:
     """
     if a PR has a merge conflict we can't merge. If configured, we should leave
@@ -1201,7 +1169,6 @@ async def test_mergeable_pull_request_merge_conflict() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict_notify_on_conflict() -> None:
     """
     if a PR has a merge conflict we can't merge. If configured, we should leave
@@ -1231,7 +1198,6 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict() -> Non
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_blacklist_title_regex() -> None:
     """
     if a PR has a merge conflict we can't merge. If the title matches the
@@ -1264,7 +1230,6 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_blacklis
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_missing_label() -> None:
     """
     if a PR has a merge conflict we can't merge. If configured, we should leave
@@ -1290,7 +1255,6 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_missing_
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_automerge_labels() -> None:
     """
     We should only notify on conflict when we have an automerge label.
@@ -1324,7 +1288,6 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_automerg
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_no_require_automerge_label() -> None:
     """
     if a PR has a merge conflict we can't merge. If require_automerge_label is set then we shouldn't notify even if notify_on_conflict is configured. This allows prevents infinite commenting.
@@ -1353,7 +1316,6 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_no_requi
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_pull_request_merged() -> None:
     """
     If the pull request is merged we shouldn't error on merge conflict.
@@ -1390,7 +1352,6 @@ async def test_mergeable_pull_request_merge_conflict_notify_on_conflict_pull_req
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_need_test_commit() -> None:
     """
     When you view a PR on GitHub, GitHub makes a test commit to see if a PR can
@@ -1415,7 +1376,6 @@ async def test_mergeable_pull_request_need_test_commit() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_need_test_commit_merging() -> None:
     """
     If we're merging a PR we should raise the PollForever exception instead of
@@ -1440,7 +1400,6 @@ async def test_mergeable_pull_request_need_test_commit_merging() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_need_test_commit_need_update() -> None:
     """
     If a pull request mergeable status is UNKNOWN we should trigger a test
@@ -1473,7 +1432,6 @@ async def test_mergeable_pull_request_need_test_commit_need_update() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_pull_request_need_test_commit_need_update_pr_not_open() -> None:
     """
     If a pull request mergeable status is UNKNOWN _and_ it is OPEN we should
@@ -1516,7 +1474,6 @@ async def test_mergeable_pull_request_need_test_commit_need_update_pr_not_open()
         assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_unknown_merge_blockage() -> None:
     """
     Test how kodiak behaves when we cannot figure out why a PR is blocked.
@@ -1539,7 +1496,6 @@ async def test_mergeable_unknown_merge_blockage() -> None:
 
 
 @pytest.mark.xfail
-@pytest.mark.asyncio
 async def test_mergeable_unknown_merge_blockage_code_owner() -> None:
     mergeable = create_mergeable()
     api = create_api()
@@ -1563,7 +1519,6 @@ async def test_mergeable_unknown_merge_blockage_code_owner() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_unknown_merge_blockage_code_owner_approval() -> None:
     mergeable = create_mergeable()
     api = create_api()
@@ -1581,7 +1536,6 @@ async def test_mergeable_unknown_merge_blockage_code_owner_approval() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_prioritize_ready_to_merge() -> None:
     """
     If we enabled merge.prioritize_ready_to_merge, then if a PR is ready to merge when it reaches Kodiak, we merge it immediately. merge.prioritize_ready_to_merge is basically the sibling of merge.update_branch_immediately.
@@ -1605,7 +1559,6 @@ async def test_mergeable_prioritize_ready_to_merge() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_merge() -> None:
     """
     If we're merging we should call api.merge
@@ -1628,7 +1581,6 @@ async def test_mergeable_merge() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_queue_for_merge_no_position() -> None:
     """
     If we're attempting to merge from the frontend we should place the PR on the queue.
@@ -1647,7 +1599,6 @@ async def test_mergeable_queue_for_merge_no_position() -> None:
     assert api.queue_for_merge.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_mergeable_passing() -> None:
     """
     This is the happy case where we want to enqueue the PR for merge.
@@ -1661,7 +1612,6 @@ async def test_mergeable_passing() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_merge_automerge_labels() -> None:
     """
     Test merge.automerge_label array allows a pull request to be merged.
@@ -1679,7 +1629,6 @@ async def test_mergeable_merge_automerge_labels() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_need_update() -> None:
     """
     When a PR isn't in the queue but needs an update we should enqueue it for merge.
@@ -1695,7 +1644,6 @@ async def test_mergeable_need_update() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_do_not_merge() -> None:
     """
     merge.do_not_merge should disable merging a PR.
@@ -1714,7 +1662,6 @@ async def test_mergeable_do_not_merge() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_do_not_merge_behind_no_update_immediately() -> None:
     """
     merge.do_not_merge without merge.update_branch_immediately means that any PR
@@ -1742,7 +1689,6 @@ async def test_mergeable_do_not_merge_behind_no_update_immediately() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_do_not_merge_with_update_branch_immediately_no_update() -> None:
     """
     merge.do_not_merge is only useful with merge.update_branch_immediately,
@@ -1764,7 +1710,6 @@ async def test_mergeable_do_not_merge_with_update_branch_immediately_no_update()
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_do_not_merge_with_update_branch_immediately_need_update() -> None:
     """
     merge.do_not_merge is only useful with merge.update_branch_immediately,
@@ -1786,7 +1731,6 @@ async def test_mergeable_do_not_merge_with_update_branch_immediately_need_update
     assert api.merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_api_call_retry_timeout() -> None:
     """
     if we enounter too many errors calling GitHub api_call_retry_timeout will be zero. we should notify users via a status check.
@@ -1822,7 +1766,6 @@ async def test_mergeable_api_call_retry_timeout() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_api_call_retry_timeout_missing_method() -> None:
     """
     if we enounter too many errors calling GitHub api_call_retry_timeout will be zero. we should notify users via a status check.
@@ -1843,7 +1786,6 @@ async def test_mergeable_api_call_retry_timeout_missing_method() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_passing_update_always_enabled() -> None:
     """
     Test happy case with update.always enabled. We should shouldn't see any
@@ -1861,7 +1803,6 @@ async def test_mergeable_passing_update_always_enabled() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_auto_approve_username() -> None:
     """
     If a PR is opened by a user on the `approve.auto_approve_usernames` list Kodiak should approve the PR.
@@ -1883,7 +1824,6 @@ async def test_mergeable_auto_approve_username() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_auto_approve_label() -> None:
     """
     If a PR has a label which is in the `approve.auto_approve_labels` list Kodiak should approve the PR.
@@ -1904,7 +1844,6 @@ async def test_mergeable_auto_approve_label() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_auto_approve_existing_approval() -> None:
     """
     If a PR is opened by a user on the `approve.auto_approve_usernames` list Kodiak should approve the PR.
@@ -1933,7 +1872,6 @@ async def test_mergeable_auto_approve_existing_approval() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_auto_approve_old_approval() -> None:
     """
     If a PR is opened by a user on the `approve.auto_approve_usernames` list Kodiak should approve the PR.
@@ -1962,7 +1900,6 @@ async def test_mergeable_auto_approve_old_approval() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_auto_approve_ignore_closed_merged_prs() -> None:
     """
     If a PR is opened by a user on the `approve.auto_approve_usernames` list Kodiak should approve the PR.
@@ -1991,7 +1928,6 @@ async def test_mergeable_auto_approve_ignore_closed_merged_prs() -> None:
         assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_auto_approve_ignore_draft_pr() -> None:
     """
     If a PR is opened by a user on the `approve.auto_approve_usernames` list Kodiak should approve the PR.
@@ -2032,7 +1968,6 @@ async def test_mergeable_auto_approve_ignore_draft_pr() -> None:
         assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_paywall_missing_subscription() -> None:
     """
     If a subscription is missing we should not raise the paywall. The web_api
@@ -2061,7 +1996,6 @@ async def test_mergeable_paywall_missing_subscription() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_paywall_subscription_blocker() -> None:
     """
     If an account has a subscription_blocker we should display the paywall.
@@ -2095,7 +2029,6 @@ async def test_mergeable_paywall_subscription_blocker() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_paywall_public_repository() -> None:
     """
     Public repositories should never see a paywall.
@@ -2128,7 +2061,6 @@ async def test_mergeable_paywall_public_repository() -> None:
         assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_paywall_missing_env(mocker: Any) -> None:
     """
     If the environment variable is disabled we should not throw up the paywall.
@@ -2158,7 +2090,6 @@ async def test_mergeable_paywall_missing_env(mocker: Any) -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_paywall_subscription_expired() -> None:
     """
     When a subscription is expired we should not merge a pull request.
@@ -2189,7 +2120,6 @@ async def test_mergeable_paywall_subscription_expired() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_paywall_trial_expired() -> None:
     """
     When a trial has expired we should not act on a pull request.
@@ -2217,7 +2147,6 @@ async def test_mergeable_paywall_trial_expired() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_paywall_seats_exceeded() -> None:
     """
     When an account has exceeded their seat usage they should hit the paywall.
@@ -2245,7 +2174,6 @@ async def test_mergeable_paywall_seats_exceeded() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_paywall_seats_exceeded_allowed_user() -> None:
     """
     Users that have a seat should be allowed to continue using Kodiak even if
@@ -2282,7 +2210,6 @@ async def test_mergeable_paywall_seats_exceeded_allowed_user() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_merge_pull_request_api_exception() -> None:
     """
     If we attempt to merge a pull request but get an internal server error from
@@ -2320,7 +2247,6 @@ async def test_mergeable_merge_pull_request_api_exception() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_merge_failure_label() -> None:
     """
     Kodiak should take no action on a pull request when
@@ -2348,7 +2274,6 @@ async def test_mergeable_merge_failure_label() -> None:
     assert api.update_branch.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_priority_merge_label() -> None:
     """
     When a PR has merge.priority_merge_label, we should place it at the front of

--- a/bot/kodiak/test_pull_request.py
+++ b/bot/kodiak/test_pull_request.py
@@ -237,7 +237,6 @@ def create_prv2(
     )
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_merge() -> None:
     """
     We should be able to merge successfully
@@ -257,7 +256,6 @@ async def test_pr_v2_merge() -> None:
     assert client.merge_pull_request.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_merge_rebase_error() -> None:
     """
     We should raise ApiCallException when we get a bad API response.
@@ -279,7 +277,6 @@ async def test_pr_v2_merge_rebase_error() -> None:
     assert b"merge-a-pull-request-merge-button" in e.value.response
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_merge_service_unavailable() -> None:
     """
     We should raise ApiCallException when we get a bad API response.
@@ -300,7 +297,6 @@ async def test_pr_v2_merge_service_unavailable() -> None:
     assert b"Service Unavailable" in e.value.response
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_update_branch_ok() -> None:
     """
     We should be able to update a branch.
@@ -313,7 +309,6 @@ async def test_pr_v2_update_branch_ok() -> None:
     assert client.update_branch.calls[0]["pull_number"] == pr_v2.number
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_update_branch_service_unavailable() -> None:
     """
     We should raise ApiCallException when we get a bad API response.
@@ -332,7 +327,6 @@ async def test_pr_v2_update_branch_service_unavailable() -> None:
     assert b"Service Unavailable" in e.value.response
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_add_label_ok() -> None:
     """
     We should be able to add a label.
@@ -345,7 +339,6 @@ async def test_pr_v2_add_label_ok() -> None:
     assert client.add_label.calls[0]["label"] == "some-label-to-delete"
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_add_label_service_unavailable() -> None:
     """
     We should raise ApiCallException when we get a bad API response.
@@ -364,7 +357,6 @@ async def test_pr_v2_add_label_service_unavailable() -> None:
     assert b"Service Unavailable" in e.value.response
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_remove_label_ok() -> None:
     """
     Check that remove_label works when
@@ -377,7 +369,6 @@ async def test_pr_v2_remove_label_ok() -> None:
     assert client.delete_label.calls[0]["label"] == "some-label-to-delete"
 
 
-@pytest.mark.asyncio
 async def test_pr_v2_remove_label_service_unavailable() -> None:
     """
     We should raise ApiCallException when we get a bad API response.
@@ -396,7 +387,6 @@ async def test_pr_v2_remove_label_service_unavailable() -> None:
     assert b"Service Unavailable" in e.value.response
 
 
-@pytest.mark.asyncio
 async def test_update_ref_ok() -> None:
     """
     Check that update_ref works
@@ -411,7 +401,6 @@ async def test_update_ref_ok() -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_update_ref_service_unavailable() -> None:
     """
     We should raise ApiCallException when we get a bad API response.

--- a/bot/kodiak/test_queries.py
+++ b/bot/kodiak/test_queries.py
@@ -62,7 +62,6 @@ def api_client(mocker: MockFixture, github_installation_id: str) -> Client:
     return client
 
 
-@pytest.mark.asyncio
 async def test_get_config_for_ref_error(
     api_client: Client, mocker: MockFixture
 ) -> None:
@@ -79,7 +78,6 @@ async def test_get_config_for_ref_error(
     assert res is None
 
 
-@pytest.mark.asyncio
 async def test_get_config_for_ref_dot_github(
     api_client: Client, mocker: MockFixture
 ) -> None:
@@ -239,7 +237,6 @@ def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 
 @pytest.fixture  # type: ignore
-@pytest.mark.asyncio
 async def setup_redis(github_installation_id: str) -> None:
     host = conf.REDIS_URL.hostname
     port = conf.REDIS_URL.port
@@ -277,7 +274,6 @@ EXPECTED_ERRORS = [
 
 # TODO: serialize EventInfoResponse to JSON to parametrize test
 @requires_redis
-@pytest.mark.asyncio
 async def test_get_event_info_blocked(
     api_client: Client,
     blocked_response: Dict[str, Any],
@@ -308,7 +304,6 @@ async def test_get_event_info_blocked(
 
 
 @requires_redis
-@pytest.mark.asyncio
 async def test_get_event_info_no_author(
     api_client: Client,
     mocker: MockFixture,
@@ -350,7 +345,6 @@ async def test_get_event_info_no_author(
     ] == EXPECTED_ERRORS
 
 
-@pytest.mark.asyncio
 async def test_get_event_info_no_latest_sha(
     api_client: Client,
     mocker: MockFixture,
@@ -455,7 +449,6 @@ def create_fake_redis_reply(res: Dict[bytes, bytes]) -> Any:
     return FakeRedis
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_missing_blocker(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -477,7 +470,6 @@ async def test_get_subscription_missing_blocker(
     )
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_missing_blocker_and_data(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -499,7 +491,6 @@ async def test_get_subscription_missing_blocker_and_data(
     )
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_missing_blocker_fully(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -514,7 +505,6 @@ async def test_get_subscription_missing_blocker_fully(
     assert res is None
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_seats_exceeded(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -538,7 +528,6 @@ async def test_get_subscription_seats_exceeded(
     )
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_seats_exceeded_no_seats(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -561,7 +550,6 @@ async def test_get_subscription_seats_exceeded_no_seats(
     )
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_seats_exceeded_missing_data(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -585,7 +573,6 @@ async def test_get_subscription_seats_exceeded_missing_data(
     )
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_seats_exceeded_invalid_data(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -609,7 +596,6 @@ async def test_get_subscription_seats_exceeded_invalid_data(
     )
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_seats_exceeded_invalid_kind(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -634,7 +620,6 @@ async def test_get_subscription_seats_exceeded_invalid_kind(
     )
 
 
-@pytest.mark.asyncio
 async def test_get_subscription_unknown_blocker(
     api_client: Client, mocker: MockFixture, mock_get_token_for_install: None
 ) -> None:
@@ -842,7 +827,6 @@ def generate_page_of_prs(numbers: Iterable[int]) -> Response:
     )
 
 
-@pytest.mark.asyncio
 async def test_get_open_pull_requests(
     mocker: MockFixture, api_client: Client, mock_get_token_for_install: None
 ) -> None:
@@ -867,7 +851,6 @@ async def test_get_open_pull_requests(
     assert patched_session_get.call_count == 4
 
 
-@pytest.mark.asyncio
 async def test_get_open_pull_requests_page_limit(
     mocker: MockFixture, api_client: Client, mock_get_token_for_install: None
 ) -> None:

--- a/bot/kodiak/tests/evaluation/test_automerge_dependencies.py
+++ b/bot/kodiak/tests/evaluation/test_automerge_dependencies.py
@@ -10,7 +10,6 @@ from kodiak.test_evaluation import (
 from kodiak.tests.dependencies.test_dependencies import FakePR, generate_test_cases
 
 
-@pytest.mark.asyncio
 async def test_merge_okay() -> None:
     """
     Happy case.
@@ -35,7 +34,6 @@ async def test_merge_okay() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_merge_mismatch_username() -> None:
     """
     We should only merge the pull request if the userrname is specified within
@@ -57,7 +55,6 @@ async def test_merge_mismatch_username() -> None:
     assert api.dequeue.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_merge_no_version_found() -> None:
     """
     If we can't find a version from the PR title, we shouldn't merge.
@@ -81,7 +78,6 @@ async def test_merge_no_version_found() -> None:
         assert api.dequeue.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_merge_disallowed_version() -> None:
     """
     We should only auto merge if the upgrade type is specified in "versions".
@@ -104,7 +100,6 @@ async def test_merge_disallowed_version() -> None:
     assert api.dequeue.call_count == 1
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("pr,update_type", generate_test_cases())
 async def test_merge_renovate(pr: FakePR, update_type: MatchType) -> None:
     mergeable = create_mergeable()

--- a/bot/kodiak/tests/evaluation/test_branch_protection.py
+++ b/bot/kodiak/tests/evaluation/test_branch_protection.py
@@ -23,7 +23,6 @@ from kodiak.test_evaluation import (
 )
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_push_allowance() -> None:
     """
     We should warn when user is missing a push allowance with restrictsPushes
@@ -47,7 +46,6 @@ async def test_mergeable_missing_push_allowance() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_push_allowance_correct() -> None:
     """
     When restrictsPushes is enabled, but Kodiak is added as a push allowance, we
@@ -69,7 +67,6 @@ async def test_mergeable_missing_push_allowance_correct() -> None:
     assert api.merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_push_allowance_correct_null_database_id() -> None:
     """
     Verify we can handle a null databaseId for the PushAllowanceActor
@@ -92,7 +89,6 @@ async def test_mergeable_missing_push_allowance_correct_null_database_id() -> No
     assert api.merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_push_allowance_merge_do_not_merge() -> None:
     """
     When merge.do_not_merge is enabled, we should ignore any issues with restrictPushes because Kodiak isn't pushing.
@@ -116,7 +112,6 @@ async def test_mergeable_missing_push_allowance_merge_do_not_merge() -> None:
     assert api.merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_requires_commit_signatures_rebase() -> None:
     """
     requiresCommitSignatures doesn't work with Kodiak when rebase is configured
@@ -149,7 +144,6 @@ async def test_mergeable_requires_commit_signatures_rebase() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_requires_commit_signatures_squash_and_merge() -> None:
     """
     requiresCommitSignatures works with merge commits and squash
@@ -180,7 +174,6 @@ async def test_mergeable_requires_commit_signatures_squash_and_merge() -> None:
         assert api.merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_required_review() -> None:
     """
     Don't merge when a review is required.
@@ -209,7 +202,6 @@ async def test_mergeable_missing_required_review() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_changes_requested() -> None:
     """
     Don't merge when a changes requested.
@@ -235,7 +227,6 @@ async def test_mergeable_missing_changes_requested() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_update_branch_immediately() -> None:
     """
     update branch immediately if configured
@@ -267,7 +258,6 @@ async def test_mergeable_update_branch_immediately() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_update_branch_immediately_mode_merging() -> None:
     """
     update branch immediately if configured. When we are merging we should raise the PollForever exception to keep the merge loop going instead of returning.
@@ -301,7 +291,6 @@ async def test_mergeable_update_branch_immediately_mode_merging() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_optimistic_update_need_branch_update() -> None:
     """
     prioritize branch update over waiting for checks when merging if merge.optimistic_updates enabled.
@@ -340,7 +329,6 @@ async def test_mergeable_optimistic_update_need_branch_update() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_need_branch_update() -> None:
     """
     prioritize waiting for checks over branch updates when merging if merge.optimistic_updates is disabled.
@@ -382,7 +370,6 @@ async def test_mergeable_need_branch_update() -> None:
     assert api.update_branch.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_queue_in_progress() -> None:
     """
     If a PR has pending status checks or is behind, we still consider it eligible for merge and throw it in the merge queue.
@@ -419,7 +406,6 @@ async def test_mergeable_queue_in_progress() -> None:
     assert api.update_branch.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_queue_in_progress_with_ready_to_merge() -> None:
     """
     If a PR has pending status checks or is behind, we still consider it eligible for merge and throw it in the merge queue.
@@ -463,7 +449,6 @@ async def test_mergeable_queue_in_progress_with_ready_to_merge() -> None:
     assert api.update_branch.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_optimistic_update_wait_for_checks() -> None:
     """
     test merge.optimistic_updates when we don't need a branch update. Since merge.optimistic_updates is enabled we should wait_for_checks
@@ -506,7 +491,6 @@ async def test_mergeable_optimistic_update_wait_for_checks() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_wait_for_checks() -> None:
     """
     test merge.optimistic_updates when we don't have checks to wait for. Since merge.optimistic_updates is disabled we should update the branch.
@@ -538,7 +522,6 @@ async def test_mergeable_wait_for_checks() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_do_not_merge_with_update_branch_immediately_waiting_for_checks() -> None:
     """
     merge.do_not_merge is only useful with merge.update_branch_immediately,
@@ -577,7 +560,6 @@ async def test_mergeable_do_not_merge_with_update_branch_immediately_waiting_for
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_update_username_blacklist() -> None:
     """
     Kodiak should not update PR if user is blacklisted.
@@ -627,7 +609,6 @@ async def test_mergeable_update_username_blacklist() -> None:
             assert api.merge.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_update_always_enabled_merging_behind_pull_request() -> None:
     """
     When we're merging with update.always enabled we don't want to update the
@@ -662,7 +643,6 @@ async def test_mergeable_update_always_enabled_merging_behind_pull_request() -> 
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_requires_conversation_resolution() -> None:
     """
     When requiresConversationResolution is enabled and we have unresolved review
@@ -691,7 +671,6 @@ async def test_mergeable_requires_conversation_resolution() -> None:
     assert "cannot merge (unresolved conversations)" in api.set_status.calls[0]["msg"]
 
 
-@pytest.mark.asyncio
 async def test_mergeable_uncollapsed_reviews() -> None:
     """
     We should only block merge for unresolved review threads if

--- a/bot/kodiak/tests/evaluation/test_check_runs.py
+++ b/bot/kodiak/tests/evaluation/test_check_runs.py
@@ -18,7 +18,6 @@ from kodiak.test_evaluation import (
 )
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_requires_status_checks_failing_status_context() -> None:
     """
     If branch protection is enabled with requiresStatusChecks but a required check is failing we should not merge.
@@ -55,7 +54,6 @@ async def test_mergeable_missing_requires_status_checks_failing_status_context()
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_missing_requires_status_checks_failing_check_run() -> None:
     """
     If branch protection is enabled with requiresStatusChecks but a required check is failing we should not merge.
@@ -103,7 +101,6 @@ async def test_mergeable_missing_requires_status_checks_failing_check_run() -> N
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_travis_ci_checks() -> None:
     """
     GitHub has some weird, _undocumented_ logic for continuous-integration/travis-ci where "continuous-integration/travis-ci/{pr,push}" become "continuous-integration/travis-ci" in requiredStatusChecks.
@@ -140,7 +137,6 @@ async def test_mergeable_travis_ci_checks() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_travis_ci_checks_success() -> None:
     """
     If continuous-integration/travis-ci/pr passes we shouldn't say we're waiting for continuous-integration/travis-ci.
@@ -182,7 +178,6 @@ async def test_mergeable_travis_ci_checks_success() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_skippable_contexts_with_status_check() -> None:
     """
     If a skippable check hasn't finished, we shouldn't do anything.
@@ -225,7 +220,6 @@ async def test_mergeable_skippable_contexts_with_status_check() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_skippable_contexts_with_check_run() -> None:
     """
     If a skippable check hasn't finished, we shouldn't do anything.
@@ -268,7 +262,6 @@ async def test_mergeable_skippable_contexts_with_check_run() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_skippable_contexts_passing() -> None:
     """
     If a skippable check is passing we should queue the PR for merging
@@ -308,7 +301,6 @@ async def test_mergeable_skippable_contexts_passing() -> None:
     assert api.merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_skippable_contexts_merging_pull_request() -> None:
     """
     If a skippable check hasn't finished but we're merging, we need to raise an exception to retry for a short period of time to allow the check to finish. We won't retry forever because skippable checks will likely never finish.
@@ -353,7 +345,6 @@ async def test_mergeable_skippable_contexts_merging_pull_request() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_skippable_check_timeout() -> None:
     """
     we wait for skippable checks when merging because it takes time for check statuses to be sent and acknowledged by GitHub. We time out after some time because skippable checks are likely to never complete. In this case we want to notify the user of this via status check.
@@ -397,7 +388,6 @@ async def test_mergeable_skippable_check_timeout() -> None:
     assert api.queue_for_merge.called is False
 
 
-@pytest.mark.asyncio
 async def test_mergeable_update_always() -> None:
     """
     Kodiak should update PR even when failing requirements for merge
@@ -435,7 +425,6 @@ async def test_mergeable_update_always() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_update_autoupdate_label() -> None:
     """
     Kodiak should update the PR when the autoupdate_label is set on the PR.
@@ -489,7 +478,6 @@ async def test_mergeable_update_autoupdate_label() -> None:
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_update_always_require_automerge_label_missing_label() -> None:
     """
     Kodiak should not update branch if update.require_automerge_label is True and we're missing the automerge label.
@@ -529,7 +517,6 @@ async def test_mergeable_update_always_require_automerge_label_missing_label() -
     assert api.merge.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_mergeable_update_always_no_require_automerge_label_missing_label() -> None:
     """
     Kodiak should update branch if update.require_automerge_label is True and we're missing the automerge label.
@@ -569,7 +556,6 @@ async def test_mergeable_update_always_no_require_automerge_label_missing_label(
     assert api.dequeue.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_duplicate_check_suites() -> None:
     """
     Kodiak should only consider the most recent check run when evaluating a PR
@@ -604,7 +590,6 @@ async def test_duplicate_check_suites() -> None:
     assert api.queue_for_merge.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_neutral_required_check_runs() -> None:
     """
     When merge.block_on_neutral_required_check_runs is enabled, we should block

--- a/bot/kodiak/tests/evaluation/test_merge_message_trailers.py
+++ b/bot/kodiak/tests/evaluation/test_merge_message_trailers.py
@@ -7,8 +7,6 @@ Tested configuration options:
 - merge.message.include_pull_request_author
 """
 
-import pytest
-
 from kodiak.config import V1, Merge, MergeBodyStyle, MergeMessage, MergeMethod
 from kodiak.evaluation import MergeBody, get_merge_body
 from kodiak.test_evaluation import (
@@ -328,7 +326,6 @@ def test_get_merge_body_include_coauthors_invalid_body_style() -> None:
     assert actual == expected
 
 
-@pytest.mark.asyncio
 async def test_mergeable_include_coauthors() -> None:
     """
     Include coauthors should attach coauthor when `merge.message.body = "pull_request_body"`

--- a/bot/kodiak/tests/evaluation/test_merge_method.py
+++ b/bot/kodiak/tests/evaluation/test_merge_method.py
@@ -1,10 +1,7 @@
-import pytest
-
 from kodiak.config import MergeMethod
 from kodiak.test_evaluation import create_api, create_config, create_mergeable
 
 
-@pytest.mark.asyncio
 async def test_rebase_merge_fast_forward() -> None:
     """
     Happy case.

--- a/bot/kodiak/tests/test_fixtures.py
+++ b/bot/kodiak/tests/test_fixtures.py
@@ -1,10 +1,7 @@
-import pytest
-
 from kodiak.queries import ThrottlerProtocol
 from kodiak.tests.fixtures import FakeThottler
 
 
-@pytest.mark.asyncio
 async def test_fake_throttler() -> None:
     throttler: ThrottlerProtocol = FakeThottler()
     async with throttler:

--- a/bot/mypy.ini
+++ b/bot/mypy.ini
@@ -16,8 +16,7 @@ disallow_untyped_calls=True
 disallow_untyped_defs=True
 disallow_incomplete_defs=True
 check_untyped_defs=True
-# @pytest.mark.asyncio is untyped
-disallow_untyped_decorators=False
+disallow_untyped_decorators=True
 
 no_implicit_optional=True
 strict_optional=True

--- a/bot/poetry.lock
+++ b/bot/poetry.lock
@@ -71,14 +71,6 @@ reference = "master"
 resolved_reference = "388a6ac390ae70ee16bdc45cf19b308d11212566"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.0"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "attrs"
 version = "21.2.0"
 description = "Classes Without Boilerplate"
@@ -232,6 +224,17 @@ description = "Decorators for Humans"
 category = "dev"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.4"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "flake8"
@@ -515,14 +518,6 @@ python-versions = "*"
 cffi = ">=1.6.0"
 
 [[package]]
-name = "more-itertools"
-version = "8.10.0"
-description = "More routines for operating on iterables, beyond itertools"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "mypy"
 version = "0.960"
 description = "Optional static typing for Python"
@@ -645,14 +640,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "py"
-version = "1.10.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "pycodestyle"
 version = "2.6.0"
 description = "Python style guide checker"
@@ -739,41 +726,39 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "6.0.1"
+version = "7.2.0"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=17.4.0"
+attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
-more-itertools = ">=4.0.0"
 packaging = "*"
-pluggy = ">=0.12,<1.0"
-py = ">=1.8.2"
-toml = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-checkqa_mypy = ["mypy (==0.780)"]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.12.0"
-description = "Pytest support for asyncio."
+version = "0.20.1"
+description = "Pytest support for asyncio"
 category = "dev"
 optional = false
-python-versions = ">= 3.5"
+python-versions = ">=3.7"
 
 [package.dependencies]
-pytest = ">=5.4.0"
+pytest = ">=6.1.0"
+typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["async_generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "pytest-cov"
@@ -1094,7 +1079,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "2fdb0ff05e66863c34f2891656208a1cdc7ee5dc24511aea5b3ff9f7b541d1d0"
+content-hash = "66e1d52ef5a34f66f3fd7f8fc8559ba8b503caba77489bfcdf5c1b80860e5131"
 
 [metadata.files]
 anyio = [
@@ -1114,10 +1099,6 @@ astroid = [
     {file = "astroid-2.8.0.tar.gz", hash = "sha256:fe81f80c0b35264acb5653302ffbd935d394f1775c5e4487df745bf9c2442708"},
 ]
 asyncio-redis = []
-atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
-]
 attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
@@ -1276,6 +1257,7 @@ decorator = [
     {file = "decorator-5.1.0-py3-none-any.whl", hash = "sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374"},
     {file = "decorator-5.1.0.tar.gz", hash = "sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7"},
 ]
+exceptiongroup = []
 flake8 = [
     {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
@@ -1495,10 +1477,6 @@ milksnake = [
     {file = "milksnake-0.1.5-py2.py3-none-any.whl", hash = "sha256:550ca1fc4222724149ee5a933e6bb8347630c0ed023a2a97701ab94fa256f6b4"},
     {file = "milksnake-0.1.5.zip", hash = "sha256:dfcd43b78bcf93897a75eea1dadf71c848319f19451cff4f3f3a628a5abe1688"},
 ]
-more-itertools = [
-    {file = "more-itertools-8.10.0.tar.gz", hash = "sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f"},
-    {file = "more_itertools-8.10.0-py3-none-any.whl", hash = "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"},
-]
 mypy = [
     {file = "mypy-0.960-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3a3e525cd76c2c4f90f1449fd034ba21fcca68050ff7c8397bb7dd25dd8b8248"},
     {file = "mypy-0.960-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7a76dc4f91e92db119b1be293892df8379b08fd31795bb44e0ff84256d34c251"},
@@ -1563,10 +1541,6 @@ prompt-toolkit = [
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
-]
-py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
@@ -1633,13 +1607,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
-pytest = [
-    {file = "pytest-6.0.1-py3-none-any.whl", hash = "sha256:8b6007800c53fdacd5a5c192203f4e531eb2a1540ad9c752e052ec0f7143dbad"},
-    {file = "pytest-6.0.1.tar.gz", hash = "sha256:85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4"},
-]
-pytest-asyncio = [
-    {file = "pytest-asyncio-0.12.0.tar.gz", hash = "sha256:475bd2f3dc0bc11d2463656b3cbaafdbec5a47b47508ea0b329ee693040eebd2"},
-]
+pytest = []
+pytest-asyncio = []
 pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},

--- a/bot/pyproject.toml
+++ b/bot/pyproject.toml
@@ -32,11 +32,9 @@ starlette = "^0.20.4"
 kodiak = 'kodiak.cli:cli'
 
 [tool.poetry.dev-dependencies]
-pytest = "6.0.1"
 black = "^21.9b0"
 mypy = "^0.960"
 ipdb = "^0.13.9"
-pytest-asyncio = "0.12.0"
 pytest-mock = "3.3.1"
 typing_extensions = "^3.7"
 pylint = "^2.3"
@@ -48,6 +46,8 @@ flake8-pyi = "^20.10"
 types-requests = "^2.28.0"
 types-toml = "^0.10.7"
 flake8-tidy-imports = "^4.8.0"
+pytest-asyncio = "0.20.1"
+pytest = "^7.2.0"
 
 [tool.poetry.plugins."pytest11"]
 "pytest_plugin" = "pytest_plugin.plugin"

--- a/bot/pytest_plugin/plugin.py
+++ b/bot/pytest_plugin/plugin.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 
-@pytest.hookimpl(tryfirst=True)
+@pytest.hookimpl(tryfirst=True)  # type: ignore[misc]
 def pytest_load_initial_conftests(
     args: object, early_config: object, parser: object
 ) -> None:

--- a/bot/tox.ini
+++ b/bot/tox.ini
@@ -1,4 +1,5 @@
 [pytest]
+asyncio_mode = auto
 addopts = --pdbcls IPython.terminal.debugger:TerminalPdb
 filterwarnings =
   ; all warnings that are not ignored should raise an error


### PR DESCRIPTION
Recently learned that the pytest-asyncio plugin can automatically handle the `pytest.mark.asyncio` stuff for us