### PR TITLE
wip: migrate to async merge api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use GitHub's asynchronous merge API to support stacked pull requests.
+
 ## 0.60.0 - 2026-05-02
 
 ### Fixed

--- a/bot/kodiak/pull_request.py
+++ b/bot/kodiak/pull_request.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Optional, Type
+from typing import Any, Awaitable, Callable, Mapping, Optional, Type
 
 import structlog
 from typing_extensions import Protocol
@@ -15,7 +16,10 @@ from kodiak.errors import (
     RetryForSkippableChecks,
 )
 from kodiak.evaluation import mergeable
-from kodiak.http import HTTPStatusError as HTTPError
+from kodiak.http import (
+    HTTPStatusError as HTTPError,
+    Response,
+)
 from kodiak.queries import Client, EventInfoResponse
 
 logger = structlog.get_logger()
@@ -23,6 +27,50 @@ logger = structlog.get_logger()
 
 RETRY_RATE_SECONDS = 2
 POLL_RATE_SECONDS = 3
+MERGE_POLL_RATE_SECONDS = 1
+# GitHub merges in the background, which can take a couple minutes for a stack
+# of pull requests. We stop polling before kodiak's own evaluation timeout so we
+# retry the evaluation instead of being killed mid merge.
+MERGE_POLL_TIMEOUT_SECONDS = 30
+
+# status codes of merge-async responses that carry a merge result.
+MERGE_STATUS_CODES = frozenset(
+    {
+        200,  # already merged, or a result for a merge we started
+        202,  # merge started
+        400,  # pull request cannot be merged
+        409,  # a merge is already in flight for this pull request
+    }
+)
+
+
+class MergeStatus:
+    """
+    https://github.github.com/gh-stack/reference/merge-api/
+    """
+
+    pending = "pending"
+    merged = "merged"
+    enqueued = "enqueued"
+    failed = "failed"
+
+
+@dataclass(frozen=True)
+class MergeResult:
+    status: str
+    details: Mapping[str, Any]
+
+
+def parse_merge_result(res: Response) -> Optional[MergeResult]:
+    try:
+        body = res.json()
+        status = body["status"]
+        details = body.get("details") or {}
+    except (ValueError, KeyError, TypeError):
+        return None
+    if not isinstance(status, str) or not isinstance(details, dict):
+        return None
+    return MergeResult(status=status, details=details)
 
 
 async def get_pr(
@@ -301,6 +349,34 @@ class PRV2:
                     exc_info=True,
                 )
 
+    def _parse_merge_response(self, res: Response, *, method: str) -> MergeResult:
+        """
+        Read the result of a merge-async response, raising for anything that
+        isn't a valid result.
+        """
+        if res.status_code in MERGE_STATUS_CODES:
+            result = parse_merge_result(res)
+            if result is not None:
+                return result
+        try:
+            res.raise_for_status()
+        except HTTPError as e:
+            self.log.warning("failed to merge pull request", res=res, exc_info=True)
+            if e.response is not None and e.response.status_code == 500:
+                raise GitHubApiInternalServerError from e
+            # we raise an exception to retry this request.
+            raise ApiCallException(
+                method=method,
+                http_status_code=res.status_code,
+                response=res.content,
+            ) from e
+        self.log.warning("could not parse merge result", res=res)
+        raise ApiCallException(
+            method=method,
+            http_status_code=res.status_code,
+            response=res.content,
+        )
+
     async def merge(
         self,
         merge_method: str,
@@ -317,25 +393,56 @@ class PRV2:
                 commit_title=commit_title,
                 commit_message=commit_message,
             )
