### PR TITLE
Suppress syntax warning caused by rure in pytest

### DIFF
--- a/bot/pyproject.toml
+++ b/bot/pyproject.toml
@@ -67,6 +67,7 @@ filterwarnings = [
   # an alternative at the moment.
   # https://github.com/pytest-dev/pytest/issues/3974
   "ignore::pytest.PytestDeprecationWarning",
+  "ignore:SyntaxWarnings",
 ]
 addopts = "--pdbcls IPython.terminal.debugger:TerminalPdb"
 env = [


### PR DESCRIPTION
Pytest was erroring because of this