### PR TITLE
Handle redacted bypass actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.60.0 - 2026-05-02
+
+### Fixed
+
+- Don't warn about "missing push allowance" when a ruleset's bypass actor is redacted by the GitHub API.
+
 ## 0.59.1 - 2026-03-12
 
 ### Fixed

--- a/bot/kodiak/evaluation.py
+++ b/bot/kodiak/evaluation.py
@@ -352,11 +352,13 @@ def is_update_rule_missing_allowance(ruleset_rule: RulesetRule) -> bool:
         # if we have some error, assume we have an allowance.
         return False
     for push_allowance in ruleset_rule.repositoryRuleset.bypassActors.nodes:
-        if (
-            push_allowance is None
-            or push_allowance.actor is None
-            or push_allowance.actor.databaseId is None
-        ):
+        # GitHub redacts the actor field when our App installation lacks the
+        # permission to read it — even when the bypass entry is for our own
+        # App. We can't distinguish "redacted self" from "redacted other
+        # App", so assume allowance to avoid blocking valid configurations.
+        if push_allowance is None or push_allowance.actor is None:
+            return False
+        if push_allowance.actor.databaseId is None:
             continue
         if str(push_allowance.actor.databaseId) == str(app_config.GITHUB_APP_ID):
             return False

--- a/bot/kodiak/test_evaluation.py
+++ b/bot/kodiak/test_evaluation.py
@@ -564,6 +564,34 @@ async def test_mergeable_with_push_allowance_with_rulesets() -> None:
     assert api.queue_for_merge.called is True
 
 
+async def test_mergeable_with_push_allowance_with_rulesets_redacted_actor() -> None:
+    """
+    GitHub returns `bypassActors.nodes: [null]` (or with `actor: null`) when
+    the App installation lacks permission to read the bypass actor — including
+    when the bypass entry is for our own App. We can't tell whether the
+    redacted entry is us or some other App, so we should not block the merge.
+    """
+    api = create_api()
+    mergeable = create_mergeable()
+
+    await mergeable(
+        api=api,
+        ruleset_rules=[
+            RulesetRule(
+                type="UPDATE",
+                parameters=None,
+                repositoryRuleset=RepositoryRuleset(
+                    bypassActors=RepositoryRulesetBypassActorConnection(nodes=[None])
+                ),
+            )
+        ],
+    )
+    assert api.set_status.call_count == 1
+    assert "config error" not in api.set_status.calls[0]["msg"]
+    assert api.dequeue.call_count == 0
+    assert api.queue_for_merge.called is True
+
+
 async def test_mergeable_missing_automerge_label() -> None:
     """
     If we're missing an automerge label we should not merge the PR.


### PR DESCRIPTION
The GraphQL API doesn't always show us the bypass actor. Instead it'll return null.

If we find a null actor, we know assume the ruleset is configured correctly. This way we don't block users.