-            try:
-                res.raise_for_status()
-            except HTTPError as e:
-                if e.response is not None and e.response.status_code == 405:
-                    self.log.info(
-                        "branch is not mergeable. PR likely already merged.", res=res
+            result = self._parse_merge_response(res, method="pull_request/merge")
+
+            # merging runs in the background so we poll until we have a result.
+            deadline = time.monotonic() + MERGE_POLL_TIMEOUT_SECONDS
+            while result.status == MergeStatus.pending:
+                uuid = result.details.get("uuid")
+                if not isinstance(uuid, str):
+                    self.log.warning("missing uuid for pending merge", res=res)
+                    raise ApiCallException(
+                        method="pull_request/merge",
+                        http_status_code=res.status_code,
+                        response=res.content,
                     )
-                else:
-                    self.log.warning(
-                        "failed to merge pull request", res=res, exc_info=True
+                if time.monotonic() > deadline:
+                    # we raise an exception to retry this request. Starting the
+                    # merge again returns the uuid of the in-flight merge, so we
+                    # resume polling instead of merging twice.
+                    self.log.info("timeout waiting for merge to finish", res=res)
+                    raise ApiCallException(
+                        method="pull_request/merge",
+                        http_status_code=res.status_code,
+                        response=res.content,
                     )
-                if e.response is not None and e.response.status_code == 500:
-                    raise GitHubApiInternalServerError from e
-                # we raise an exception to retry this request.
-                raise ApiCallException(
-                    method="pull_request/merge",
-                    http_status_code=res.status_code,
-                    response=res.content,
-                ) from e
+                await asyncio.sleep(MERGE_POLL_RATE_SECONDS)
+                res = await api_client.get_merge_pull_request_result(
+                    number=self.number, uuid=uuid
+                )
+                result = self._parse_merge_response(
+                    res, method="pull_request/merge_result"
+                )
+
+            if result.status == MergeStatus.merged:
+                return
+            if result.status == MergeStatus.enqueued:
+                self.log.info("pull request added to merge queue", res=res)
+                return
+            # a merge can fail for a merge conflict, an unmet branch protection
+            # rule, a closed pull request, etc. Nothing was merged.
+            self.log.warning(
+                "failed to merge pull request",
+                res=res,
+                merge_status=result.status,
+                message=result.details.get("message"),
+            )
+            # we raise an exception to retry this request.
+            raise ApiCallException(
+                method="pull_request/merge",
+                http_status_code=res.status_code,
+                response=res.content,
+            )
 
     async def update_ref(self, ref: str, sha: str) -> None:
         self.log.info("update_ref", ref=ref, sha=sha)

--- a/bot/kodiak/queries/__init__.py
+++ b/bot/kodiak/queries/__init__.py
@@ -473,16 +473,6 @@ class EventInfoResponse:
     commits: List[Commit] = field(default_factory=list)
 
 
-MERGE_PR_MUTATION = """
-mutation merge($PRId: ID!, $SHA: GitObjectID!, $title: String, $body: String) {
-  mergePullRequest(input: {pullRequestId: $PRId, expectedHeadOid: $SHA, commitHeadline: $title, commitBody: $body}) {
-    clientMutationId
-  }
-}
-
-"""
-
-
 class PushAllowanceActor(BaseModel):
     """
     https://developer.github.com/v4/object/app/
@@ -1356,6 +1346,14 @@ query {
         commit_title: Optional[str],
         commit_message: Optional[str],
     ) -> http.Response:
+        """
+        Start an asynchronous merge. The result is fetched via
+        get_merge_pull_request_result.
+
+        The synchronous merge endpoint cannot merge stacked pull requests.
+
+        https://github.github.com/gh-stack/reference/merge-api/
+        """
         body = dict(merge_method=merge_method)
         # we must not pass the keys for commit_title or commit_message when they
         # are null because GitHub will error saying the title/message cannot be
@@ -1368,9 +1366,26 @@ query {
         headers = await get_headers(
             session=self.session, installation_id=self.installation_id
         )
-        url = conf.v3_url(f"/repos/{self.owner}/{self.repo}/pulls/{number}/merge")
+        url = conf.v3_url(f"/repos/{self.owner}/{self.repo}/pulls/{number}/merge-async")
         async with self.throttler:
             return await self.session.put(url, headers=headers, json=body)
+
+    async def get_merge_pull_request_result(
+        self, number: int, uuid: str
+    ) -> http.Response:
+        """
+        Fetch the result of a merge started by merge_pull_request.
+
+        https://github.github.com/gh-stack/reference/merge-api/
+        """
+        headers = await get_headers(
+            session=self.session, installation_id=self.installation_id
+        )
+        url = conf.v3_url(
+            f"/repos/{self.owner}/{self.repo}/pulls/{number}/merge-async/{urllib.parse.quote(uuid)}"
+        )
+        async with self.throttler:
+            return await self.session.get(url, headers=headers)
 
     async def update_ref(self, *, ref: str, sha: str) -> http.Response:
         """

--- a/bot/kodiak/test_pull_request.py
+++ b/bot/kodiak/test_pull_request.py
@@ -17,7 +17,7 @@ from typing_extensions import Protocol
 
 import kodiak.http as requests
 from kodiak.config import V1, Merge, MergeMethod
-from kodiak.errors import ApiCallException
+from kodiak.errors import ApiCallException, GitHubApiInternalServerError
 from kodiak.http import Request
 from kodiak.pull_request import PRV2, EventInfoResponse, QueueForMergeCallback
 from kodiak.queries import (
@@ -145,6 +145,18 @@ class MockMergePullRequest(BaseMockFunc):
         return self.response
 
 
+class MockGetMergePullRequestResult(BaseMockFunc):
+    # responses are returned in order. The last response is repeated for any
+    # further calls.
+    responses: List[requests.Response]
+
+    async def __call__(self, number: int, uuid: str) -> requests.Response:
+        self.log_call(dict(number=number, uuid=uuid))
+        if len(self.responses) > 1:
+            return self.responses.pop(0)
+        return self.responses[0]
+
+
 class MockDeleteLabel(BaseMockFunc):
     response: requests.Response
 
@@ -179,6 +191,7 @@ class MockUpdateRef(BaseMockFunc):
 
 class FakeClientProtocol(Protocol):
     merge_pull_request: MockMergePullRequest
+    get_merge_pull_request_result: MockGetMergePullRequestResult
     delete_label: MockDeleteLabel
     add_label: MockAddLabel
     update_branch: MockUpdateBranch
@@ -196,6 +209,7 @@ class FakeClientProtocol(Protocol):
 def create_client() -> Type[FakeClientProtocol]:
     class FakeClient:
         merge_pull_request = MockMergePullRequest()
+        get_merge_pull_request_result = MockGetMergePullRequestResult()
         delete_label = MockDeleteLabel()
         add_label = MockAddLabel()
         update_branch = MockUpdateBranch()
@@ -245,33 +259,142 @@ def create_prv2(
     )
 
 
-async def test_pr_v2_merge() -> None:
+PENDING_MERGE_RESPONSE = b"""{
+  "status": "pending",
+  "details": {
+    "message": "Merge request enqueued.",
+    "uuid": "630b9d5e-3f2a-4f7e-8b0c-2d5f9a8c1e42",
+    "merge_method": "squash",
+    "merge_action": "default",
+    "expected_head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+  }
+}"""
+
+MERGED_MERGE_RESPONSE = b"""{
+  "status": "merged",
+  "details": {
+    "message": "Pull request was merged.",
+    "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+  }
+}"""
+
+
+@pytest.fixture
+def fast_merge_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("kodiak.pull_request.MERGE_POLL_RATE_SECONDS", 0)
+
+
+async def test_pr_v2_merge(fast_merge_poll: None) -> None:
     """
-    We should be able to merge successfully
+    We should be able to merge successfully. Merging runs in the background, so
+    we poll for the result.
     """
     client = create_client()
     client.merge_pull_request.response = create_response(
-        content=b"""{
-      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-      "merged": true,
-      "message": "Pull Request successfully merged"
-    }""",
-        status_code=200,
+        content=PENDING_MERGE_RESPONSE, status_code=202
+    )
+    client.get_merge_pull_request_result.responses = [
+        create_response(content=PENDING_MERGE_RESPONSE, status_code=200),
+        create_response(content=MERGED_MERGE_RESPONSE, status_code=200),
+    ]
+
+    pr_v2 = create_prv2(client=client)
+    await pr_v2.merge("squash", commit_title="my title", commit_message="my message")
+    assert client.merge_pull_request.call_count == 1
+    assert client.get_merge_pull_request_result.call_count == 2
+    assert (
+        client.get_merge_pull_request_result.calls[0]["uuid"]
+        == "630b9d5e-3f2a-4f7e-8b0c-2d5f9a8c1e42"
+    )
+
+
+async def test_pr_v2_merge_already_merged() -> None:
+    """
+    When a pull request is already merged we get a result without a uuid to
+    poll.
+    """
+    client = create_client()
+    client.merge_pull_request.response = create_response(
+        content=MERGED_MERGE_RESPONSE, status_code=200
     )
 
     pr_v2 = create_prv2(client=client)
     await pr_v2.merge("squash", commit_title="my title", commit_message="my message")
     assert client.merge_pull_request.call_count == 1
+    assert client.get_merge_pull_request_result.call_count == 0
 
 
-async def test_pr_v2_merge_rebase_error() -> None:
+async def test_pr_v2_merge_existing_merge_request(fast_merge_poll: None) -> None:
     """
-    We should raise ApiCallException when we get a bad API response.
+    When a merge is already in flight GitHub returns a conflict with the uuid of
+    the existing merge request, which we poll like our own.
     """
     client = create_client()
     client.merge_pull_request.response = create_response(
-        content=b"""{"message":"This branch can't be rebased","documentation_url":"https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button"}""",
-        status_code=405,
+        content=PENDING_MERGE_RESPONSE, status_code=409
+    )
+    client.get_merge_pull_request_result.responses = [
+        create_response(content=MERGED_MERGE_RESPONSE, status_code=200)
+    ]
+
+    pr_v2 = create_prv2(client=client)
+    await pr_v2.merge("squash", commit_title="my title", commit_message="my message")
+    assert client.get_merge_pull_request_result.call_count == 1
+
+
+async def test_pr_v2_merge_enqueued(fast_merge_poll: None) -> None:
+    """
+    A pull request added to GitHub's merge queue is merged by the queue, so
+    we're done.
+    """
+    client = create_client()
+    client.merge_pull_request.response = create_response(
+        content=PENDING_MERGE_RESPONSE, status_code=202
+    )
+    client.get_merge_pull_request_result.responses = [
+        create_response(
+            content=b"""{"status":"enqueued","details":{"message":"Pull request was added to the merge queue."}}""",
+            status_code=200,
+        )
+    ]
+
+    pr_v2 = create_prv2(client=client)
+    await pr_v2.merge("squash", commit_title="my title", commit_message="my message")
+    assert client.get_merge_pull_request_result.call_count == 1
+
+
+async def test_pr_v2_merge_failed(fast_merge_poll: None) -> None:
+    """
+    We should raise ApiCallException when the merge fails.
+    """
+    client = create_client()
+    client.merge_pull_request.response = create_response(
+        content=PENDING_MERGE_RESPONSE, status_code=202
+    )
+    client.get_merge_pull_request_result.responses = [
+        create_response(
+            content=b"""{"status":"failed","details":{"message":"Merge conflict: the pull request could not be merged."}}""",
+            status_code=200,
+        )
+    ]
+
+    pr_v2 = create_prv2(client=client)
+    with pytest.raises(ApiCallException) as e:
+        await pr_v2.merge(
+            "squash", commit_title="my title", commit_message="my message"
+        )
+    assert e.value.method == "pull_request/merge"
+    assert b"Merge conflict" in e.value.response
+
+
+async def test_pr_v2_merge_not_mergeable() -> None:
+    """
+    A closed or draft pull request is rejected when we start the merge.
+    """
+    client = create_client()
+    client.merge_pull_request.response = create_response(
+        content=b"""{"status":"failed","details":{"message":"Pull request is closed."}}""",
+        status_code=400,
     )
 
     pr_v2 = create_prv2(client=client)
@@ -279,10 +402,69 @@ async def test_pr_v2_merge_rebase_error() -> None:
         await pr_v2.merge(
             "squash", commit_title="my title", commit_message="my message"
         )
-    assert client.merge_pull_request.call_count == 1
+    assert client.get_merge_pull_request_result.call_count == 0
     assert e.value.method == "pull_request/merge"
-    assert e.value.status_code == 405
-    assert b"merge-a-pull-request-merge-button" in e.value.response
+    assert e.value.status_code == 400
+
+
+async def test_pr_v2_merge_poll_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    We give up polling before kodiak's evaluation timeout. Retrying the merge
+    resumes polling the in-flight merge request.
+    """
+    monkeypatch.setattr("kodiak.pull_request.MERGE_POLL_RATE_SECONDS", 0)
+    monkeypatch.setattr("kodiak.pull_request.MERGE_POLL_TIMEOUT_SECONDS", 0)
+    client = create_client()
+    client.merge_pull_request.response = create_response(
+        content=PENDING_MERGE_RESPONSE, status_code=202
+    )
+    client.get_merge_pull_request_result.responses = [
+        create_response(content=PENDING_MERGE_RESPONSE, status_code=200)
+    ]
+
+    pr_v2 = create_prv2(client=client)
+    with pytest.raises(ApiCallException) as e:
+        await pr_v2.merge(
+            "squash", commit_title="my title", commit_message="my message"
+        )
+    assert e.value.method == "pull_request/merge"
+
+
+async def test_pr_v2_merge_expired_result(fast_merge_poll: None) -> None:
+    """
+    We should raise ApiCallException when the merge result is gone.
+    """
+    client = create_client()
+    client.merge_pull_request.response = create_response(
+        content=PENDING_MERGE_RESPONSE, status_code=202
+    )
+    client.get_merge_pull_request_result.responses = [
+        create_response(content=b"""{"message":"Not Found"}""", status_code=404)
+    ]
+
+    pr_v2 = create_prv2(client=client)
+    with pytest.raises(ApiCallException) as e:
+        await pr_v2.merge(
+            "squash", commit_title="my title", commit_message="my message"
+        )
+    assert e.value.method == "pull_request/merge_result"
+    assert e.value.status_code == 404
+
+
+async def test_pr_v2_merge_internal_server_error() -> None:
+    """
+    A 500 is not safe to retry.
+    """
+    client = create_client()
+    client.merge_pull_request.response = create_response(
+        content=b"""{"message":"Server Error"}""", status_code=500
+    )
+
+    pr_v2 = create_prv2(client=client)
+    with pytest.raises(GitHubApiInternalServerError):
+        await pr_v2.merge(
+            "squash", commit_title="my title", commit_message="my message"
+        )
 
 
 async def test_pr_v2_merge_service_unavailable() -> None:


### PR DESCRIPTION
TODOs

- [ ] Use branch protection of stack base branch for stacked PRs
- [ ] Support rebasing PR stack for "require up-to-date". GitHub's "Rebase stack" button does a server side rebase to update. How do we replicate that using public APIs?

https://github.com/orgs/community/discussions/201439#discussioncomment-17846374